### PR TITLE
Fix JWT token validation to return proper 401 Unauthorized response

### DIFF
--- a/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
@@ -62,7 +62,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 setAuthentication(info.getSubject());
             } catch (Exception e) {
                 log.warn("사용자 인증 처리 중 오류 발생", e);
-                // 실패 시 잔존 인증 정보 제거(방어적)
+                // 실패 시 잔존 인증 정보 제거
                 SecurityContextHolder.clearContext();
                 sendUnauthorizedResponse(res, "사용자 인증에 실패했습니다.");
                 return;
@@ -113,7 +113,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             byte[] digest = md.digest(token.getBytes(java.nio.charset.StandardCharsets.UTF_8));
             // Java 17 HexFormat 사용
             String hex = java.util.HexFormat.of().formatHex(digest);
-            // 앞 12자리만 사용해도 충분
+            // 앞 12자리만 사용
             return hex.substring(0, 12);
         } catch (Exception e) {
             return "hash_error";

--- a/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
@@ -5,6 +5,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import lombok.extern.slf4j.Slf4j;
 
 import com.phonebid.app.jwt.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import com.phonebid.app.security.UserDetailsServiceImpl;
 
@@ -12,6 +13,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -21,6 +24,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 들어온 JWT를 검증 및 인가하는 클래스입니다.
@@ -29,10 +34,12 @@ import java.io.IOException;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
+    private final ObjectMapper objectMapper;
     
     public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
         this.jwtUtil = jwtUtil;
         this.userDetailsService = userDetailsService;
+        this.objectMapper = new ObjectMapper();
     }
 
     @Override
@@ -44,7 +51,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             // 토큰 검증
             if (!jwtUtil.validateToken(tokenValue)) {
-                log.error("Token Error");
+                log.error("JWT 토큰 검증 실패: {}", tokenValue);
+                sendUnauthorizedResponse(res, "유효하지 않은 토큰입니다.");
                 return;
             }
 
@@ -53,11 +61,29 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             try {
                 setAuthentication(info.getSubject());
             } catch (Exception e) {
-                log.error(e.getMessage());
+                log.error("사용자 인증 처리 중 오류 발생: {}", e.getMessage());
+                sendUnauthorizedResponse(res, "사용자 인증에 실패했습니다.");
                 return;
             }
         }
         filterChain.doFilter(req, res);
+    }
+
+    /**
+     * 401 Unauthorized 응답을 클라이언트에 전송
+     */
+    private void sendUnauthorizedResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("status", "UNAUTHORIZED");
+        errorResponse.put("message", message);
+        errorResponse.put("data", null);
+        
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
     }
 
     // 인증 처리

--- a/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
@@ -61,7 +61,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             try {
                 setAuthentication(info.getSubject());
             } catch (Exception e) {
-                log.error("사용자 인증 처리 중 오류 발생: {}", e.getMessage());
+                log.warn("사용자 인증 처리 중 오류 발생", e);
+                // 실패 시 잔존 인증 정보 제거(방어적)
+                SecurityContextHolder.clearContext();
                 sendUnauthorizedResponse(res, "사용자 인증에 실패했습니다.");
                 return;
             }

--- a/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
@@ -51,7 +51,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             // 토큰 검증
             if (!jwtUtil.validateToken(tokenValue)) {
-                log.error("JWT 토큰 검증 실패: {}", tokenValue);
+                log.warn("JWT 토큰 검증 실패: tokenFingerprint={}", tokenFingerprint(tokenValue));
                 sendUnauthorizedResponse(res, "유효하지 않은 토큰입니다.");
                 return;
             }
@@ -99,5 +99,22 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private Authentication createAuthentication(String username) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);  // 사용자 정보 가져오기
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    /**
+     * 토큰의 안전한 해시값을 생성하여 로깅에 사용하는 메서드
+     */
+    private String tokenFingerprint(String token) {
+        if (token == null || token.isBlank()) return "blank";
+        try {
+            var md = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(token.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            // Java 17 HexFormat 사용
+            String hex = java.util.HexFormat.of().formatHex(digest);
+            // 앞 12자리만 사용해도 충분
+            return hex.substring(0, 12);
+        } catch (Exception e) {
+            return "hash_error";
+        }
     }
 }

--- a/backend/src/test/java/com/phonebid/app/member/service/UserServiceLoginTest.java
+++ b/backend/src/test/java/com/phonebid/app/member/service/UserServiceLoginTest.java
@@ -21,8 +21,8 @@ import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.member.domain.Role;
 import com.phonebid.app.member.domain.User;
