### PR TITLE
Add username, password, nickname fields to User entity and refactor Role enum

### DIFF
--- a/backend/src/main/java/com/phonebid/app/user/domain/Role.java
+++ b/backend/src/main/java/com/phonebid/app/user/domain/Role.java
@@ -1,17 +1,26 @@
 package com.phonebid.app.user.domain;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public enum Role {
-    CONSUMER("소비자", "견적을 요청하는 일반 사용자"),
-    SELLER("판매자", "입찰에 참여하는 판매업체"),
-    ADMIN("관리자", "시스템 관리자");
+    CONSUMER("소비자", "견적을 요청하는 일반 사용자", Authority.CONSUMER),
+    SELLER("판매자", "입찰에 참여하는 판매업체", Authority.SELLER),
+    ADMIN("관리자", "시스템 관리자", Authority.ADMIN);
 
     private final String displayName;
     private final String description;
+    private final String authority;
+
+    Role(String displayName, String description, String authority) {
+        this.displayName = displayName;
+        this.description = description;
+        this.authority = authority;
+    }
+
+    public String getAuthority() {
+        return this.authority;
+    }
 
     public boolean hasSellerPrivilege() {
         return this == SELLER || this == ADMIN;
@@ -19,5 +28,12 @@ public enum Role {
 
     public boolean hasAdminPrivilege() {
         return this == ADMIN;
+    }
+
+    // 사용자 권한을 관리하는 inner 클래스
+    public static class Authority {
+        public static final String CONSUMER = "ROLE_CONSUMER";
+        public static final String SELLER = "ROLE_SELLER";
+        public static final String ADMIN = "ROLE_ADMIN";
     }
 } 

--- a/backend/src/main/java/com/phonebid/app/user/domain/User.java
+++ b/backend/src/main/java/com/phonebid/app/user/domain/User.java
@@ -22,11 +22,13 @@ public class User {
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
-    @Size(min = 4, max = 10)  // 길이를 4~10자로 제한
+    @Size(min = 4, max = 10, message = "유저ID는 4자 이상 10자 이하여야 합니다")  // 길이를 4~10자로 제한
     @Pattern(regexp = "^[a-z0-9]+$")  // 알파벳 소문자와 숫자로만 구성
     @Column(name = "username", nullable = false, unique = true)
     private String username;
 
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다")
+    //@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$", message = "비밀번호는 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다")
     @Column(name = "password", nullable = false)
     private String password;
 
@@ -37,6 +39,8 @@ public class User {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9_-]+$", message = "닉네임은 한글, 영문, 숫자, _, -만 사용 가능합니다")
     @Column(name = "nickname", nullable = false)
     private String nickname;
 

--- a/backend/src/main/java/com/phonebid/app/user/domain/User.java
+++ b/backend/src/main/java/com/phonebid/app/user/domain/User.java
@@ -1,10 +1,13 @@
 package com.phonebid.app.user.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -19,11 +22,23 @@ public class User {
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
+    @Size(min = 4, max = 10)  // 길이를 4~10자로 제한
+    @Pattern(regexp = "^[a-z0-9]+$")  // 알파벳 소문자와 숫자로만 구성
+    @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Email
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
@@ -36,11 +51,13 @@ public class User {
     @Column(name = "provider_id", nullable = false)
     private String providerId;
 
-
     @Builder
-    public User(String email, String name, Role role, Provider provider, String providerId) {
+    public User(String username, String password, String email, String name, String nickname, Role role, Provider provider, String providerId) {
+        this.username = username;
+        this.password = password;
         this.email = email;
         this.name = name;
+        this.nickname = nickname;
         this.role = role;
         this.provider = provider;
         this.providerId = providerId;
@@ -61,6 +78,14 @@ public class User {
 
     public void updateName(String name) {
         this.name = name;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
     }
 
     public void updateRole(Role role) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6

## 📝작업 내용

- User 엔티티 필드 추가 
  - username 필드 추가: 아이디로 사용할 사용자명 (4-10자, 소문자+숫자만 허용)
  - password 필드 추가: 인증을 위한 비밀번호 필드
  - nickname 필드 추가: 표시용 닉네임 필드
  - validation 어노테이션 추가: Size, Pattern, Email 어노테이션으로 입력값 검증 강화
  - 업데이트 메서드 추가: updateNickname(), updatePassword() 메서드 추가
- Role enum 리팩토링
  - Authority 상수 일관성 개선: 하드코딩된 "ROLE_SELLER", "ROLE_ADMIN"을 Authority.SELLER, Authority.ADMIN으로 변경
  - 코드 유지보수성 향상: 중앙화된 Authority 상수 사용으로 일관성 확보