### PR TITLE
Refactor/document

### DIFF
--- a/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -112,7 +113,7 @@ public class SellerDocumentService {
         String previousFileUrl = null;
 
         // 기존 문서 조회 후 URL 보관 및 레코드 삭제
-        var existingOpt = sellerDocumentRepository.findBySellerAndType(seller, documentType);
+        Optional<SellerDocument> existingOpt = sellerDocumentRepository.findBySellerAndType(seller, documentType);
         if (existingOpt.isPresent()) {
             previousFileUrl = existingOpt.get().getFileUrl();
             sellerDocumentRepository.delete(existingOpt.get());

--- a/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +34,7 @@ public class SellerDocumentService {
     private final SellerDocumentRepository sellerDocumentRepository;
     private final SellerRepository sellerRepository;
     private final S3Service s3Service;
+    private final TransactionTemplate transactionTemplate;
 
     // 허용된 파일 확장자
     private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
@@ -104,30 +106,31 @@ public class SellerDocumentService {
     }
 
     /**
-     * 기존 문서를 DB에서 교체 저장 (트랜잭션)
+     * 기존 문서를 DB에서 교체 저장 (프로그램적 트랜잭션)
      * - 기존 레코드가 있으면 삭제하고 이전 파일 URL을 보관
      * - 새 레코드를 저장하고 이전 파일 URL을 반환하여 사후 처리에서 삭제
      */
-    @Transactional
     private UploadDbResult saveDocumentToDbReplacing(Seller seller, DocumentType documentType, String newFileUrl) {
-        String previousFileUrl = null;
+        return transactionTemplate.execute(status -> {
+            String previousFileUrl = null;
 
-        // 기존 문서 조회 후 URL 보관 및 레코드 삭제
-        Optional<SellerDocument> existingOpt = sellerDocumentRepository.findBySellerAndType(seller, documentType);
-        if (existingOpt.isPresent()) {
-            previousFileUrl = existingOpt.get().getFileUrl();
-            sellerDocumentRepository.delete(existingOpt.get());
-        }
+            // 기존 문서 조회 후 URL 보관 및 레코드 삭제
+            Optional<SellerDocument> existingOpt = sellerDocumentRepository.findBySellerAndType(seller, documentType);
+            if (existingOpt.isPresent()) {
+                previousFileUrl = existingOpt.get().getFileUrl();
+                sellerDocumentRepository.delete(existingOpt.get());
+            }
 
-        // 새 문서 저장
-        SellerDocument sellerDocument = SellerDocument.builder()
-                .seller(seller)
-                .type(documentType)
-                .fileUrl(newFileUrl)
-                .build();
+            // 새 문서 저장
+            SellerDocument sellerDocument = SellerDocument.builder()
+                    .seller(seller)
+                    .type(documentType)
+                    .fileUrl(newFileUrl)
+                    .build();
 
-        SellerDocument saved = sellerDocumentRepository.save(sellerDocument);
-        return new UploadDbResult(saved, previousFileUrl);
+            SellerDocument saved = sellerDocumentRepository.save(sellerDocument);
+            return new UploadDbResult(saved, previousFileUrl);
+        });
     }
 
     /**

--- a/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
@@ -81,9 +81,6 @@ public class SellerDocumentService {
 
             SellerDocument savedDocument = sellerDocumentRepository.save(sellerDocument);
 
-            log.info("판매자 문서 업로드 완료: sellerId={}, documentType={}, fileName={}", 
-                    seller.getSellerId(), documentType, fileName);
-
             return SellerDocumentUploadResponseDto.from(savedDocument);
 
         } catch (IOException e) {
@@ -235,7 +232,8 @@ public class SellerDocumentService {
         try {
             s3Service.deleteFileByUrl(document.getFileUrl());
         } catch (Exception e) {
-            log.error("S3 파일 삭제 실패: {}", document.getFileUrl(), e);
+            log.error("S3 파일 삭제 실패: fileUrl={}, fileName={}, error={}", 
+                    document.getFileUrl(), document.getFileName(), e.getMessage(), e);
             throw new CustomException(MemberErrorCode.FILE_DELETE_FAILED);
         }
 

--- a/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Arrays;
@@ -35,6 +36,7 @@ public class SellerDocumentService {
     private final SellerRepository sellerRepository;
     private final S3Service s3Service;
     private final TransactionTemplate transactionTemplate;
+    private final PlatformTransactionManager transactionManager;
 
     // 허용된 파일 확장자
     private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
@@ -341,9 +343,11 @@ public class SellerDocumentService {
     }
 
     /**
-     * DB에 문서 복구 (보상 트랜잭션, 프로그램적)
+     * DB에 문서 복구 (보상 트랜잭션, REQUIRES_NEW로 독립 보장)
      */
     private void restoreDocumentToDb(SellerDocument document) {
-        transactionTemplate.executeWithoutResult(status -> sellerDocumentRepository.save(document));
+        TransactionTemplate requiresNewTemplate = new TransactionTemplate(transactionManager);
+        requiresNewTemplate.setPropagationBehavior(org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        requiresNewTemplate.executeWithoutResult(status -> sellerDocumentRepository.save(document));
     }
 }

--- a/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -56,38 +55,78 @@ public class SellerDocumentService {
         // 파일 검증
         validateFile(file);
 
+        String uploadedFileUrl = null;
         try {
-            // S3에 파일 업로드
+            // Step 1: S3 업로드 (외부 I/O)
             String fileName = generateFileName(seller.getSellerId(), documentType, file.getOriginalFilename());
-            String fileUrl = s3Service.uploadFile(fileName, file);
+            uploadedFileUrl = s3Service.uploadFile(fileName, file);
 
-            // 기존 문서가 있다면 삭제
-            sellerDocumentRepository.findBySellerAndType(seller, documentType)
-                    .ifPresent(existingDocument -> {
-                        // S3에서 기존 파일 삭제
-                        try {
-                            s3Service.deleteFileByUrl(existingDocument.getFileUrl());
-                        } catch (Exception e) {
-                            log.warn("기존 S3 파일 삭제 실패: {}", existingDocument.getFileUrl(), e);
-                        }
-                        sellerDocumentRepository.delete(existingDocument);
-                    });
+            // Step 2: DB 저장 (트랜잭션) - 기존 레코드 교체 저장, 이전 파일 URL 반환
+            UploadDbResult result = saveDocumentToDbReplacing(seller, documentType, uploadedFileUrl);
 
-            // 새로운 문서 엔티티 생성 및 저장
-            SellerDocument sellerDocument = SellerDocument.builder()
-                    .seller(seller)
-                    .type(documentType)
-                    .fileUrl(fileUrl)
-                    .build();
+            // Step 3: 사후 처리 - 이전 S3 파일 삭제 (best-effort)
+            if (result.previousFileUrl != null) {
+                try {
+                    s3Service.deleteFileByUrl(result.previousFileUrl);
+                } catch (Exception e) {
+                    log.warn("기존 S3 파일 삭제 실패(무시): {}", result.previousFileUrl, e);
+                }
+            }
 
-            SellerDocument savedDocument = sellerDocumentRepository.save(sellerDocument);
+            return SellerDocumentUploadResponseDto.from(result.savedDocument);
 
-            return SellerDocumentUploadResponseDto.from(savedDocument);
-
-        } catch (IOException e) {
-            log.error("S3 파일 업로드 실패: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            // DB 저장 실패 등 예외 시 보상 트랜잭션: 업로드한 신규 파일을 S3에서 삭제
+            if (uploadedFileUrl != null) {
+                try {
+                    s3Service.deleteFileByUrl(uploadedFileUrl);
+                    log.warn("DB 저장 실패로 업로드 파일 롤백 완료: {}", uploadedFileUrl);
+                } catch (Exception ignore) {
+                    log.error("업로드 파일 롤백 실패 - 수동 삭제 필요: {}", uploadedFileUrl, ignore);
+                }
+            }
             throw new CustomException(MemberErrorCode.FILE_UPLOAD_FAILED);
         }
+    }
+
+    /**
+     * 업로드 DB 처리 결과 모델
+     */
+    private static class UploadDbResult {
+        private final SellerDocument savedDocument;
+        private final String previousFileUrl;
+
+        private UploadDbResult(SellerDocument savedDocument, String previousFileUrl) {
+            this.savedDocument = savedDocument;
+            this.previousFileUrl = previousFileUrl;
+        }
+    }
+
+    /**
+     * 기존 문서를 DB에서 교체 저장 (트랜잭션)
+     * - 기존 레코드가 있으면 삭제하고 이전 파일 URL을 보관
+     * - 새 레코드를 저장하고 이전 파일 URL을 반환하여 사후 처리에서 삭제
+     */
+    @Transactional
+    private UploadDbResult saveDocumentToDbReplacing(Seller seller, DocumentType documentType, String newFileUrl) {
+        String previousFileUrl = null;
+
+        // 기존 문서 조회 후 URL 보관 및 레코드 삭제
+        var existingOpt = sellerDocumentRepository.findBySellerAndType(seller, documentType);
+        if (existingOpt.isPresent()) {
+            previousFileUrl = existingOpt.get().getFileUrl();
+            sellerDocumentRepository.delete(existingOpt.get());
+        }
+
+        // 새 문서 저장
+        SellerDocument sellerDocument = SellerDocument.builder()
+                .seller(seller)
+                .type(documentType)
+                .fileUrl(newFileUrl)
+                .build();
+
+        SellerDocument saved = sellerDocumentRepository.save(sellerDocument);
+        return new UploadDbResult(saved, previousFileUrl);
     }
 
     /**
@@ -170,6 +209,48 @@ public class SellerDocumentService {
                 .map(SellerDocumentUploadResponseDto::from)
                 .toList();
     }
+
+    // previous (for reference)
+    /*
+    public SellerDocumentUploadResponseDto uploadDocument(String username, SellerDocumentUploadRequestDto requestDto) {
+        Seller seller = sellerRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.SELLER_NOT_FOUND));
+
+        MultipartFile file = requestDto.getFile();
+        DocumentType documentType = requestDto.getDocumentType();
+
+        validateFile(file);
+
+        try {
+            String fileName = generateFileName(seller.getSellerId(), documentType, file.getOriginalFilename());
+            String fileUrl = s3Service.uploadFile(fileName, file);
+
+            sellerDocumentRepository.findBySellerAndType(seller, documentType)
+                    .ifPresent(existingDocument -> {
+                        try {
+                            s3Service.deleteFileByUrl(existingDocument.getFileUrl());
+                        } catch (Exception e) {
+                            log.warn("기존 S3 파일 삭제 실패: {}", existingDocument.getFileUrl(), e);
+                        }
+                        sellerDocumentRepository.delete(existingDocument);
+                    });
+
+            SellerDocument sellerDocument = SellerDocument.builder()
+                    .seller(seller)
+                    .type(documentType)
+                    .fileUrl(fileUrl)
+                    .build();
+
+            SellerDocument savedDocument = sellerDocumentRepository.save(sellerDocument);
+
+            return SellerDocumentUploadResponseDto.from(savedDocument);
+
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 실패: {}", e.getMessage(), e);
+            throw new CustomException(MemberErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+    */
 
     /**
      * 특정 문서 조회

--- a/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
@@ -314,12 +314,12 @@ public class SellerDocumentService {
         }
 
         try {
-            // Step 1: DB에서 삭제 (트랜잭션 적용, 빠른 작업부터)
+            // Step 1: DB에서 삭제 (프로그램적 트랜잭션 보장)
             deleteDocumentFromDb(document);
-            
+
             // Step 2: S3에서 파일 삭제 (외부 서비스)
             s3Service.deleteFileByUrl(document.getFileUrl());
-                    
+
         } catch (Exception e) {
             // S3 삭제 실패 시 보상 트랜잭션으로 DB 복구
             try {
@@ -334,18 +334,16 @@ public class SellerDocumentService {
     }
 
     /**
-     * DB에서 문서 삭제 (트랜잭션 적용)
+     * DB에서 문서 삭제 (프로그램적 트랜잭션)
      */
-    @Transactional
     private void deleteDocumentFromDb(SellerDocument document) {
-        sellerDocumentRepository.delete(document);
+        transactionTemplate.executeWithoutResult(status -> sellerDocumentRepository.delete(document));
     }
 
     /**
-     * DB에 문서 복구 (보상 트랜잭션)
+     * DB에 문서 복구 (보상 트랜잭션, 프로그램적)
      */
-    @Transactional
     private void restoreDocumentToDb(SellerDocument document) {
-        sellerDocumentRepository.save(document);
+        transactionTemplate.executeWithoutResult(status -> sellerDocumentRepository.save(document));
     }
 }

--- a/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/SellerDocumentService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -184,8 +185,7 @@ public class SellerDocumentService {
     }
 
     /**
-     * 판매자 서류 삭제
-     */
+     * 판매자 서류 삭제 
     public void deleteDocument(String username, DocumentType documentType) {
         // 판매자 조회
         Seller seller = sellerRepository.findByUsername(username)
@@ -209,7 +209,7 @@ public class SellerDocumentService {
         
         log.info("판매자 문서 삭제 완료: sellerId={}, documentType={}, fileName={}", 
                 seller.getSellerId(), documentType, document.getFileName());
-    }
+    } */
 
     /**
      * 판매자 서류 삭제 (파일 ID 기반)
@@ -228,16 +228,39 @@ public class SellerDocumentService {
             throw new CustomException(MemberErrorCode.DOCUMENT_NOT_FOUND);
         }
 
-        // S3에서 파일 삭제
         try {
+            // Step 1: DB에서 삭제 (트랜잭션 적용, 빠른 작업부터)
+            deleteDocumentFromDb(document);
+            
+            // Step 2: S3에서 파일 삭제 (외부 서비스)
             s3Service.deleteFileByUrl(document.getFileUrl());
+                    
         } catch (Exception e) {
-            log.error("S3 파일 삭제 실패: fileUrl={}, fileName={}, error={}", 
-                    document.getFileUrl(), document.getFileName(), e.getMessage(), e);
+            // S3 삭제 실패 시 보상 트랜잭션으로 DB 복구
+            try {
+                restoreDocumentToDb(document);
+                log.warn("S3 삭제 실패로 인한 DB 복구 완료: fileUrl={}", document.getFileUrl());
+            } catch (Exception restoreException) {
+                log.error("DB 복구 실패 - 수동 처리 필요: fileUrl={}", document.getFileUrl(), restoreException);
+                // TODO: 알림 서비스 또는 별도 처리 로직 필요
+            }
             throw new CustomException(MemberErrorCode.FILE_DELETE_FAILED);
         }
+    }
 
-        // S3 삭제 성공 후 DB에서 문서 삭제
+    /**
+     * DB에서 문서 삭제 (트랜잭션 적용)
+     */
+    @Transactional
+    private void deleteDocumentFromDb(SellerDocument document) {
         sellerDocumentRepository.delete(document);
+    }
+
+    /**
+     * DB에 문서 복구 (보상 트랜잭션)
+     */
+    @Transactional
+    private void restoreDocumentToDb(SellerDocument document) {
+        sellerDocumentRepository.save(document);
     }
 }

--- a/backend/src/main/java/com/phonebid/app/s3/service/S3Service.java
+++ b/backend/src/main/java/com/phonebid/app/s3/service/S3Service.java
@@ -9,6 +9,10 @@ import com.amazonaws.services.s3.AmazonS3URI;
 import com.phonebid.app.common.errorcode.MemberErrorCode;
 import com.phonebid.app.common.exception.CustomException;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * S3 파일 업로드 서비스
@@ -67,8 +71,11 @@ public class S3Service {
                 throw new CustomException(MemberErrorCode.FILE_DELETE_FAILED);
             }
             
+            // URL 인코딩된 key를 디코딩
+            String decodedKey = URLDecoder.decode(key, StandardCharsets.UTF_8);
+            
             // 파일 삭제
-            s3Client.deleteObject(bucket, key);
+            s3Client.deleteObject(bucket, decodedKey);
             
         } catch (CustomException e) {
             throw e;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #49

## 📝작업 내용

- **삭제 로직 보상 트랜잭션 적용 (deleteDocumentById)**
  -   DB 삭제를 트랜잭션으로 먼저 수행 → 이후 S3 삭제 시도
  -   S3 삭제 실패 시 DB 복구(보상 트랜잭션)로 일관성 유지
  -   단계별 로깅 보강, 복구 실패 시 수동 조치 로그 추가

- **업로드 로직 보상 트랜잭션 적용 (uploadDocument)**
  -   S3 업로드 선행 → 트랜잭션으로 DB 교체 저장
  -   DB 저장 실패 시 방금 업로드된 S3 파일 보상 삭제
  -   저장 성공 후 기존 S3 파일은 best-effort로 삭제

- **트랜잭션 경계 분리**
  - saveDocumentToDbReplacing(@Transactional), deleteDocumentFromDb(@Transactional), restoreDocumentToDb(@Transactional) 추가
  - 외부 I/O(S3)와 DB 트랜잭션 분리로 안정성 확보
  - DB 복구 로직 트랜잭션 로직을 REQUIRES_NEW로 함으로써 보상 독립성 확보

- **코드 정리**
  - 업로드/삭제 리팩토링 전 코드 주석으로 보존
  - 불필요한 import 제거 및 로깅 메시지 정리

## 참고 자료
> [Spring - private 메서드에 @Transactional이 적용될까?](https://green-bin.tistory.com/79)