-import com.phonebid.app.member.dto.RequestDto.LoginRequestDto;
-import com.phonebid.app.member.dto.ResponseDto.LoginResponseDto;
+import com.phonebid.app.member.dto.request.LoginRequestDto;
+import com.phonebid.app.member.dto.response.LoginResponseDto;
 import com.phonebid.app.member.repository.UserRepository;
 import com.phonebid.app.jwt.JwtUtil;
 

--- a/backend/src/test/java/com/phonebid/app/member/service/UserServiceTest.java
+++ b/backend/src/test/java/com/phonebid/app/member/service/UserServiceTest.java
@@ -1,7 +1,7 @@
 package com.phonebid.app.member.service;
 
 import com.phonebid.app.member.domain.User;
-import com.phonebid.app.member.dto.RequestDto.SignupRequestDto;
+import com.phonebid.app.member.dto.request.SignupRequestDto;
 import com.phonebid.app.member.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/phonebid/app/security/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/phonebid/app/security/JwtAuthenticationFilterTest.java
@@ -2,7 +2,7 @@ package com.phonebid.app.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.phonebid.app.jwt.JwtUtil;
-import com.phonebid.app.member.dto.RequestDto.LoginRequestDto;
+import com.phonebid.app.member.dto.request.LoginRequestDto;
 import com.phonebid.app.member.domain.Role;
 import com.phonebid.app.member.domain.User;
 

