### PR TITLE
feat #5, #13 : add error response method to ApiResponse

### DIFF
--- a/backend/src/main/java/com/phonebid/app/common/dto/ApiResponse.java
+++ b/backend/src/main/java/com/phonebid/app/common/dto/ApiResponse.java
@@ -28,7 +28,25 @@ public class ApiResponse<T> {
     private String message;
     private T data;
 
+    /**
+     * 성공 응답 생성용 팩토리 메서드
+     * @param status HTTP 상태 코드
+     * @param message 응답 메시지
+     * @param data 응답 데이터
+     * @return ApiResponse 객체
+     */
     public static <T> ApiResponse<T> success(HttpStatus status, String message, T data) {
+        return new ApiResponse<>(status, message, data);
+    }
+    
+    /**
+     * 에러 응답 생성용 팩토리 메서드
+     * @param status HTTP 상태 코드
+     * @param message 에러 메시지
+     * @param data 에러 관련 데이터 (선택사항)
+     * @return ApiResponse 객체
+     */
+    public static <T> ApiResponse<T> error(HttpStatus status, String message, T data) {
         return new ApiResponse<>(status, message, data);
     }
 }

--- a/backend/src/main/java/com/phonebid/app/common/exception/ErrorResponse.java
+++ b/backend/src/main/java/com/phonebid/app/common/exception/ErrorResponse.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 /**
+ * @deprecated 이 클래스는 더 이상 사용되지 않습니다.
+ * 대신 {@link com.phonebid.app.common.dto.ApiResponse}를 사용하세요.
+ * 
  * ErrorResponse는 예외가 발생했을 때 클라이언트에게 반환될 응답 객체입니다.
  * 상태 코드, 에러 메시지, 그리고 유효성 검증 오류 정보를 포함할 수 있습니다.
  * 응답 body 에 포함시킬 수 있습니다.
@@ -33,7 +36,18 @@ import org.springframework.http.HttpStatus;
  *      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
  *  }
  * }</pre>
+ * 
+ * <p><strong>권장사항:</strong></p>
+ * <pre>{@code
+ * // 대신 ApiResponse를 사용하세요
+ * @ExceptionHandler(CustomException.class)
+ * public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+ *   return ResponseEntity.status(e.getErrorCode().getStatus())
+ *       .body(ApiResponse.error(e.getErrorCode().getStatus(), e.getMessage(), null));
+ * }
+ * }</pre>
  */
+@Deprecated(since = "1.0.0", forRemoval = true)
 @Getter
 @Builder
 public class ErrorResponse {
@@ -42,12 +56,22 @@ public class ErrorResponse {
     private String message;
     private Map<String, String> validation;
 
+    /**
+     * @deprecated 이 메서드는 더 이상 사용되지 않습니다.
+     * 대신 {@link com.phonebid.app.common.dto.ApiResponse#error(HttpStatus, String, Object)}를 사용하세요.
+     */
+    @Deprecated(since = "1.0.0", forRemoval = true)
     public static ErrorResponse error(ErrorCode errorCode) {
         return ErrorResponse.builder()
                 .status(errorCode.getStatus())
                 .message(errorCode.getMessage()).build();
     }
 
+    /**
+     * @deprecated 이 메서드는 더 이상 사용되지 않습니다.
+     * 대신 {@link com.phonebid.app.common.dto.ApiResponse}의 data 필드를 사용하세요.
+     */
+    @Deprecated(since = "1.0.0", forRemoval = true)
     public void addValidation(String field, String errorMessage) {
         if (validation == null) {
             validation = new HashMap<>();

--- a/backend/src/main/java/com/phonebid/app/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/phonebid/app/common/exception/GlobalExceptionHandler.java
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
         log.error("CustomException 발생: {}", e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getStatus())
-                .body(ApiResponse.success(e.getErrorCode().getStatus(), e.getMessage(), null));
+                .body(ApiResponse.error(e.getErrorCode().getStatus(), e.getMessage(), null));
     }
 
     /**
@@ -39,7 +39,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.error("IllegalArgumentException 발생: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiResponse.success(HttpStatus.CONFLICT, e.getMessage(), null));
+                .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage(), null));
     }
 
     /**
@@ -55,7 +55,7 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.success(HttpStatus.BAD_REQUEST, "입력 값이 유효하지 않습니다.", validationErrors));
+                .body(ApiResponse.error(HttpStatus.BAD_REQUEST, "입력 값이 유효하지 않습니다.", validationErrors));
     }
 
     /**
@@ -71,7 +71,7 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.success(HttpStatus.BAD_REQUEST, "입력 값이 유효하지 않습니다.", validationErrors));
+                .body(ApiResponse.error(HttpStatus.BAD_REQUEST, "입력 값이 유효하지 않습니다.", validationErrors));
     }
 
     /**
@@ -84,6 +84,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error("예상치 못한 예외 발생: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.success(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 문제가 발생했습니다.", null));
+                .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 문제가 발생했습니다.", null));
     }
 } 


### PR DESCRIPTION


## #️⃣연관된 이슈

> #5, #13

## 📝작업 내용
- Add error() static factory method to ApiResponse
- Update GlobalExceptionHandler to use error() instead of success()
- Improve clarity between success and error responses