### PR TITLE
feat: Add PortOne V2 payment init, verification, and success/fail redirects

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	// WebFlux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -49,7 +50,7 @@ dependencies {
 	// Environment variables (.env file support)
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	// Test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/backend/src/main/java/com/phonebid/app/PhonebidApplication.java
+++ b/backend/src/main/java/com/phonebid/app/PhonebidApplication.java
@@ -2,8 +2,12 @@ package com.phonebid.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import com.phonebid.app.common.config.PortOneV2Properties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(PortOneV2Properties.class)
 public class PhonebidApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/phonebid/app/common/config/PortOneV2Properties.java
+++ b/backend/src/main/java/com/phonebid/app/common/config/PortOneV2Properties.java
@@ -1,0 +1,36 @@
+package com.phonebid.app.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "portone.v2")
+public class PortOneV2Properties {
+
+    private String storeId;
+    private String apiSecret;
+    private String channelKey;
+
+    public String getStoreId() {
+        return storeId;
+    }
+
+    public void setStoreId(String storeId) {
+        this.storeId = storeId;
+    }
+
+    public String getApiSecret() {
+        return apiSecret;
+    }
+
+    public void setApiSecret(String apiSecret) {
+        this.apiSecret = apiSecret;
+    }
+
+    public String getChannelKey() {
+        return channelKey;
+    }
+
+    public void setChannelKey(String channelKey) {
+        this.channelKey = channelKey;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/common/config/PortOneV2Properties.java
+++ b/backend/src/main/java/com/phonebid/app/common/config/PortOneV2Properties.java
@@ -8,6 +8,7 @@ public class PortOneV2Properties {
     private String storeId;
     private String apiSecret;
     private String channelKey;
+    private String webhookSecret;
 
     public String getStoreId() {
         return storeId;
@@ -31,6 +32,14 @@ public class PortOneV2Properties {
 
     public void setChannelKey(String channelKey) {
         this.channelKey = channelKey;
+    }
+
+    public String getWebhookSecret() {
+        return webhookSecret;
+    }
+
+    public void setWebhookSecret(String webhookSecret) {
+        this.webhookSecret = webhookSecret;
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/common/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/phonebid/app/common/config/WebSecurityConfig.java
@@ -124,8 +124,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/v1/users/login").permitAll() // 로그인 엔드포인트 접근 허가
                         .requestMatchers("/api/v1/auth/kakao/**").permitAll() // 카카오 OAuth 엔드포인트 접근 허가
                         .requestMatchers("/api/v1/auth/naver/**").permitAll() // 네이버 OAuth 엔드포인트 접근 허가
-                        .requestMatchers("/api/v1/payments/portone/**").permitAll() // PortOne 결제 엔드포인트 접근 허가
-                        //.requestMatchers(HttpMethod.GET, "/api/boards/**").permitAll()
+                        .requestMatchers("/api/v1/payments/portone/**").permitAll() // PortOne 결제 엔드포인트 접근 허가                      //.requestMatchers(HttpMethod.GET, "/api/boards/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 

--- a/backend/src/main/java/com/phonebid/app/common/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/phonebid/app/common/config/WebSecurityConfig.java
@@ -124,6 +124,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/v1/users/login").permitAll() // 로그인 엔드포인트 접근 허가
                         .requestMatchers("/api/v1/auth/kakao/**").permitAll() // 카카오 OAuth 엔드포인트 접근 허가
                         .requestMatchers("/api/v1/auth/naver/**").permitAll() // 네이버 OAuth 엔드포인트 접근 허가
+                        .requestMatchers("/api/v1/payments/portone/**").permitAll() // PortOne 결제 엔드포인트 접근 허가
                         //.requestMatchers(HttpMethod.GET, "/api/boards/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );

--- a/backend/src/main/java/com/phonebid/app/trade/controller/PortOnePaymentConfirmRequest.java
+++ b/backend/src/main/java/com/phonebid/app/trade/controller/PortOnePaymentConfirmRequest.java
@@ -1,0 +1,9 @@
+package com.phonebid.app.trade.controller;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PortOnePaymentConfirmRequest(
+        @NotBlank String paymentId
+) {
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/controller/PortOnePaymentController.java
+++ b/backend/src/main/java/com/phonebid/app/trade/controller/PortOnePaymentController.java
@@ -1,0 +1,36 @@
+package com.phonebid.app.trade.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.trade.dto.request.PgPaymentRequest;
+import com.phonebid.app.trade.dto.response.PortOnePaymentInitResponse;
+import com.phonebid.app.trade.service.PortOnePaymentService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/payments/portone")
+@RequiredArgsConstructor
+public class PortOnePaymentController {
+
+    private final PortOnePaymentService portOnePaymentService;
+
+    @PostMapping("/init")
+    public ResponseEntity<ApiResponse<PortOnePaymentInitResponse>> initializePayment(@Validated @RequestBody PgPaymentRequest request) {
+        PortOnePaymentInitResponse response = portOnePaymentService.preparePayment(request);
+        ApiResponse<PortOnePaymentInitResponse> body = ApiResponse.success(
+                HttpStatus.OK,
+                "PortOne 결제 초기화 성공",
+                response
+        );
+        return ResponseEntity.ok(body);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/controller/PortOnePaymentController.java
+++ b/backend/src/main/java/com/phonebid/app/trade/controller/PortOnePaymentController.java
@@ -2,7 +2,6 @@ package com.phonebid.app.trade.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,7 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.phonebid.app.common.dto.ApiResponse;
 import com.phonebid.app.trade.dto.request.PgPaymentRequest;
 import com.phonebid.app.trade.dto.response.PortOnePaymentInitResponse;
+import com.phonebid.app.trade.dto.response.PortOnePaymentStatusResponse;
 import com.phonebid.app.trade.service.PortOnePaymentService;
+import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,12 +24,23 @@ public class PortOnePaymentController {
     private final PortOnePaymentService portOnePaymentService;
 
     @PostMapping("/init")
-    public ResponseEntity<ApiResponse<PortOnePaymentInitResponse>> initializePayment(@Validated @RequestBody PgPaymentRequest request) {
+    public ResponseEntity<ApiResponse<PortOnePaymentInitResponse>> initializePayment(@Valid @RequestBody PgPaymentRequest request) {
         PortOnePaymentInitResponse response = portOnePaymentService.preparePayment(request);
         ApiResponse<PortOnePaymentInitResponse> body = ApiResponse.success(
                 HttpStatus.OK,
                 "PortOne 결제 초기화 성공",
                 response
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @PostMapping("/confirm")
+    public ResponseEntity<ApiResponse<PortOnePaymentStatusResponse>> confirmPayment(@RequestBody PortOnePaymentConfirmRequest request) {
+        PortOnePaymentStatusResponse status = portOnePaymentService.verifyPayment(request.paymentId());
+        ApiResponse<PortOnePaymentStatusResponse> body = ApiResponse.success(
+                HttpStatus.OK,
+                "PortOne 결제 검증 완료",
+                status
         );
         return ResponseEntity.ok(body);
     }

--- a/backend/src/main/java/com/phonebid/app/trade/controller/PortOneWebhookController.java
+++ b/backend/src/main/java/com/phonebid/app/trade/controller/PortOneWebhookController.java
@@ -1,0 +1,39 @@
+package com.phonebid.app.trade.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.trade.service.PortOneWebhookService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/payments/portone/webhook")
+@RequiredArgsConstructor
+public class PortOneWebhookController {
+
+    private final PortOneWebhookService portOneWebhookService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> handleWebhook(
+            @RequestBody String payload,
+            @RequestHeader("webhook-id") String webhookId,
+            @RequestHeader("webhook-timestamp") String webhookTimestamp,
+            @RequestHeader("webhook-signature") String webhookSignature) {
+
+        portOneWebhookService.handleWebhook(payload, webhookId, webhookTimestamp, webhookSignature);
+        ApiResponse<Void> body = ApiResponse.success(
+                HttpStatus.OK,
+                "PortOne 웹훅 처리 완료",
+                null
+        );
+        return ResponseEntity.ok(body);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/dto/request/PgPaymentRequest.java
+++ b/backend/src/main/java/com/phonebid/app/trade/dto/request/PgPaymentRequest.java
@@ -1,0 +1,17 @@
+package com.phonebid.app.trade.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PgPaymentRequest {
+    private String merchantUid;     // 주문 고유 ID
+    private Integer amount;         // 결제 금액
+    private String productName;     // 상품명
+    private String buyerName;       // 구매자 이름
+    private String buyerEmail;      // 구매자 이메일
+    private String buyerPhone;      // 구매자 전화번호
+    private String returnUrl;       // 결제 완료 후 리턴 URL
+    private String cancelUrl;       // 결제 취소 시 리턴 URL
+}

--- a/backend/src/main/java/com/phonebid/app/trade/dto/request/PgPaymentRequest.java
+++ b/backend/src/main/java/com/phonebid/app/trade/dto/request/PgPaymentRequest.java
@@ -1,16 +1,27 @@
 package com.phonebid.app.trade.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class PgPaymentRequest {
+    @NotBlank
     private String merchantUid;     // 주문 고유 ID
+    @NotNull
+    @Min(1)
     private Integer amount;         // 결제 금액
+    @NotBlank
     private String productName;     // 상품명
+    @NotBlank
     private String buyerName;       // 구매자 이름
+    @Email
     private String buyerEmail;      // 구매자 이메일
+    @NotBlank
     private String buyerPhone;      // 구매자 전화번호
     private String returnUrl;       // 결제 완료 후 리턴 URL
     private String cancelUrl;       // 결제 취소 시 리턴 URL

--- a/backend/src/main/java/com/phonebid/app/trade/dto/request/PgRefundRequest.java
+++ b/backend/src/main/java/com/phonebid/app/trade/dto/request/PgRefundRequest.java
@@ -2,11 +2,18 @@ package com.phonebid.app.trade.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @Builder
 public class PgRefundRequest {
+    @NotBlank
     private String pgTid;          // 원본 거래 ID
+    @NotNull
+    @Min(1)
     private Integer refundAmount;   // 환불 금액
+    @NotBlank
     private String reason;         // 환불 사유
 }

--- a/backend/src/main/java/com/phonebid/app/trade/dto/request/PgRefundRequest.java
+++ b/backend/src/main/java/com/phonebid/app/trade/dto/request/PgRefundRequest.java
@@ -1,0 +1,12 @@
+package com.phonebid.app.trade.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PgRefundRequest {
+    private String pgTid;          // 원본 거래 ID
+    private Integer refundAmount;   // 환불 금액
+    private String reason;         // 환불 사유
+}

--- a/backend/src/main/java/com/phonebid/app/trade/dto/response/PgPaymentResponse.java
+++ b/backend/src/main/java/com/phonebid/app/trade/dto/response/PgPaymentResponse.java
@@ -1,0 +1,15 @@
+package com.phonebid.app.trade.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PgPaymentResponse {
+    private boolean success;        // 성공 여부
+    private String pgTid;          // PG 거래 ID
+    private String paymentUrl;     // 결제 페이지 URL
+    private Integer amount;        // 결제 금액
+    private String status;         // 결제 상태
+    private String message;        // 응답 메시지
+}

--- a/backend/src/main/java/com/phonebid/app/trade/dto/response/PgRefundResponse.java
+++ b/backend/src/main/java/com/phonebid/app/trade/dto/response/PgRefundResponse.java
@@ -1,0 +1,12 @@
+package com.phonebid.app.trade.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PgRefundResponse {
+    private boolean success;        // 성공 여부
+    private Integer refundAmount;   // 환불 금액
+    private String message;        // 응답 메시지
+}

--- a/backend/src/main/java/com/phonebid/app/trade/dto/response/PortOnePaymentInitResponse.java
+++ b/backend/src/main/java/com/phonebid/app/trade/dto/response/PortOnePaymentInitResponse.java
@@ -1,0 +1,21 @@
+package com.phonebid.app.trade.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PortOnePaymentInitResponse {
+
+    private final String storeId;
+    private final String channelKey;
+    private final String paymentId;
+    private final String orderName;
+    private final Integer amount;
+    private final String buyerName;
+    private final String buyerEmail;
+    private final String buyerPhone;
+    private final String redirectUrl;
+    private final String cancelUrl;
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/dto/response/PortOnePaymentStatusResponse.java
+++ b/backend/src/main/java/com/phonebid/app/trade/dto/response/PortOnePaymentStatusResponse.java
@@ -1,0 +1,15 @@
+package com.phonebid.app.trade.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PortOnePaymentStatusResponse {
+
+    private final String paymentId;
+    private final String status;
+    private final Long amount;
+    private final String currency;
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/service/PortOneClient.java
+++ b/backend/src/main/java/com/phonebid/app/trade/service/PortOneClient.java
@@ -1,0 +1,29 @@
+package com.phonebid.app.trade.service;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.phonebid.app.common.config.PortOneV2Properties;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class PortOneClient {
+
+    private final WebClient webClient;
+    private final PortOneV2Properties portOneV2Properties;
+
+    public Mono<String> getPayment(String paymentId) {
+        return webClient
+                .get()
+                .uri("https://api.portone.io/payments/{paymentId}", paymentId)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "PortOne " + portOneV2Properties.getApiSecret())
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/service/PortOnePaymentService.java
+++ b/backend/src/main/java/com/phonebid/app/trade/service/PortOnePaymentService.java
@@ -6,7 +6,11 @@ import org.springframework.stereotype.Service;
 
 import com.phonebid.app.common.config.PortOneV2Properties;
 import com.phonebid.app.trade.dto.request.PgPaymentRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.phonebid.app.trade.dto.response.PortOnePaymentInitResponse;
+import com.phonebid.app.trade.dto.response.PortOnePaymentStatusResponse;
+import reactor.core.publisher.Mono;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 public class PortOnePaymentService {
 
     private final PortOneV2Properties portOneV2Properties;
+    private final PortOneClient portOneClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public PortOnePaymentInitResponse preparePayment(PgPaymentRequest request) {
         String paymentId = generatePaymentId();
@@ -36,6 +42,29 @@ public class PortOnePaymentService {
     private String generatePaymentId() {
         String uuid = UUID.randomUUID().toString().replace("-", "");
         return "pay-" + uuid;
+    }
+
+    public PortOnePaymentStatusResponse verifyPayment(String paymentId) {
+        String responseBody = portOneClient.getPayment(paymentId).blockOptional()
+                .orElseThrow(() -> new IllegalStateException("PortOne 결제 조회 실패"));
+
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode paymentNode = root.path("payment");
+
+            String status = paymentNode.path("status").asText();
+            long amount = paymentNode.path("amount").path("total").asLong();
+            String currency = paymentNode.path("currency").path("value").asText();
+
+            return PortOnePaymentStatusResponse.builder()
+                    .paymentId(paymentId)
+                    .status(status)
+                    .amount(amount)
+                    .currency(currency)
+                    .build();
+        } catch (Exception e) {
+            throw new IllegalStateException("PortOne 응답 파싱 실패", e);
+        }
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/trade/service/PortOnePaymentService.java
+++ b/backend/src/main/java/com/phonebid/app/trade/service/PortOnePaymentService.java
@@ -1,0 +1,41 @@
+package com.phonebid.app.trade.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.phonebid.app.common.config.PortOneV2Properties;
+import com.phonebid.app.trade.dto.request.PgPaymentRequest;
+import com.phonebid.app.trade.dto.response.PortOnePaymentInitResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PortOnePaymentService {
+
+    private final PortOneV2Properties portOneV2Properties;
+
+    public PortOnePaymentInitResponse preparePayment(PgPaymentRequest request) {
+        String paymentId = generatePaymentId();
+
+        return PortOnePaymentInitResponse.builder()
+                .storeId(portOneV2Properties.getStoreId())
+                .channelKey(portOneV2Properties.getChannelKey())
+                .paymentId(paymentId)
+                .orderName(request.getProductName())
+                .amount(request.getAmount())
+                .buyerName(request.getBuyerName())
+                .buyerEmail(request.getBuyerEmail())
+                .buyerPhone(request.getBuyerPhone())
+                .redirectUrl(request.getReturnUrl())
+                .cancelUrl(request.getCancelUrl())
+                .build();
+    }
+
+    private String generatePaymentId() {
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        return "pay-" + uuid;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/service/PortOneWebhookService.java
+++ b/backend/src/main/java/com/phonebid/app/trade/service/PortOneWebhookService.java
@@ -26,8 +26,6 @@ public class PortOneWebhookService {
         if (!verifySignature(payload, webhookId, webhookTimestamp, webhookSignature)) {
             throw new IllegalArgumentException("포트원 웹훅 서명 검증 실패");
         }
-
-        log.info("포트원 웹훅 수신: payload={}", payload);
     }
 
     private boolean verifySignature(String payload, String webhookId, String webhookTimestamp, String webhookSignature) {

--- a/backend/src/main/java/com/phonebid/app/trade/service/PortOneWebhookService.java
+++ b/backend/src/main/java/com/phonebid/app/trade/service/PortOneWebhookService.java
@@ -1,6 +1,7 @@
 package com.phonebid.app.trade.service;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -20,7 +21,6 @@ public class PortOneWebhookService {
     private static final Logger log = LoggerFactory.getLogger(PortOneWebhookService.class);
 
     private final PortOneV2Properties portOneV2Properties;
-    private final PortOnePaymentService portOnePaymentService;
 
     public void handleWebhook(String payload, String webhookId, String webhookTimestamp, String webhookSignature) {
         if (!verifySignature(payload, webhookId, webhookTimestamp, webhookSignature)) {
@@ -37,20 +37,30 @@ public class PortOneWebhookService {
             SecretKeySpec secretKey = new SecretKeySpec(portOneV2Properties.getWebhookSecret().getBytes(StandardCharsets.UTF_8), "HmacSHA256");
             mac.init(secretKey);
             byte[] rawHmac = mac.doFinal(dataToSign.getBytes(StandardCharsets.UTF_8));
-            String expectedSignature = bytesToHex(rawHmac);
-            return expectedSignature.equals(webhookSignature);
+            byte[] receivedSignature = hexToBytes(webhookSignature);
+            return MessageDigest.isEqual(rawHmac, receivedSignature);
         } catch (Exception e) {
             log.error("웹훅 서명 검증 중 오류", e);
             return false;
         }
     }
 
-    private String bytesToHex(byte[] bytes) {
-        StringBuilder sb = new StringBuilder(bytes.length * 2);
-        for (byte b : bytes) {
-            sb.append(String.format("%02x", b));
+    private byte[] hexToBytes(String hex) {
+        if (hex == null || hex.length() % 2 != 0) {
+            throw new IllegalArgumentException("유효하지 않은 서명 형식");
         }
-        return sb.toString();
+
+        int len = hex.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            int high = Character.digit(hex.charAt(i), 16);
+            int low = Character.digit(hex.charAt(i + 1), 16);
+            if (high < 0 || low < 0) {
+                throw new IllegalArgumentException("서명에 허용되지 않은 문자가 포함되어 있습니다.");
+            }
+            data[i / 2] = (byte) ((high << 4) + low);
+        }
+        return data;
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/trade/service/PortOneWebhookService.java
+++ b/backend/src/main/java/com/phonebid/app/trade/service/PortOneWebhookService.java
@@ -1,0 +1,56 @@
+package com.phonebid.app.trade.service;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.phonebid.app.common.config.PortOneV2Properties;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PortOneWebhookService {
+
+    private static final Logger log = LoggerFactory.getLogger(PortOneWebhookService.class);
+
+    private final PortOneV2Properties portOneV2Properties;
+    private final PortOnePaymentService portOnePaymentService;
+
+    public void handleWebhook(String payload, String webhookId, String webhookTimestamp, String webhookSignature) {
+        if (!verifySignature(payload, webhookId, webhookTimestamp, webhookSignature)) {
+            throw new IllegalArgumentException("포트원 웹훅 서명 검증 실패");
+        }
+
+        log.info("포트원 웹훅 수신: payload={}", payload);
+    }
+
+    private boolean verifySignature(String payload, String webhookId, String webhookTimestamp, String webhookSignature) {
+        try {
+            String dataToSign = webhookId + webhookTimestamp + payload;
+            Mac mac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secretKey = new SecretKeySpec(portOneV2Properties.getWebhookSecret().getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            mac.init(secretKey);
+            byte[] rawHmac = mac.doFinal(dataToSign.getBytes(StandardCharsets.UTF_8));
+            String expectedSignature = bytesToHex(rawHmac);
+            return expectedSignature.equals(webhookSignature);
+        } catch (Exception e) {
+            log.error("웹훅 서명 검증 중 오류", e);
+            return false;
+        }
+    }
+
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -58,3 +58,9 @@ cloud:
       secret-key: ${AWS_SECRET_KEY}
     s3:
       bucket: ${AWS_S3_BUCKET}
+
+# PG 결제 설정 (V2)
+portone:
+  v2:
+    store-id: ${PORTONE_STORE_ID}
+    api-secret: ${PORTONE_API_SECRET}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -64,3 +64,4 @@ portone:
   v2:
     store-id: ${PORTONE_STORE_ID}
     api-secret: ${PORTONE_API_SECRET}
+    channel-key: ${PORTONE_CHANNEL_KEY}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -65,3 +65,4 @@ portone:
     store-id: ${PORTONE_STORE_ID}
     api-secret: ${PORTONE_API_SECRET}
     channel-key: ${PORTONE_CHANNEL_KEY}
+    webhook-secret: ${PORTONE_WEBHOOK_SECRET}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@portone/browser-sdk": "^0.1.0",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.83.0",
     "autoprefixer": "^10.4.21",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@portone/browser-sdk':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
@@ -445,6 +448,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@portone/browser-sdk@0.1.0':
+    resolution: {integrity: sha512-4LO5XXqAohbXQbjHXjsJD8YCwNv/6RVkBXhWw+Icf5Hogx1RyRuVJ9Qfa4hr72j+oZCbUCBiaLpPUBVf+Weu1Q==}
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -2026,6 +2032,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@portone/browser-sdk@0.1.0': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -10,6 +10,8 @@ import AuctionListPage from "pages/AuctionListPage";
 import WeeklyRankingPage from "pages/WeeklyRankingPage";
 import QuoteCreatePage from "pages/QuoteCreatePage";
 import QuoteCreateWizardPage from "@/pages/QuoteCreateWizardPage";
+import PaymentSuccessPage from "pages/PaymentSuccessPage";
+import PaymentFailPage from "pages/PaymentFailPage";
 
 export const AppRouter: React.FC = () => {
   return (
@@ -22,6 +24,8 @@ export const AppRouter: React.FC = () => {
         <Route path="/confetti" element={<ConfettiTestPage />} />
         {/* <Route path="/auctions/create" element={<QuoteCreateWizardPage />} /> */}
         <Route path="/auctions/create" element={<QuoteCreatePage />} />
+        <Route path="/payment/success" element={<PaymentSuccessPage />} />
+        <Route path="/payment/fail" element={<PaymentFailPage />} />
 
         {/* Layout이 포함된 일반 페이지들 */}
         <Route

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -8,7 +8,7 @@ import AuthCallbackPage from "pages/AuthCallbackPage";
 import ConfettiTestPage from "pages/ConfettiPage";
 import AuctionListPage from "pages/AuctionListPage";
 import WeeklyRankingPage from "pages/WeeklyRankingPage";
-// import QuoteCreatePage from "pages/QuoteCreatePage";
+import QuoteCreatePage from "pages/QuoteCreatePage";
 import QuoteCreateWizardPage from "@/pages/QuoteCreateWizardPage";
 
 export const AppRouter: React.FC = () => {
@@ -20,8 +20,8 @@ export const AppRouter: React.FC = () => {
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
         <Route path="/confetti" element={<ConfettiTestPage />} />
-        <Route path="/auctions/create" element={<QuoteCreateWizardPage />} />
-        {/* <Route path="/auctions/create" element={<QuoteCreatePage />} /> */}
+        {/* <Route path="/auctions/create" element={<QuoteCreateWizardPage />} /> */}
+        <Route path="/auctions/create" element={<QuoteCreatePage />} />
 
         {/* Layout이 포함된 일반 페이지들 */}
         <Route

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "store/authStore";
 import { useState } from "react";
+import { PortOnePaymentButton } from "../payment/PortOnePaymentButton";
 
 const Header: React.FC = () => {
   const { isAuthenticated, user, logout } = useAuthStore();
@@ -12,6 +13,7 @@ const Header: React.FC = () => {
       console.error("로그아웃 실패:", error);
     }
   };
+  const navigate = useNavigate();
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -49,6 +51,22 @@ const Header: React.FC = () => {
             >
               이용방법
             </Link>
+            <div className="space-y-3">
+              <PortOnePaymentButton
+                label="결제 창 테스트"
+                requestPayload={{
+                  merchantUid: `demo-${Date.now()}`,
+                  amount: 1000,
+                  productName:  "PhoneBid 견적",
+                  buyerName: "홍길동",
+                  buyerEmail: "demo@example.com",
+                  buyerPhone: "01012345678",
+                  returnUrl: `${window.location.origin}/payment/success`,
+                  cancelUrl: `${window.location.origin}/payment/cancel`,
+                }}
+                onSuccess={() => navigate("/auctions")}
+              />
+            </div>
           </nav>
 
           {/* 사용자 메뉴 */}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,7 +1,6 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useAuthStore } from "store/authStore";
 import { useState } from "react";
-import { PortOnePaymentButton } from "../payment/PortOnePaymentButton";
 
 const Header: React.FC = () => {
   const { isAuthenticated, user, logout } = useAuthStore();
@@ -13,8 +12,6 @@ const Header: React.FC = () => {
       console.error("로그아웃 실패:", error);
     }
   };
-  const navigate = useNavigate();
-
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const toggleMobileMenu = () => setIsMobileMenuOpen((prev) => !prev);
@@ -51,22 +48,6 @@ const Header: React.FC = () => {
             >
               이용방법
             </Link>
-            <div className="space-y-3">
-              <PortOnePaymentButton
-                label="결제 창 테스트"
-                requestPayload={{
-                  merchantUid: `demo-${Date.now()}`,
-                  amount: 1000,
-                  productName:  "PhoneBid 견적",
-                  buyerName: "홍길동",
-                  buyerEmail: "demo@example.com",
-                  buyerPhone: "01012345678",
-                  returnUrl: `${window.location.origin}/payment/success`,
-                  cancelUrl: `${window.location.origin}/payment/cancel`,
-                }}
-                onSuccess={() => navigate("/auctions")}
-              />
-            </div>
           </nav>
 
           {/* 사용자 메뉴 */}

--- a/frontend/src/components/payment/PortOnePaymentButton.tsx
+++ b/frontend/src/components/payment/PortOnePaymentButton.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 
 import { Button } from "components/ui/button";
@@ -23,6 +24,7 @@ export const PortOnePaymentButton: React.FC<PortOnePaymentButtonProps> = ({
   label = "결제하기",
 }) => {
   const [isProcessing, setProcessing] = useState(false);
+  const navigate = useNavigate();
 
   const handleClick = useCallback(async () => {
     if (isProcessing) {
@@ -60,6 +62,14 @@ export const PortOnePaymentButton: React.FC<PortOnePaymentButtonProps> = ({
         };
         toast.error(response.message ?? "결제에 실패했습니다.");
         onFailure?.(failureResult);
+        const query = new URLSearchParams();
+        if (response.code) {
+          query.set("code", response.code);
+        }
+        if (response.message) {
+          query.set("message", response.message);
+        }
+        navigate(`/payment/fail?${query.toString()}`);
         return;
       }
 
@@ -68,14 +78,20 @@ export const PortOnePaymentButton: React.FC<PortOnePaymentButtonProps> = ({
       };
       toast.success("결제가 요청되었습니다.");
       onSuccess?.(successResult);
+      if (response.paymentId) {
+        navigate(`/payment/success?paymentId=${encodeURIComponent(response.paymentId)}`);
+      } else {
+        navigate(`/payment/success`);
+      }
     } catch (error) {
       console.error("PortOne 결제 호출 중 오류", error);
       toast.error("결제를 시작하지 못했습니다.");
       onFailure?.({ message: "SDK 호출 실패" });
+      navigate(`/payment/fail?message=${encodeURIComponent("SDK 호출 실패")}`);
     } finally {
       setProcessing(false);
     }
-  }, [isProcessing, onFailure, onSuccess, requestPayload]);
+  }, [isProcessing, navigate, onFailure, onSuccess, requestPayload]);
 
   return (
     <Button onClick={handleClick} disabled={isProcessing}>

--- a/frontend/src/components/payment/PortOnePaymentButton.tsx
+++ b/frontend/src/components/payment/PortOnePaymentButton.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useState } from "react";
+import { toast } from "react-toastify";
+
+import { Button } from "components/ui/button";
+import { requestPortOnePaymentInit } from "services/paymentService";
+import { loadPortOneSdk } from "utils/portoneLoader";
+import type {
+  PortOnePaymentRequest,
+  PortOnePaymentResult,
+} from "types/PaymentTypes";
+
+interface PortOnePaymentButtonProps {
+  requestPayload: PortOnePaymentRequest;
+  onSuccess?: (result: PortOnePaymentResult) => void;
+  onFailure?: (result: PortOnePaymentResult) => void;
+  label?: string;
+}
+
+export const PortOnePaymentButton: React.FC<PortOnePaymentButtonProps> = ({
+  requestPayload,
+  onSuccess,
+  onFailure,
+  label = "결제하기",
+}) => {
+  const [isProcessing, setProcessing] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    if (isProcessing) {
+      return;
+    }
+
+    setProcessing(true);
+
+    try {
+      const initData = await requestPortOnePaymentInit(requestPayload);
+      const PortOne = await loadPortOneSdk();
+
+      const response = await PortOne.requestPayment({
+        storeId: initData.storeId,
+        channelKey: initData.channelKey,
+        paymentId: initData.paymentId,
+        orderName: initData.orderName,
+        payMethod: "CARD",
+        totalAmount: initData.amount,
+        currency: "CURRENCY_KRW",
+        redirectUrl: initData.redirectUrl,
+        cancelUrl: initData.cancelUrl,
+        customer: {
+          fullName: initData.buyerName,
+          phoneNumber: initData.buyerPhone,
+          email: initData.buyerEmail,
+        },
+      });
+
+      if (response.code) {
+        const failureResult: PortOnePaymentResult = {
+          paymentId: response.paymentId,
+          code: response.code,
+          message: response.message,
+        };
+        toast.error(response.message ?? "결제에 실패했습니다.");
+        onFailure?.(failureResult);
+        return;
+      }
+
+      const successResult: PortOnePaymentResult = {
+        paymentId: response.paymentId,
+      };
+      toast.success("결제가 요청되었습니다.");
+      onSuccess?.(successResult);
+    } catch (error) {
+      console.error("PortOne 결제 호출 중 오류", error);
+      toast.error("결제를 시작하지 못했습니다.");
+      onFailure?.({ message: "SDK 호출 실패" });
+    } finally {
+      setProcessing(false);
+    }
+  }, [isProcessing, onFailure, onSuccess, requestPayload]);
+
+  return (
+    <Button onClick={handleClick} disabled={isProcessing}>
+      {isProcessing ? "결제 준비중..." : label}
+    </Button>
+  );
+};
+

--- a/frontend/src/pages/PaymentFailPage.tsx
+++ b/frontend/src/pages/PaymentFailPage.tsx
@@ -1,0 +1,24 @@
+import { Link, useSearchParams } from "react-router-dom";
+
+const PaymentFailPage: React.FC = () => {
+  const [params] = useSearchParams();
+  const code = params.get("code");
+  const message = params.get("message");
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-12 space-y-6 text-center">
+      <h1 className="text-2xl font-bold text-red-500">결제 실패</h1>
+      <div className="space-y-2 text-sm">
+        {code && <p>오류 코드: {code}</p>}
+        {message && <p>사유: {message}</p>}
+        {!code && !message && <p>결제가 취소되었거나 실패했습니다.</p>}
+      </div>
+      <Link className="text-primary underline" to="/">
+        홈으로 돌아가기
+      </Link>
+    </div>
+  );
+};
+
+export default PaymentFailPage;
+

--- a/frontend/src/pages/PaymentSuccessPage.tsx
+++ b/frontend/src/pages/PaymentSuccessPage.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { useSearchParams, Link } from "react-router-dom";
+import { toast } from "react-toastify";
+
+import { requestPortOnePaymentConfirm } from "services/paymentService";
+import type { PortOnePaymentStatusResponse } from "types/PaymentTypes";
+
+const PaymentSuccessPage: React.FC = () => {
+  const [params] = useSearchParams();
+  const paymentId = params.get("paymentId");
+  const [status, setStatus] = useState<PortOnePaymentStatusResponse | null>(
+    null
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const verify = async () => {
+      if (!paymentId) {
+        setError("paymentId가 전달되지 않았습니다.");
+        return;
+      }
+      try {
+        const result = await requestPortOnePaymentConfirm({ paymentId });
+        setStatus(result);
+      } catch (err) {
+        console.error("결제 검증 실패", err);
+        toast.error("결제 상태 확인에 실패했습니다.");
+        setError("결제 상태 확인 중 오류가 발생했습니다.");
+      }
+    };
+    verify();
+  }, [paymentId]);
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-12 space-y-6 text-center">
+      <h1 className="text-2xl font-bold">결제 결과 확인</h1>
+      {!paymentId && (
+        <p className="text-red-500">paymentId가 전달되지 않았습니다.</p>
+      )}
+      {error && <p className="text-red-500">{error}</p>}
+      {status && (
+        <div className="space-y-2 text-sm">
+          <p>결제 ID: {status.paymentId}</p>
+          <p>상태: {status.status}</p>
+          <p>
+            금액: {status.amount?.toLocaleString()} {status.currency}
+          </p>
+        </div>
+      )}
+      <Link className="text-primary underline" to="/">
+        홈으로 돌아가기
+      </Link>
+    </div>
+  );
+};
+
+export default PaymentSuccessPage;
+

--- a/frontend/src/pages/QuoteCreatePage.tsx
+++ b/frontend/src/pages/QuoteCreatePage.tsx
@@ -426,9 +426,8 @@ const QuoteCreatePage: React.FC = () => {
                   buyerEmail: "demo@example.com",
                   buyerPhone: "01012345678",
                   returnUrl: `${window.location.origin}/payment/success`,
-                  cancelUrl: `${window.location.origin}/payment/cancel`,
+                  cancelUrl: `${window.location.origin}/payment/fail`,
                 }}
-                onSuccess={() => navigate("/auctions")}
               />
               <StepFooter
                 nextLabel="제출"

--- a/frontend/src/pages/QuoteCreatePage.tsx
+++ b/frontend/src/pages/QuoteCreatePage.tsx
@@ -7,6 +7,7 @@ import type {
   PurchaseMethod,
 } from "types/QuoteTypes";
 import { DEFAULT_EXPIRED_HOURS } from "types/QuoteTypes";
+import { PortOnePaymentButton } from "components/payment/PortOnePaymentButton";
 import OptionGrid from "components/quote/OptionGrid";
 
 const StepHeader = ({ title, step }: { title: string; step: number }) => (
@@ -414,7 +415,26 @@ const QuoteCreatePage: React.FC = () => {
                 마감: {draft.expiredHours ?? DEFAULT_EXPIRED_HOURS}시간 후
               </div>
             </div>
-            <StepFooter nextLabel="제출" onNext={() => navigate("/auctions")} />
+            <div className="space-y-3">
+              <PortOnePaymentButton
+                label="결제 창 테스트"
+                requestPayload={{
+                  merchantUid: `demo-${Date.now()}`,
+                  amount: 1000,
+                  productName: draft.model ?? "PhoneBid 견적",
+                  buyerName: "홍길동",
+                  buyerEmail: "demo@example.com",
+                  buyerPhone: "01012345678",
+                  returnUrl: `${window.location.origin}/payment/success`,
+                  cancelUrl: `${window.location.origin}/payment/cancel`,
+                }}
+                onSuccess={() => navigate("/auctions")}
+              />
+              <StepFooter
+                nextLabel="제출"
+                onNext={() => navigate("/auctions")}
+              />
+            </div>
           </>
         )}
       </div>

--- a/frontend/src/services/paymentService.ts
+++ b/frontend/src/services/paymentService.ts
@@ -2,15 +2,27 @@ import { apiClient } from "./apiClient";
 import type {
   PortOnePaymentInitResponse,
   PortOnePaymentRequest,
+  PortOnePaymentConfirmRequest,
+  PortOnePaymentStatusResponse,
 } from "types/PaymentTypes";
 
 const PORTONE_INIT_ENDPOINT = "/payments/portone/init";
+const PORTONE_CONFIRM_ENDPOINT = "/payments/portone/confirm";
 
 export const requestPortOnePaymentInit = async (
   payload: PortOnePaymentRequest
 ): Promise<PortOnePaymentInitResponse> => {
   return apiClient.post<PortOnePaymentInitResponse>(
     PORTONE_INIT_ENDPOINT,
+    payload
+  );
+};
+
+export const requestPortOnePaymentConfirm = async (
+  payload: PortOnePaymentConfirmRequest
+): Promise<PortOnePaymentStatusResponse> => {
+  return apiClient.post<PortOnePaymentStatusResponse>(
+    PORTONE_CONFIRM_ENDPOINT,
     payload
   );
 };

--- a/frontend/src/services/paymentService.ts
+++ b/frontend/src/services/paymentService.ts
@@ -1,0 +1,17 @@
+import { apiClient } from "./apiClient";
+import type {
+  PortOnePaymentInitResponse,
+  PortOnePaymentRequest,
+} from "types/PaymentTypes";
+
+const PORTONE_INIT_ENDPOINT = "/payments/portone/init";
+
+export const requestPortOnePaymentInit = async (
+  payload: PortOnePaymentRequest
+): Promise<PortOnePaymentInitResponse> => {
+  return apiClient.post<PortOnePaymentInitResponse>(
+    PORTONE_INIT_ENDPOINT,
+    payload
+  );
+};
+

--- a/frontend/src/types/PaymentTypes.ts
+++ b/frontend/src/types/PaymentTypes.ts
@@ -1,0 +1,30 @@
+export interface PortOnePaymentInitResponse {
+  storeId: string;
+  channelKey: string;
+  paymentId: string;
+  orderName: string;
+  amount: number;
+  buyerName: string;
+  buyerEmail?: string;
+  buyerPhone?: string;
+  redirectUrl?: string;
+  cancelUrl?: string;
+}
+
+export interface PortOnePaymentRequest {
+  merchantUid: string;
+  amount: number;
+  productName: string;
+  buyerName: string;
+  buyerEmail?: string;
+  buyerPhone?: string;
+  returnUrl?: string;
+  cancelUrl?: string;
+}
+
+export interface PortOnePaymentResult {
+  paymentId?: string;
+  code?: string;
+  message?: string;
+}
+

--- a/frontend/src/types/PaymentTypes.ts
+++ b/frontend/src/types/PaymentTypes.ts
@@ -28,3 +28,14 @@ export interface PortOnePaymentResult {
   message?: string;
 }
 
+export interface PortOnePaymentConfirmRequest {
+  paymentId: string;
+}
+
+export interface PortOnePaymentStatusResponse {
+  paymentId: string;
+  status: string;
+  amount: number;
+  currency: string;
+}
+

--- a/frontend/src/utils/portoneLoader.ts
+++ b/frontend/src/utils/portoneLoader.ts
@@ -1,0 +1,35 @@
+declare global {
+  interface Window {
+    PortOne?: typeof import("@portone/browser-sdk/v2");
+  }
+}
+
+const PORTONE_SDK_URL = "https://cdn.portone.io/v2/browser-sdk.js";
+
+let loaderPromise: Promise<typeof import("@portone/browser-sdk/v2")> | null = null;
+
+export const loadPortOneSdk = async () => {
+  if (window.PortOne) {
+    return window.PortOne;
+  }
+
+  if (!loaderPromise) {
+    loaderPromise = new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = PORTONE_SDK_URL;
+      script.async = true;
+      script.onload = () => {
+        if (window.PortOne) {
+          resolve(window.PortOne);
+        } else {
+          reject(new Error("PortOne SDK 로드에 실패했습니다."));
+        }
+      };
+      script.onerror = () => reject(new Error("PortOne SDK 스크립트 로드 오류"));
+      document.head.appendChild(script);
+    });
+  }
+
+  return loaderPromise;
+};
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev:backend": "cd backend && ./gradlew bootRun",
+    "dev:backend:w": "cd backend && .\\gradlew bootRun",
     "dev:frontend": "cd frontend && pnpm dev",
     "dev": "sh -c 'cd backend && ./gradlew bootRun & cd frontend && pnpm dev'",
     "test": "cd backend && ./gradlew test"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #52

## 📝작업 내용

## Portone 결제 초기화 API 구현 `2025.10.10`

**구현 요약**

- **백엔드**
- PortOneV2Properties에 channelKey 추가 후 PhonebidApplication에서 설정 바인딩 활성화.
- PortOnePaymentService에서 주문 ID 생성과 설정값을 사용해 PortOne SDK 호출에 필요한 초기화 데이터를 구성.
- PgPaymentRequest에 검증 애노테이션을 적용하고, 프런트가 전달해야 할 필드를 명확화.
- PortOnePaymentInitResponse와 PortOnePaymentController를 추가하여 /api/v1/payments/portone/init 엔드포인트에서 초기화 정보를 반환.
- **프론트엔드**
- 결제 초기화 서비스(services/paymentService.ts), PortOne SDK 로더(utils/portoneLoader.ts), 타입 정의를 추가.
- 재사용 가능한 PortOnePaymentButton 컴포넌트를 구현

---

## 백엔드 Portone 결제 검증 및 웹훅 처리 구현 및 프론트엔드 결제 성공/실패 리다이렉트 페이지 및 검증 호출 구현 `2025.10.12`

**구현 요약**

- **백엔드**
- PortOneV2Properties에 webhookSecret 추가하고 application.yml에서 매핑.
- PortOneClient로 PortOne REST getPayment 호출 구현.
- PortOnePaymentService에 결제 검증 메서드 추가하여 PortOne 응답 파싱(PortOnePaymentStatusResponse).
- PortOnePaymentController에 /confirm 엔드포인트와 요청 DTO(PortOnePaymentConfirmRequest) 추가.
- PortOneWebhookService·PortOneWebhookController로 웹훅 서명 검증(HMAC-SHA256) 처리.
- **프론트엔드**
- 결제 성공/실패 페이지(PaymentSuccessPage, PaymentFailPage)와 라우트 등록.
- 성공 페이지에서 confirm API 호출하여 결제 상태 표시.
- PaymentTypes, paymentService 확장(확인 요청/응답 타입, confirm API).
- PortOnePaymentButton 성공 콜백 제거 및 returnUrl/cancelUrl을 새 페이지로 수정.