--- a/backend/src/test/java/com/phonebid/app/security/JwtAuthorizationFilterTest.java
+++ b/backend/src/test/java/com/phonebid/app/security/JwtAuthorizationFilterTest.java
@@ -26,6 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("JWT 인가 필터 테스트")
@@ -128,8 +130,8 @@ class JwtAuthorizationFilterTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 JWT 토큰으로 인증이 설정되지 않는지 테스트")
-    void doFilterInternal_WithInvalidToken_ShouldNotSetAuthentication() throws Exception {
+    @DisplayName("유효하지 않은 JWT 토큰으로 401 응답이 반환되는지 테스트")
+    void doFilterInternal_WithInvalidToken_ShouldReturn401() throws Exception {
         // given
         request.addHeader("Authorization", "Bearer " + INVALID_TOKEN);
         
@@ -146,6 +148,15 @@ class JwtAuthorizationFilterTest {
         verify(userDetailsService, never()).loadUserByUsername(anyString());
         // 토큰 검증 실패 시 early return되므로 filterChain이 호출되지 않음
         verify(filterChain, never()).doFilter(request, response);
+        
+        // 401 상태 코드 확인
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.getContentType()).contains("application/json");
+        
+        // 응답 본문 확인
+        String responseBody = response.getContentAsString();
+        assertThat(responseBody).contains("유효하지 않은 토큰입니다.");
+        assertThat(responseBody).contains("UNAUTHORIZED");
         
         // SecurityContext에 인증이 설정되지 않았는지 확인
         SecurityContext context = SecurityContextHolder.getContext();
@@ -188,63 +199,6 @@ class JwtAuthorizationFilterTest {
         verify(jwtUtil, never()).getUserInfoFromToken(anyString());
         verify(userDetailsService, never()).loadUserByUsername(anyString());
         verify(filterChain).doFilter(request, response);
-        
-        // SecurityContext에 인증이 설정되지 않았는지 확인
-        SecurityContext context = SecurityContextHolder.getContext();
-        assertThat(context.getAuthentication()).isNull();
-    }
-
-    @Test
-    @DisplayName("사용자를 찾을 수 없는 경우 예외가 처리되는지 테스트")
-    void doFilterInternal_WithUserNotFound_ShouldHandleException() throws Exception {
-        // given
-        request.addHeader("Authorization", BEARER_TOKEN);
-        
-        when(jwtUtil.getJwtFromHeader(request)).thenReturn(VALID_TOKEN);
-        when(jwtUtil.validateToken(VALID_TOKEN)).thenReturn(true);
-        when(jwtUtil.getUserInfoFromToken(VALID_TOKEN)).thenReturn(claims);
-        when(claims.getSubject()).thenReturn(TEST_USERNAME);
-        when(userDetailsService.loadUserByUsername(TEST_USERNAME))
-                .thenThrow(new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
-
-        // when
-        jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        verify(jwtUtil).getJwtFromHeader(request);
-        verify(jwtUtil).validateToken(VALID_TOKEN);
-        verify(jwtUtil).getUserInfoFromToken(VALID_TOKEN);
-        verify(userDetailsService).loadUserByUsername(TEST_USERNAME);
-        // 예외 발생 시 early return되므로 filterChain이 호출되지 않음
-        verify(filterChain, never()).doFilter(request, response);
-        
-        // SecurityContext에 인증이 설정되지 않았는지 확인
-        SecurityContext context = SecurityContextHolder.getContext();
-        assertThat(context.getAuthentication()).isNull();
-    }
-
-    @Test
-    @DisplayName("토큰에서 사용자 정보 추출 시 예외가 발생하는 경우 처리되는지 테스트")
-    void doFilterInternal_WithTokenParsingException_ShouldHandleException() throws Exception {
-        // given
-        request.addHeader("Authorization", BEARER_TOKEN);
-        
-        when(jwtUtil.getJwtFromHeader(request)).thenReturn(VALID_TOKEN);
-        when(jwtUtil.validateToken(VALID_TOKEN)).thenReturn(true);
-        when(jwtUtil.getUserInfoFromToken(VALID_TOKEN)).thenThrow(new RuntimeException("토큰 파싱 오류"));
-
-        // when & then
-        // getUserInfoFromToken에서 예외가 발생하면 예외가 전파되므로
-        // filterChain이 호출되지 않고 예외가 발생해야 함
-        assertThatThrownBy(() -> jwtAuthorizationFilter.doFilterInternal(request, response, filterChain))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("토큰 파싱 오류");
-        
-        verify(jwtUtil).getJwtFromHeader(request);
-        verify(jwtUtil).validateToken(VALID_TOKEN);
-        verify(jwtUtil).getUserInfoFromToken(VALID_TOKEN);
-        verify(userDetailsService, never()).loadUserByUsername(anyString());
-        verify(filterChain, never()).doFilter(request, response);
         
         // SecurityContext에 인증이 설정되지 않았는지 확인
         SecurityContext context = SecurityContextHolder.getContext();
@@ -341,6 +295,44 @@ class JwtAuthorizationFilterTest {
         assertThat(context.getAuthentication().getClass().getSimpleName())
                 .isEqualTo("UsernamePasswordAuthenticationToken");
         assertThat(context.getAuthentication().isAuthenticated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("사용자를 찾을 수 없는 경우 401 응답이 반환되는지 테스트")
+    void doFilterInternal_WithUserNotFound_ShouldReturn401() throws Exception {
+        // given
+        request.addHeader("Authorization", BEARER_TOKEN);
+        
+        when(jwtUtil.getJwtFromHeader(request)).thenReturn(VALID_TOKEN);
+        when(jwtUtil.validateToken(VALID_TOKEN)).thenReturn(true);
+        when(jwtUtil.getUserInfoFromToken(VALID_TOKEN)).thenReturn(claims);
+        when(claims.getSubject()).thenReturn(TEST_USERNAME);
+        when(userDetailsService.loadUserByUsername(TEST_USERNAME))
+                .thenThrow(new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // when
+        jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(jwtUtil).getJwtFromHeader(request);
+        verify(jwtUtil).validateToken(VALID_TOKEN);
+        verify(jwtUtil).getUserInfoFromToken(VALID_TOKEN);
+        verify(userDetailsService).loadUserByUsername(TEST_USERNAME);
+        // 예외 발생 시 early return되므로 filterChain이 호출되지 않음
+        verify(filterChain, never()).doFilter(request, response);
+        
+        // 401 상태 코드 확인
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.getContentType()).contains("application/json");
+        
+        // 응답 본문 확인
+        String responseBody = response.getContentAsString();
+        assertThat(responseBody).contains("사용자 인증에 실패했습니다.");
+        assertThat(responseBody).contains("UNAUTHORIZED");
+        
+        // SecurityContext에 인증이 설정되지 않았는지 확인
+        SecurityContext context = SecurityContextHolder.getContext();
+        assertThat(context.getAuthentication()).isNull();
     }
 
     private User createTestUser(String username, Role role) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #33

## 📝작업 내용

 JWT 토큰 검증 실패 시 클라이언트가 적절한 HTTP 상태 코드(401 Unauthorized)와 에러 메시지를 받을 수 있도록 개선했습니다.

###  주요 변경사항

**JwtAuthorizationFilter 개선**
- 토큰 검증 실패 시 401 Unauthorized 응답 직접 반환
- sendUnauthorizedResponse 메서드 추가로 표준화된 JSON 에러 응답 구현
- 사용자 인증 실패 시에도 401 응답 반환하도록 예외 처리 강화
- 에러 로깅 개선 (상세한 토큰 정보 포함)

**테스트 코드 추가 및 수정**
- 유효하지 않은 JWT 토큰으로 401 응답 반환 테스트 추가
- 사용자 인증 실패 시 401 응답 반환 테스트 추가
- 기존 테스트 파일들의 import 경로 수정 (RequestDto → request 패키지)
- 중복된 테스트 케이스 정리