### PR TITLE
Feature/mypage

### DIFF
--- a/.cursor/rules/database-schema.mdc
+++ b/.cursor/rules/database-schema.mdc
@@ -452,6 +452,7 @@ idx_seller_documents_type       -- seller_documents(type) - 문서 타입별 조
 - LAZY 로딩 기본 사용
 - N+1 문제 방지를 위한 JOIN FETCH 활용
 - 페이징 처리 필수 (대용량 데이터)
+- 페이지네이션 시에는 batch fetching 사용
 - 적절한 인덱스 활용
 - 복합 쿼리 시 인덱스 힌트 고려
 
@@ -958,6 +959,7 @@ idx_seller_documents_type       -- seller_documents(type) - 문서 타입별 조
 - LAZY 로딩 기본 사용
 - N+1 문제 방지를 위한 JOIN FETCH 활용
 - 페이징 처리 필수 (대용량 데이터)
+- 페이지네이션 시에는 batch fetching 사용
 - 적절한 인덱스 활용
 - 복합 쿼리 시 인덱스 힌트 고려
 

--- a/backend/src/main/java/com/phonebid/app/common/errorcode/CommonErrorCode.java
+++ b/backend/src/main/java/com/phonebid/app/common/errorcode/CommonErrorCode.java
@@ -55,7 +55,14 @@ public enum CommonErrorCode implements ErrorCode {
     SAME_PASSWORD(HttpStatus.BAD_REQUEST, "새 비밀번호는 현재 비밀번호와 달라야 합니다."),
 
     // 사용자 관련 에러
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // 은행 관련 에러
+    INVALID_BANK_NAME(HttpStatus.BAD_REQUEST, "지원하지 않는 은행명입니다."),
+    INVALID_BANK_CODE(HttpStatus.BAD_REQUEST, "지원하지 않는 은행 코드입니다."),
+
+    // 계좌 관련 에러
+    DUPLICATE_ACCOUNT(HttpStatus.CONFLICT, "이미 등록된 계좌입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/phonebid/app/customerservice/controller/FaqController.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/controller/FaqController.java
@@ -1,0 +1,44 @@
+package com.phonebid.app.customerservice.controller;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.customerservice.domain.FaqCategory;
+import com.phonebid.app.customerservice.dto.response.FaqDetailResponseDto;
+import com.phonebid.app.customerservice.dto.response.FaqResponseDto;
+import com.phonebid.app.customerservice.service.FaqService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage/customerservice/faqs")
+public class FaqController {
+
+    private final FaqService faqService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<FaqResponseDto>>> getAllFaqs(
+            @RequestParam(required = false) FaqCategory category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Page<FaqResponseDto> responseDto = faqService.getAllFaqs(category, page, size);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "FAQ 목록 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    @GetMapping("/{faqId}")
+    public ResponseEntity<ApiResponse<FaqDetailResponseDto>> getFaqDetail(@PathVariable UUID faqId) {
+
+        FaqDetailResponseDto responseDto = faqService.getFaqDetail(faqId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "FAQ 상세 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/controller/InquiryController.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/controller/InquiryController.java
@@ -1,0 +1,83 @@
+package com.phonebid.app.customerservice.controller;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.customerservice.dto.request.InquiryCreateRequestDto;
+import com.phonebid.app.customerservice.dto.request.InquiryUpdateRequestDto;
+import com.phonebid.app.customerservice.dto.response.InquiryDetailResponseDto;
+import com.phonebid.app.customerservice.dto.response.InquiryResponseDto;
+import com.phonebid.app.customerservice.service.InquiryService;
+import com.phonebid.app.security.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage/customerservice/inquiries")
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createInquiry(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                           @Valid @RequestBody InquiryCreateRequestDto requestDto) {
+
+        inquiryService.createInquiry(userDetails.getUsername(), requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, "문의가 성공적으로 등록되었습니다.", null));
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<Page<InquiryResponseDto>>> getMyInquiries(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Page<InquiryResponseDto> responseDto = inquiryService.getMyInquiries(
+                userDetails.getUsername(), page, size);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "나의 문의내역 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    @GetMapping("/{inquiryId}")
+    public ResponseEntity<ApiResponse<InquiryDetailResponseDto>> getInquiryDetail(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                  @PathVariable UUID inquiryId) {
+
+        InquiryDetailResponseDto responseDto = inquiryService.getInquiryDetail(
+                userDetails.getUsername(), inquiryId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "문의 상세 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    @PutMapping("/{inquiryId}")
+    public ResponseEntity<ApiResponse<Void>> updateInquiry(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID inquiryId,
+            @Valid @RequestBody InquiryUpdateRequestDto requestDto) {
+
+        inquiryService.updateInquiry(userDetails.getUsername(), inquiryId, requestDto);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "문의 수정이 성공적으로 완료되었습니다.", null));
+    }
+
+    @DeleteMapping("/{inquiryId}")
+    public ResponseEntity<ApiResponse<Void>> deleteInquiry(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                           @PathVariable UUID inquiryId) {
+
+        inquiryService.deleteInquiry(userDetails.getUsername(), inquiryId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "문의 삭제가 성공적으로 완료되었습니다.", null));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/controller/NoticeController.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/controller/NoticeController.java
@@ -1,0 +1,41 @@
+package com.phonebid.app.customerservice.controller;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.customerservice.dto.response.NoticeDetailResponseDto;
+import com.phonebid.app.customerservice.dto.response.NoticeResponseDto;
+import com.phonebid.app.customerservice.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage/customerservice/notices")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<NoticeResponseDto>>> getAllNotices(@RequestParam(defaultValue = "0") int page, 
+                                                                              @RequestParam(defaultValue = "10") int size) {
+
+        Page<NoticeResponseDto> responseDto = noticeService.getAllNotices(page, size);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "공지사항 목록 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<NoticeDetailResponseDto>> getNoticeDetail(@PathVariable UUID noticeId) {
+
+        NoticeDetailResponseDto responseDto = noticeService.getNoticeDetail(noticeId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "공지사항 상세 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/controller/admin/AdminFaqController.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/controller/admin/AdminFaqController.java
@@ -1,0 +1,58 @@
+package com.phonebid.app.customerservice.controller.admin;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.customerservice.dto.request.FaqCreateRequestDto;
+import com.phonebid.app.customerservice.dto.request.FaqUpdateRequestDto;
+import com.phonebid.app.customerservice.service.FaqService;
+import com.phonebid.app.security.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/customerservice/faqs")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminFaqController {
+
+    private final FaqService faqService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createFaq(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                       @Valid @RequestBody FaqCreateRequestDto requestDto) {
+
+        faqService.createFaq(userDetails.getUsername(), requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, "FAQ가 성공적으로 작성되었습니다.", null));
+    }
+
+    @PutMapping("/{faqId}")
+    public ResponseEntity<ApiResponse<Void>> updateFaq(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID faqId,
+            @Valid @RequestBody FaqUpdateRequestDto requestDto) {
+
+        faqService.updateFaq(userDetails.getUsername(), faqId, requestDto);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "FAQ 수정이 성공적으로 완료되었습니다.", null));
+    }
+
+    @DeleteMapping("/{faqId}")
+    public ResponseEntity<ApiResponse<Void>> deleteFaq(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                       @PathVariable UUID faqId) {
+
+        faqService.deleteFaq(userDetails.getUsername(), faqId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "FAQ 삭제가 성공적으로 완료되었습니다.", null));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/controller/admin/AdminInquiryController.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/controller/admin/AdminInquiryController.java
@@ -34,7 +34,7 @@ public class AdminInquiryController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
-        Page<InquiryResponseDto> responseDto = inquiryService.getAllInquiries(status, category, page, size);
+        Page<InquiryResponseDto> responseDto = inquiryService.getAllInquiries(userDetails.getUsername(), status, category, page, size);
 
         return ResponseEntity.ok()
                 .body(ApiResponse.success(HttpStatus.OK, "전체 문의 목록 조회가 성공적으로 완료되었습니다.", responseDto));

--- a/backend/src/main/java/com/phonebid/app/customerservice/controller/admin/AdminInquiryController.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/controller/admin/AdminInquiryController.java
@@ -1,0 +1,80 @@
+package com.phonebid.app.customerservice.controller.admin;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.customerservice.domain.InquiryCategory;
+import com.phonebid.app.customerservice.domain.InquiryStatus;
+import com.phonebid.app.customerservice.dto.request.InquiryReplyRequestDto;
+import com.phonebid.app.customerservice.dto.response.InquiryResponseDto;
+import com.phonebid.app.customerservice.service.InquiryService;
+import com.phonebid.app.security.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/customerservice/inquiries")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminInquiryController {
+
+    private final InquiryService inquiryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<InquiryResponseDto>>> getAllInquiries(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = false) InquiryStatus status,
+            @RequestParam(required = false) InquiryCategory category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Page<InquiryResponseDto> responseDto = inquiryService.getAllInquiries(status, category, page, size);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "전체 문의 목록 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    @PostMapping("/{inquiryId}/reply")
+    public ResponseEntity<ApiResponse<Void>> createReply(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID inquiryId,
+            @Valid @RequestBody InquiryReplyRequestDto requestDto) {
+
+        inquiryService.createReply(userDetails.getUsername(), inquiryId, requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, "답변이 성공적으로 작성되었습니다.", null));
+    }
+
+    @PutMapping("/{inquiryId}/reply/{replyId}")
+    public ResponseEntity<ApiResponse<Void>> updateReply(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID inquiryId,
+            @PathVariable UUID replyId,
+            @Valid @RequestBody InquiryReplyRequestDto requestDto) {
+
+        inquiryService.updateReply(userDetails.getUsername(), inquiryId, replyId, requestDto);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "답변 수정이 성공적으로 완료되었습니다.", null));
+    }
+
+    @DeleteMapping("/{inquiryId}/reply/{replyId}")
+    public ResponseEntity<ApiResponse<Void>> deleteReply(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable UUID inquiryId,
+            @PathVariable UUID replyId) {
+
+        inquiryService.deleteReply(userDetails.getUsername(), inquiryId, replyId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "답변 삭제가 성공적으로 완료되었습니다.", null));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/controller/admin/AdminNoticeController.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/controller/admin/AdminNoticeController.java
@@ -1,0 +1,57 @@
+package com.phonebid.app.customerservice.controller.admin;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.customerservice.dto.request.NoticeCreateRequestDto;
+import com.phonebid.app.customerservice.dto.request.NoticeUpdateRequestDto;
+import com.phonebid.app.customerservice.service.NoticeService;
+import com.phonebid.app.security.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/customerservice/notices")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminNoticeController {
+
+    private final NoticeService noticeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createNotice(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                          @Valid @RequestBody NoticeCreateRequestDto requestDto) {
+
+        noticeService.createNotice(userDetails.getUsername(), requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, "공지사항이 성공적으로 작성되었습니다.", null));
+    }
+
+    @PutMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<Void>> updateNotice(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                          @PathVariable UUID noticeId,
+                                                          @Valid @RequestBody NoticeUpdateRequestDto requestDto) {
+
+        noticeService.updateNotice(userDetails.getUsername(), noticeId, requestDto);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "공지사항 수정이 성공적으로 완료되었습니다.", null));
+    }
+
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteNotice(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                          @PathVariable UUID noticeId) {
+
+        noticeService.deleteNotice(userDetails.getUsername(), noticeId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "공지사항 삭제가 성공적으로 완료되었습니다.", null));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/domain/Faq.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/domain/Faq.java
@@ -1,0 +1,74 @@
+package com.phonebid.app.customerservice.domain;
+
+import com.phonebid.app.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "faqs", indexes = {
+    @Index(name = "idx_faqs_category", columnList = "category")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Faq extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    @Comment("FAQ 고유 ID (UUID)")
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    @Comment("FAQ 카테고리")
+    private FaqCategory category;
+
+    @Column(name = "question", nullable = false, length = 200)
+    @Comment("질문")
+    private String question;
+
+    @Column(name = "answer", nullable = false, columnDefinition = "TEXT")
+    @Comment("답변")
+    private String answer;
+
+    @Column(name = "view_count", nullable = false)
+    @Comment("조회수")
+    private Long viewCount;
+
+    @Builder
+    public Faq(FaqCategory category, String question, String answer) {
+        this.category = category;
+        this.question = question;
+        this.answer = answer;
+        this.viewCount = 0L;
+    }
+
+    public void updateCategory(FaqCategory category) {
+        this.category = category;
+    }
+
+    public void updateQuestion(String question) {
+        this.question = question;
+    }
+
+    public void updateAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+
+    public void softDelete(String deletedBy) {
+        this.deletedAt = java.time.LocalDateTime.now();
+        this.deletedBy = deletedBy;
+        this.isDelete = true;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/domain/FaqCategory.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/domain/FaqCategory.java
@@ -1,0 +1,22 @@
+package com.phonebid.app.customerservice.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum FaqCategory {
+    SERVICE("서비스 이용", "서비스 이용 방법 안내"),
+    PAYMENT("결제/환불", "결제 및 환불 관련 안내"),
+    DELIVERY("배송", "배송 관련 안내"),
+    ACCOUNT("계정", "계정 관리 안내"),
+    PRODUCT("상품", "상품 관련 안내"),
+    ETC("기타", "기타 안내");
+
+    private final String displayName;
+    private final String description;
+
+    FaqCategory(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/domain/Inquiry.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/domain/Inquiry.java
@@ -1,0 +1,92 @@
+package com.phonebid.app.customerservice.domain;
+
+import com.phonebid.app.common.domain.BaseEntity;
+import com.phonebid.app.member.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "inquiries", indexes = {
+    @Index(name = "idx_inquiries_user_id", columnList = "user_id"),
+    @Index(name = "idx_inquiries_status", columnList = "status"),
+    @Index(name = "idx_inquiries_category", columnList = "category")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Inquiry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    @Comment("문의 고유 ID (UUID)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("문의 작성자")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    @Comment("문의 카테고리")
+    private InquiryCategory category;
+
+    @Column(name = "title", nullable = false, length = 200)
+    @Comment("문의 제목")
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Comment("문의 내용")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Comment("문의 상태")
+    private InquiryStatus status;
+
+    @Builder
+    public Inquiry(User user, InquiryCategory category, String title, String content) {
+        this.user = user;
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.status = InquiryStatus.PENDING;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateCategory(InquiryCategory category) {
+        this.category = category;
+    }
+
+    public void changeStatus(InquiryStatus status) {
+        this.status = status;
+    }
+
+    public boolean isAnswered() {
+        return this.status == InquiryStatus.ANSWERED;
+    }
+
+    public boolean canBeModified() {
+        return this.status == InquiryStatus.PENDING;
+    }
+
+    public void softDelete(String deletedBy) {
+        this.deletedAt = java.time.LocalDateTime.now();
+        this.deletedBy = deletedBy;
+        this.isDelete = true;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/domain/InquiryCategory.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/domain/InquiryCategory.java
@@ -1,0 +1,21 @@
+package com.phonebid.app.customerservice.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum InquiryCategory {
+    PAYMENT("결제", "결제 관련 문의"),
+    DELIVERY("배송", "배송 관련 문의"),
+    ACCOUNT("계정", "계정 관련 문의"),
+    PRODUCT("상품", "상품 관련 문의"),
+    ETC("기타", "기타 문의");
+
+    private final String displayName;
+    private final String description;
+
+    InquiryCategory(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/domain/InquiryReply.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/domain/InquiryReply.java
@@ -1,0 +1,59 @@
+package com.phonebid.app.customerservice.domain;
+
+import com.phonebid.app.common.domain.BaseEntity;
+import com.phonebid.app.member.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "inquiry_replies", indexes = {
+    @Index(name = "idx_inquiry_replies_inquiry_id", columnList = "inquiry_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InquiryReply extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    @Comment("답변 고유 ID (UUID)")
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inquiry_id", nullable = false, unique = true)
+    @Comment("문의")
+    private Inquiry inquiry;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id", nullable = false)
+    @Comment("답변 작성 관리자")
+    private User admin;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Comment("답변 내용")
+    private String content;
+
+    @Builder
+    public InquiryReply(Inquiry inquiry, User admin, String content) {
+        this.inquiry = inquiry;
+        this.admin = admin;
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void softDelete(String deletedBy) {
+        this.deletedAt = java.time.LocalDateTime.now();
+        this.deletedBy = deletedBy;
+        this.isDelete = true;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/domain/InquiryStatus.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/domain/InquiryStatus.java
@@ -1,0 +1,19 @@
+package com.phonebid.app.customerservice.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum InquiryStatus {
+    PENDING("대기중", "답변 대기 중인 문의"),
+    ANSWERED("답변완료", "답변이 완료된 문의"),
+    CLOSED("종료", "종료된 문의");
+
+    private final String displayName;
+    private final String description;
+
+    InquiryStatus(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/domain/Notice.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/domain/Notice.java
@@ -1,0 +1,81 @@
+package com.phonebid.app.customerservice.domain;
+
+import com.phonebid.app.common.domain.BaseEntity;
+import com.phonebid.app.member.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "notices", indexes = {
+    @Index(name = "idx_notices_is_important", columnList = "is_important"),
+    @Index(name = "idx_notices_created_at", columnList = "created_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    @Comment("공지사항 고유 ID (UUID)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id", nullable = false)
+    @Comment("작성 관리자")
+    private User admin;
+
+    @Column(name = "title", nullable = false, length = 200)
+    @Comment("공지사항 제목")
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Comment("공지사항 내용")
+    private String content;
+
+    @Column(name = "is_important", nullable = false)
+    @Comment("중요 공지 여부")
+    private Boolean isImportant;
+
+    @Column(name = "view_count", nullable = false)
+    @Comment("조회수")
+    private Long viewCount;
+
+    @Builder
+    public Notice(User admin, String title, String content, Boolean isImportant) {
+        this.admin = admin;
+        this.title = title;
+        this.content = content;
+        this.isImportant = isImportant != null ? isImportant : false;
+        this.viewCount = 0L;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateIsImportant(Boolean isImportant) {
+        this.isImportant = isImportant;
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+
+    public void softDelete(String deletedBy) {
+        this.deletedAt = java.time.LocalDateTime.now();
+        this.deletedBy = deletedBy;
+        this.isDelete = true;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/request/FaqCreateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/request/FaqCreateRequestDto.java
@@ -1,0 +1,24 @@
+package com.phonebid.app.customerservice.dto.request;
+
+import com.phonebid.app.customerservice.domain.FaqCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FaqCreateRequestDto {
+
+    @NotNull(message = "FAQ 카테고리는 필수입니다.")
+    private FaqCategory category;
+
+    @NotBlank(message = "질문은 필수입니다.")
+    @Size(max = 200, message = "질문은 200자 이하여야 합니다.")
+    private String question;
+
+    @NotBlank(message = "답변은 필수입니다.")
+    private String answer;
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/request/FaqUpdateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/request/FaqUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.phonebid.app.customerservice.dto.request;
+
+import com.phonebid.app.customerservice.domain.FaqCategory;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FaqUpdateRequestDto {
+
+    private FaqCategory category;
+
+    @Size(max = 200, message = "질문은 200자 이하여야 합니다.")
+    private String question;
+
+    private String answer;
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/request/InquiryCreateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/request/InquiryCreateRequestDto.java
@@ -1,0 +1,24 @@
+package com.phonebid.app.customerservice.dto.request;
+
+import com.phonebid.app.customerservice.domain.InquiryCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InquiryCreateRequestDto {
+
+    @NotNull(message = "문의 카테고리는 필수입니다.")
+    private InquiryCategory category;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/request/InquiryReplyRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/request/InquiryReplyRequestDto.java
@@ -1,0 +1,14 @@
+package com.phonebid.app.customerservice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InquiryReplyRequestDto {
+
+    @NotBlank(message = "답변 내용은 필수입니다.")
+    private String content;
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/request/InquiryUpdateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/request/InquiryUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.phonebid.app.customerservice.dto.request;
+
+import com.phonebid.app.customerservice.domain.InquiryCategory;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InquiryUpdateRequestDto {
+
+    private InquiryCategory category;
+
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다.")
+    private String title;
+
+    private String content;
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/request/NoticeCreateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/request/NoticeCreateRequestDto.java
@@ -1,0 +1,21 @@
+package com.phonebid.app.customerservice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeCreateRequestDto {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    private Boolean isImportant;
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/request/NoticeUpdateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/request/NoticeUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.phonebid.app.customerservice.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeUpdateRequestDto {
+
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다.")
+    private String title;
+
+    private String content;
+
+    private Boolean isImportant;
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/response/FaqDetailResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/response/FaqDetailResponseDto.java
@@ -1,0 +1,33 @@
+package com.phonebid.app.customerservice.dto.response;
+
+import com.phonebid.app.customerservice.domain.Faq;
+import com.phonebid.app.customerservice.domain.FaqCategory;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class FaqDetailResponseDto {
+
+    private UUID id;
+    private FaqCategory category;
+    private String question;
+    private String answer;
+    private Long viewCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static FaqDetailResponseDto from(Faq faq) {
+        FaqDetailResponseDto dto = new FaqDetailResponseDto();
+        dto.id = faq.getId();
+        dto.category = faq.getCategory();
+        dto.question = faq.getQuestion();
+        dto.answer = faq.getAnswer();
+        dto.viewCount = faq.getViewCount();
+        dto.createdAt = faq.getCreatedAt();
+        dto.updatedAt = faq.getUpdatedAt();
+        return dto;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/response/FaqResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/response/FaqResponseDto.java
@@ -1,0 +1,31 @@
+package com.phonebid.app.customerservice.dto.response;
+
+import com.phonebid.app.customerservice.domain.Faq;
+import com.phonebid.app.customerservice.domain.FaqCategory;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class FaqResponseDto {
+
+    private UUID id;
+    private FaqCategory category;
+    private String question;
+    private Long viewCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static FaqResponseDto from(Faq faq) {
+        FaqResponseDto dto = new FaqResponseDto();
+        dto.id = faq.getId();
+        dto.category = faq.getCategory();
+        dto.question = faq.getQuestion();
+        dto.viewCount = faq.getViewCount();
+        dto.createdAt = faq.getCreatedAt();
+        dto.updatedAt = faq.getUpdatedAt();
+        return dto;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/response/InquiryDetailResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/response/InquiryDetailResponseDto.java
@@ -1,0 +1,59 @@
+package com.phonebid.app.customerservice.dto.response;
+
+import com.phonebid.app.customerservice.domain.Inquiry;
+import com.phonebid.app.customerservice.domain.InquiryCategory;
+import com.phonebid.app.customerservice.domain.InquiryReply;
+import com.phonebid.app.customerservice.domain.InquiryStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class InquiryDetailResponseDto {
+
+    private UUID id;
+    private InquiryCategory category;
+    private String title;
+    private String content;
+    private InquiryStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private InquiryReplyDto reply;
+
+    @Getter
+    public static class InquiryReplyDto {
+        private UUID id;
+        private String content;
+        private String adminNickname;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static InquiryReplyDto from(InquiryReply reply) {
+            if (reply == null) {
+                return null;
+            }
+            InquiryReplyDto dto = new InquiryReplyDto();
+            dto.id = reply.getId();
+            dto.content = reply.getContent();
+            dto.adminNickname = reply.getAdmin().getNickname();
+            dto.createdAt = reply.getCreatedAt();
+            dto.updatedAt = reply.getUpdatedAt();
+            return dto;
+        }
+    }
+
+    public static InquiryDetailResponseDto from(Inquiry inquiry, InquiryReply reply) {
+        InquiryDetailResponseDto dto = new InquiryDetailResponseDto();
+        dto.id = inquiry.getId();
+        dto.category = inquiry.getCategory();
+        dto.title = inquiry.getTitle();
+        dto.content = inquiry.getContent();
+        dto.status = inquiry.getStatus();
+        dto.createdAt = inquiry.getCreatedAt();
+        dto.updatedAt = inquiry.getUpdatedAt();
+        dto.reply = InquiryReplyDto.from(reply);
+        return dto;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/response/InquiryDetailResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/response/InquiryDetailResponseDto.java
@@ -36,7 +36,7 @@ public class InquiryDetailResponseDto {
             InquiryReplyDto dto = new InquiryReplyDto();
             dto.id = reply.getId();
             dto.content = reply.getContent();
-            dto.adminNickname = reply.getAdmin().getNickname();
+            dto.adminNickname = reply.getAdmin() != null ? reply.getAdmin().getNickname() : null;
             dto.createdAt = reply.getCreatedAt();
             dto.updatedAt = reply.getUpdatedAt();
             return dto;

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/response/InquiryResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/response/InquiryResponseDto.java
@@ -1,0 +1,32 @@
+package com.phonebid.app.customerservice.dto.response;
+
+import com.phonebid.app.customerservice.domain.Inquiry;
+import com.phonebid.app.customerservice.domain.InquiryCategory;
+import com.phonebid.app.customerservice.domain.InquiryStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class InquiryResponseDto {
+
+    private UUID id;
+    private InquiryCategory category;
+    private String title;
+    private InquiryStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static InquiryResponseDto from(Inquiry inquiry) {
+        InquiryResponseDto dto = new InquiryResponseDto();
+        dto.id = inquiry.getId();
+        dto.category = inquiry.getCategory();
+        dto.title = inquiry.getTitle();
+        dto.status = inquiry.getStatus();
+        dto.createdAt = inquiry.getCreatedAt();
+        dto.updatedAt = inquiry.getUpdatedAt();
+        return dto;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/response/NoticeDetailResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/response/NoticeDetailResponseDto.java
@@ -1,0 +1,34 @@
+package com.phonebid.app.customerservice.dto.response;
+
+import com.phonebid.app.customerservice.domain.Notice;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class NoticeDetailResponseDto {
+
+    private UUID id;
+    private String title;
+    private String content;
+    private Boolean isImportant;
+    private Long viewCount;
+    private String adminNickname;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static NoticeDetailResponseDto from(Notice notice) {
+        NoticeDetailResponseDto dto = new NoticeDetailResponseDto();
+        dto.id = notice.getId();
+        dto.title = notice.getTitle();
+        dto.content = notice.getContent();
+        dto.isImportant = notice.getIsImportant();
+        dto.viewCount = notice.getViewCount();
+        dto.adminNickname = notice.getAdmin().getNickname();
+        dto.createdAt = notice.getCreatedAt();
+        dto.updatedAt = notice.getUpdatedAt();
+        return dto;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/response/NoticeDetailResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/response/NoticeDetailResponseDto.java
@@ -25,7 +25,7 @@ public class NoticeDetailResponseDto {
         dto.content = notice.getContent();
         dto.isImportant = notice.getIsImportant();
         dto.viewCount = notice.getViewCount();
-        dto.adminNickname = notice.getAdmin().getNickname();
+        dto.adminNickname = notice.getAdmin() != null ? notice.getAdmin().getNickname() : null;
         dto.createdAt = notice.getCreatedAt();
         dto.updatedAt = notice.getUpdatedAt();
         return dto;

--- a/backend/src/main/java/com/phonebid/app/customerservice/dto/response/NoticeResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/dto/response/NoticeResponseDto.java
@@ -1,0 +1,30 @@
+package com.phonebid.app.customerservice.dto.response;
+
+import com.phonebid.app.customerservice.domain.Notice;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class NoticeResponseDto {
+
+    private UUID id;
+    private String title;
+    private Boolean isImportant;
+    private Long viewCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static NoticeResponseDto from(Notice notice) {
+        NoticeResponseDto dto = new NoticeResponseDto();
+        dto.id = notice.getId();
+        dto.title = notice.getTitle();
+        dto.isImportant = notice.getIsImportant();
+        dto.viewCount = notice.getViewCount();
+        dto.createdAt = notice.getCreatedAt();
+        dto.updatedAt = notice.getUpdatedAt();
+        return dto;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/errorcode/CustomerServiceErrorCode.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/errorcode/CustomerServiceErrorCode.java
@@ -1,0 +1,32 @@
+package com.phonebid.app.customerservice.errorcode;
+
+import com.phonebid.app.common.errorcode.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum CustomerServiceErrorCode implements ErrorCode {
+
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
+    INQUIRY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 문의에 접근할 수 없습니다."),
+    INQUIRY_CANNOT_MODIFY(HttpStatus.BAD_REQUEST, "답변이 완료된 문의는 수정할 수 없습니다."),
+    INQUIRY_REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "답변을 찾을 수 없습니다."),
+    INQUIRY_REPLY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 답변이 작성된 문의입니다."),
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
+    FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ를 찾을 수 없습니다."),
+    ONLY_ADMIN_ALLOWED(HttpStatus.FORBIDDEN, "관리자만 접근할 수 있습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/FaqRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/FaqRepository.java
@@ -15,10 +15,11 @@ import java.util.UUID;
 @Repository
 public interface FaqRepository extends JpaRepository<Faq, UUID> {
 
-    @Query("SELECT f FROM Faq f WHERE (:category IS NULL OR f.category = :category) ORDER BY f.createdAt DESC")
+    @Query("SELECT f FROM Faq f WHERE (:category IS NULL OR f.category = :category) " +
+           "AND (f.isDelete = false OR f.isDelete IS NULL) ORDER BY f.createdAt DESC")
     Page<Faq> findAllWithCategoryFilter(@Param("category") FaqCategory category, Pageable pageable);
 
-    @Query("SELECT f FROM Faq f WHERE f.id = :id")
+    @Query("SELECT f FROM Faq f WHERE f.id = :id AND (f.isDelete = false OR f.isDelete IS NULL)")
     Optional<Faq> findByIdForView(@Param("id") UUID id);
 }
 

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/FaqRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/FaqRepository.java
@@ -1,0 +1,24 @@
+package com.phonebid.app.customerservice.repository;
+
+import com.phonebid.app.customerservice.domain.Faq;
+import com.phonebid.app.customerservice.domain.FaqCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface FaqRepository extends JpaRepository<Faq, UUID> {
+
+    @Query("SELECT f FROM Faq f WHERE (:category IS NULL OR f.category = :category) ORDER BY f.createdAt DESC")
+    Page<Faq> findAllWithCategoryFilter(@Param("category") FaqCategory category, Pageable pageable);
+
+    @Query("SELECT f FROM Faq f WHERE f.id = :id")
+    Optional<Faq> findByIdForView(@Param("id") UUID id);
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryReplyRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryReplyRepository.java
@@ -12,7 +12,8 @@ import java.util.UUID;
 @Repository
 public interface InquiryReplyRepository extends JpaRepository<InquiryReply, UUID> {
 
-    @Query("SELECT ir FROM InquiryReply ir WHERE ir.inquiry.id = :inquiryId")
+    @Query("SELECT ir FROM InquiryReply ir WHERE ir.inquiry.id = :inquiryId " +
+           "AND (ir.isDelete = false OR ir.isDelete IS NULL)")
     Optional<InquiryReply> findByInquiryId(@Param("inquiryId") UUID inquiryId);
 }
 

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryReplyRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryReplyRepository.java
@@ -15,5 +15,9 @@ public interface InquiryReplyRepository extends JpaRepository<InquiryReply, UUID
     @Query("SELECT ir FROM InquiryReply ir JOIN FETCH ir.admin WHERE ir.inquiry.id = :inquiryId " +
            "AND (ir.isDelete = false OR ir.isDelete IS NULL)")
     Optional<InquiryReply> findByInquiryId(@Param("inquiryId") UUID inquiryId);
+
+    @Query("SELECT ir FROM InquiryReply ir WHERE ir.id = :id " +
+           "AND (ir.isDelete = false OR ir.isDelete IS NULL)")
+    Optional<InquiryReply> findByIdAndNotDeleted(@Param("id") UUID id);
 }
 

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryReplyRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryReplyRepository.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Repository
 public interface InquiryReplyRepository extends JpaRepository<InquiryReply, UUID> {
 
-    @Query("SELECT ir FROM InquiryReply ir WHERE ir.inquiry.id = :inquiryId " +
+    @Query("SELECT ir FROM InquiryReply ir JOIN FETCH ir.admin WHERE ir.inquiry.id = :inquiryId " +
            "AND (ir.isDelete = false OR ir.isDelete IS NULL)")
     Optional<InquiryReply> findByInquiryId(@Param("inquiryId") UUID inquiryId);
 }

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryReplyRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryReplyRepository.java
@@ -1,0 +1,18 @@
+package com.phonebid.app.customerservice.repository;
+
+import com.phonebid.app.customerservice.domain.InquiryReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface InquiryReplyRepository extends JpaRepository<InquiryReply, UUID> {
+
+    @Query("SELECT ir FROM InquiryReply ir WHERE ir.inquiry.id = :inquiryId")
+    Optional<InquiryReply> findByInquiryId(@Param("inquiryId") UUID inquiryId);
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryRepository.java
@@ -16,19 +16,19 @@ import java.util.UUID;
 @Repository
 public interface InquiryRepository extends JpaRepository<Inquiry, UUID> {
 
-    @Query("SELECT i FROM Inquiry i WHERE i.user.username = :username ORDER BY i.createdAt DESC")
+    @Query("SELECT i FROM Inquiry i WHERE i.user.username = :username " +
+           "AND (i.isDelete = false OR i.isDelete IS NULL) ORDER BY i.createdAt DESC")
     Page<Inquiry> findByUsername(@Param("username") String username, Pageable pageable);
 
-    @Query("SELECT i FROM Inquiry i WHERE i.id = :id AND i.user.username = :username")
+    @Query("SELECT i FROM Inquiry i WHERE i.id = :id AND i.user.username = :username " +
+           "AND (i.isDelete = false OR i.isDelete IS NULL)")
     Optional<Inquiry> findByIdAndUsername(@Param("id") UUID id, @Param("username") String username);
 
     @Query("SELECT i FROM Inquiry i WHERE " +
            "(:status IS NULL OR i.status = :status) AND " +
-           "(:category IS NULL OR i.category = :category) " +
+           "(:category IS NULL OR i.category = :category) AND " +
+           "(i.isDelete = false OR i.isDelete IS NULL) " +
            "ORDER BY i.createdAt DESC")
-    Page<Inquiry> findAllWithFilters(
-            @Param("status") InquiryStatus status,
-            @Param("category") InquiryCategory category,
-            Pageable pageable);
+    Page<Inquiry> findAllWithFilters(@Param("status") InquiryStatus status, @Param("category") InquiryCategory category, Pageable pageable);
 }
 

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryRepository.java
@@ -1,0 +1,34 @@
+package com.phonebid.app.customerservice.repository;
+
+import com.phonebid.app.customerservice.domain.Inquiry;
+import com.phonebid.app.customerservice.domain.InquiryCategory;
+import com.phonebid.app.customerservice.domain.InquiryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface InquiryRepository extends JpaRepository<Inquiry, UUID> {
+
+    @Query("SELECT i FROM Inquiry i WHERE i.user.username = :username ORDER BY i.createdAt DESC")
+    Page<Inquiry> findByUsername(@Param("username") String username, Pageable pageable);
+
+    @Query("SELECT i FROM Inquiry i WHERE i.id = :id AND i.user.username = :username")
+    Optional<Inquiry> findByIdAndUsername(@Param("id") UUID id, @Param("username") String username);
+
+    @Query("SELECT i FROM Inquiry i WHERE " +
+           "(:status IS NULL OR i.status = :status) AND " +
+           "(:category IS NULL OR i.category = :category) " +
+           "ORDER BY i.createdAt DESC")
+    Page<Inquiry> findAllWithFilters(
+            @Param("status") InquiryStatus status,
+            @Param("category") InquiryCategory category,
+            Pageable pageable);
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/InquiryRepository.java
@@ -30,5 +30,9 @@ public interface InquiryRepository extends JpaRepository<Inquiry, UUID> {
            "(i.isDelete = false OR i.isDelete IS NULL) " +
            "ORDER BY i.createdAt DESC")
     Page<Inquiry> findAllWithFilters(@Param("status") InquiryStatus status, @Param("category") InquiryCategory category, Pageable pageable);
+
+    @Query("SELECT i FROM Inquiry i WHERE i.id = :id " +
+           "AND (i.isDelete = false OR i.isDelete IS NULL)")
+    Optional<Inquiry> findByIdAndNotDeleted(@Param("id") UUID id);
 }
 

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/NoticeRepository.java
@@ -1,0 +1,23 @@
+package com.phonebid.app.customerservice.repository;
+
+import com.phonebid.app.customerservice.domain.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, UUID> {
+
+    @Query("SELECT n FROM Notice n ORDER BY n.isImportant DESC, n.createdAt DESC")
+    Page<Notice> findAllOrdered(Pageable pageable);
+
+    @Query("SELECT n FROM Notice n WHERE n.id = :id")
+    Optional<Notice> findByIdForView(@Param("id") UUID id);
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/NoticeRepository.java
@@ -18,7 +18,7 @@ public interface NoticeRepository extends JpaRepository<Notice, UUID> {
            "ORDER BY n.isImportant DESC, n.createdAt DESC")
     Page<Notice> findAllOrdered(Pageable pageable);
 
-    @Query("SELECT n FROM Notice n WHERE n.id = :id AND (n.isDelete = false OR n.isDelete IS NULL)")
+    @Query("SELECT n FROM Notice n JOIN FETCH n.admin WHERE n.id = :id AND (n.isDelete = false OR n.isDelete IS NULL)")
     Optional<Notice> findByIdForView(@Param("id") UUID id);
 }
 

--- a/backend/src/main/java/com/phonebid/app/customerservice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/repository/NoticeRepository.java
@@ -14,10 +14,11 @@ import java.util.UUID;
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, UUID> {
 
-    @Query("SELECT n FROM Notice n ORDER BY n.isImportant DESC, n.createdAt DESC")
+    @Query("SELECT n FROM Notice n WHERE (n.isDelete = false OR n.isDelete IS NULL) " +
+           "ORDER BY n.isImportant DESC, n.createdAt DESC")
     Page<Notice> findAllOrdered(Pageable pageable);
 
-    @Query("SELECT n FROM Notice n WHERE n.id = :id")
+    @Query("SELECT n FROM Notice n WHERE n.id = :id AND (n.isDelete = false OR n.isDelete IS NULL)")
     Optional<Notice> findByIdForView(@Param("id") UUID id);
 }
 

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/FaqService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/FaqService.java
@@ -1,0 +1,98 @@
+package com.phonebid.app.customerservice.service;
+
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.customerservice.domain.Faq;
+import com.phonebid.app.customerservice.domain.FaqCategory;
+import com.phonebid.app.customerservice.dto.request.FaqCreateRequestDto;
+import com.phonebid.app.customerservice.dto.request.FaqUpdateRequestDto;
+import com.phonebid.app.customerservice.dto.response.FaqDetailResponseDto;
+import com.phonebid.app.customerservice.dto.response.FaqResponseDto;
+import com.phonebid.app.customerservice.errorcode.CustomerServiceErrorCode;
+import com.phonebid.app.customerservice.repository.FaqRepository;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FaqService {
+
+    private final FaqRepository faqRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public Page<FaqResponseDto> getAllFaqs(FaqCategory category, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Faq> faqs = faqRepository.findAllWithCategoryFilter(category, pageable);
+        return faqs.map(FaqResponseDto::from);
+    }
+
+    @Transactional
+    public FaqDetailResponseDto getFaqDetail(UUID faqId) {
+        Faq faq = faqRepository.findByIdForView(faqId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.FAQ_NOT_FOUND));
+
+        faq.incrementViewCount();
+        return FaqDetailResponseDto.from(faq);
+    }
+
+    @Transactional
+    public void createFaq(String adminUsername, FaqCreateRequestDto requestDto) {
+        loadActiveAdmin(adminUsername);
+
+        Faq faq = Faq.builder()
+                .category(requestDto.getCategory())
+                .question(requestDto.getQuestion().trim())
+                .answer(requestDto.getAnswer().trim())
+                .build();
+
+        faqRepository.save(faq);
+    }
+
+    @Transactional
+    public void updateFaq(String adminUsername, UUID faqId, FaqUpdateRequestDto requestDto) {
+        Faq faq = faqRepository.findById(faqId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.FAQ_NOT_FOUND));
+
+        if (requestDto.getCategory() != null) {
+            faq.updateCategory(requestDto.getCategory());
+        }
+        if (requestDto.getQuestion() != null && !requestDto.getQuestion().trim().isEmpty()) {
+            faq.updateQuestion(requestDto.getQuestion().trim());
+        }
+        if (requestDto.getAnswer() != null && !requestDto.getAnswer().trim().isEmpty()) {
+            faq.updateAnswer(requestDto.getAnswer().trim());
+        }
+    }
+
+    @Transactional
+    public void deleteFaq(String adminUsername, UUID faqId) {
+        Faq faq = faqRepository.findById(faqId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.FAQ_NOT_FOUND));
+
+        faq.softDelete(adminUsername);
+    }
+
+    private User loadActiveUser(String username) {
+        return userRepository.findByUsername(username)
+                .filter(user -> !user.isDeleted())
+                .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+    }
+
+    private User loadActiveAdmin(String username) {
+        User user = loadActiveUser(username);
+        if (!user.isAdmin()) {
+            throw new CustomException(CustomerServiceErrorCode.ONLY_ADMIN_ALLOWED);
+        }
+        return user;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/FaqService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/FaqService.java
@@ -59,6 +59,8 @@ public class FaqService {
 
     @Transactional
     public void updateFaq(String adminUsername, UUID faqId, FaqUpdateRequestDto requestDto) {
+        loadActiveAdmin(adminUsername);
+
         Faq faq = faqRepository.findById(faqId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.FAQ_NOT_FOUND));
 
@@ -75,6 +77,8 @@ public class FaqService {
 
     @Transactional
     public void deleteFaq(String adminUsername, UUID faqId) {
+        loadActiveAdmin(adminUsername);
+
         Faq faq = faqRepository.findById(faqId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.FAQ_NOT_FOUND));
 
@@ -87,6 +91,10 @@ public class FaqService {
                 .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
     }
 
+    /**
+     * 활성 관리자 조회 및 권한 검증
+     * 관리자가 아닌 경우 예외를 발생시킵니다.
+     */
     private User loadActiveAdmin(String username) {
         User user = loadActiveUser(username);
         if (!user.isAdmin()) {

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
@@ -1,0 +1,162 @@
+package com.phonebid.app.customerservice.service;
+
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.customerservice.domain.Inquiry;
+import com.phonebid.app.customerservice.domain.InquiryCategory;
+import com.phonebid.app.customerservice.domain.InquiryReply;
+import com.phonebid.app.customerservice.domain.InquiryStatus;
+import com.phonebid.app.customerservice.dto.request.InquiryCreateRequestDto;
+import com.phonebid.app.customerservice.dto.request.InquiryReplyRequestDto;
+import com.phonebid.app.customerservice.dto.request.InquiryUpdateRequestDto;
+import com.phonebid.app.customerservice.dto.response.InquiryDetailResponseDto;
+import com.phonebid.app.customerservice.dto.response.InquiryResponseDto;
+import com.phonebid.app.customerservice.errorcode.CustomerServiceErrorCode;
+import com.phonebid.app.customerservice.repository.InquiryReplyRepository;
+import com.phonebid.app.customerservice.repository.InquiryRepository;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryService {
+
+    private final InquiryRepository inquiryRepository;
+    private final InquiryReplyRepository inquiryReplyRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createInquiry(String username, InquiryCreateRequestDto requestDto) {
+        User user = loadActiveUser(username);
+
+        Inquiry inquiry = Inquiry.builder()
+                .user(user)
+                .category(requestDto.getCategory())
+                .title(requestDto.getTitle().trim())
+                .content(requestDto.getContent().trim())
+                .build();
+
+        inquiryRepository.save(inquiry);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<InquiryResponseDto> getMyInquiries(String username, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Inquiry> inquiries = inquiryRepository.findByUsername(username, pageable);
+        return inquiries.map(InquiryResponseDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public InquiryDetailResponseDto getInquiryDetail(String username, UUID inquiryId) {
+        Inquiry inquiry = inquiryRepository.findByIdAndUsername(inquiryId, username)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_NOT_FOUND));
+
+        Optional<InquiryReply> reply = inquiryReplyRepository.findByInquiryId(inquiryId);
+        return InquiryDetailResponseDto.from(inquiry, reply.orElse(null));
+    }
+
+    @Transactional
+    public void updateInquiry(String username, UUID inquiryId, InquiryUpdateRequestDto requestDto) {
+        Inquiry inquiry = inquiryRepository.findByIdAndUsername(inquiryId, username)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_NOT_FOUND));
+
+        if (!inquiry.canBeModified()) {
+            throw new CustomException(CustomerServiceErrorCode.INQUIRY_CANNOT_MODIFY);
+        }
+
+        if (requestDto.getCategory() != null) {
+            inquiry.updateCategory(requestDto.getCategory());
+        }
+        if (requestDto.getTitle() != null && !requestDto.getTitle().trim().isEmpty()) {
+            inquiry.updateTitle(requestDto.getTitle().trim());
+        }
+        if (requestDto.getContent() != null && !requestDto.getContent().trim().isEmpty()) {
+            inquiry.updateContent(requestDto.getContent().trim());
+        }
+    }
+
+    @Transactional
+    public void deleteInquiry(String username, UUID inquiryId) {
+        Inquiry inquiry = inquiryRepository.findByIdAndUsername(inquiryId, username)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_NOT_FOUND));
+
+        inquiry.softDelete(username);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<InquiryResponseDto> getAllInquiries(InquiryStatus status, InquiryCategory category, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Inquiry> inquiries = inquiryRepository.findAllWithFilters(status, category, pageable);
+        return inquiries.map(InquiryResponseDto::from);
+    }
+
+    @Transactional
+    public void createReply(String adminUsername, UUID inquiryId, InquiryReplyRequestDto requestDto) {
+        User admin = loadActiveAdmin(adminUsername);
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_NOT_FOUND));
+
+        Optional<InquiryReply> existingReply = inquiryReplyRepository.findByInquiryId(inquiryId);
+        if (existingReply.isPresent()) {
+            throw new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_ALREADY_EXISTS);
+        }
+
+        InquiryReply reply = InquiryReply.builder()
+                .inquiry(inquiry)
+                .admin(admin)
+                .content(requestDto.getContent().trim())
+                .build();
+
+        inquiryReplyRepository.save(reply);
+        inquiry.changeStatus(InquiryStatus.ANSWERED);
+    }
+
+    @Transactional
+    public void updateReply(String adminUsername, UUID inquiryId, UUID replyId, InquiryReplyRequestDto requestDto) {
+        InquiryReply reply = inquiryReplyRepository.findById(replyId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_NOT_FOUND));
+
+        if (!reply.getInquiry().getId().equals(inquiryId)) {
+            throw new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_NOT_FOUND);
+        }
+
+        reply.updateContent(requestDto.getContent().trim());
+    }
+
+    @Transactional
+    public void deleteReply(String adminUsername, UUID inquiryId, UUID replyId) {
+        InquiryReply reply = inquiryReplyRepository.findById(replyId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_NOT_FOUND));
+
+        if (!reply.getInquiry().getId().equals(inquiryId)) {
+            throw new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_NOT_FOUND);
+        }
+
+        reply.softDelete(adminUsername);
+        reply.getInquiry().changeStatus(InquiryStatus.PENDING);
+    }
+
+    private User loadActiveUser(String username) {
+        return userRepository.findByUsername(username)
+                .filter(user -> !user.isDeleted())
+                .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+    }
+
+    private User loadActiveAdmin(String username) {
+        User user = loadActiveUser(username);
+        if (!user.isAdmin()) {
+            throw new CustomException(CustomerServiceErrorCode.ONLY_ADMIN_ALLOWED);
+        }
+        return user;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
@@ -122,6 +122,8 @@ public class InquiryService {
 
     @Transactional
     public void updateReply(String adminUsername, UUID inquiryId, UUID replyId, InquiryReplyRequestDto requestDto) {
+        loadActiveAdmin(adminUsername);
+
         InquiryReply reply = inquiryReplyRepository.findById(replyId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_NOT_FOUND));
 
@@ -134,6 +136,8 @@ public class InquiryService {
 
     @Transactional
     public void deleteReply(String adminUsername, UUID inquiryId, UUID replyId) {
+        loadActiveAdmin(adminUsername);
+
         InquiryReply reply = inquiryReplyRepository.findById(replyId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_NOT_FOUND));
 

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
@@ -104,7 +104,7 @@ public class InquiryService {
     @Transactional
     public void createReply(String adminUsername, UUID inquiryId, InquiryReplyRequestDto requestDto) {
         User admin = loadActiveAdmin(adminUsername);
-        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+        Inquiry inquiry = inquiryRepository.findByIdAndNotDeleted(inquiryId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_NOT_FOUND));
 
         Optional<InquiryReply> existingReply = inquiryReplyRepository.findByInquiryId(inquiryId);
@@ -126,7 +126,7 @@ public class InquiryService {
     public void updateReply(String adminUsername, UUID inquiryId, UUID replyId, InquiryReplyRequestDto requestDto) {
         loadActiveAdmin(adminUsername);
 
-        InquiryReply reply = inquiryReplyRepository.findById(replyId)
+        InquiryReply reply = inquiryReplyRepository.findByIdAndNotDeleted(replyId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_NOT_FOUND));
 
         if (!reply.getInquiry().getId().equals(inquiryId)) {
@@ -140,7 +140,7 @@ public class InquiryService {
     public void deleteReply(String adminUsername, UUID inquiryId, UUID replyId) {
         loadActiveAdmin(adminUsername);
 
-        InquiryReply reply = inquiryReplyRepository.findById(replyId)
+        InquiryReply reply = inquiryReplyRepository.findByIdAndNotDeleted(replyId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.INQUIRY_REPLY_NOT_FOUND));
 
         if (!reply.getInquiry().getId().equals(inquiryId)) {

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
@@ -151,6 +151,10 @@ public class InquiryService {
                 .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
     }
 
+    /**
+     * 활성 관리자 조회 및 권한 검증
+     * 관리자가 아닌 경우 예외를 발생시킵니다.
+     */
     private User loadActiveAdmin(String username) {
         User user = loadActiveUser(username);
         if (!user.isAdmin()) {

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/InquiryService.java
@@ -93,7 +93,9 @@ public class InquiryService {
     }
 
     @Transactional(readOnly = true)
-    public Page<InquiryResponseDto> getAllInquiries(InquiryStatus status, InquiryCategory category, int page, int size) {
+    public Page<InquiryResponseDto> getAllInquiries(String adminUsername, InquiryStatus status, InquiryCategory category, int page, int size) {
+        loadActiveAdmin(adminUsername);
+
         Pageable pageable = PageRequest.of(page, size);
         Page<Inquiry> inquiries = inquiryRepository.findAllWithFilters(status, category, pageable);
         return inquiries.map(InquiryResponseDto::from);

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/NoticeService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/NoticeService.java
@@ -59,6 +59,8 @@ public class NoticeService {
 
     @Transactional
     public void updateNotice(String adminUsername, UUID noticeId, NoticeUpdateRequestDto requestDto) {
+        loadActiveAdmin(adminUsername);
+
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.NOTICE_NOT_FOUND));
 
@@ -75,6 +77,8 @@ public class NoticeService {
 
     @Transactional
     public void deleteNotice(String adminUsername, UUID noticeId) {
+        loadActiveAdmin(adminUsername);
+
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.NOTICE_NOT_FOUND));
 
@@ -87,6 +91,10 @@ public class NoticeService {
                 .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
     }
 
+    /**
+     * 활성 관리자 조회 및 권한 검증
+     * 관리자가 아닌 경우 예외를 발생시킵니다.
+     */
     private User loadActiveAdmin(String username) {
         User user = loadActiveUser(username);
         if (!user.isAdmin()) {

--- a/backend/src/main/java/com/phonebid/app/customerservice/service/NoticeService.java
+++ b/backend/src/main/java/com/phonebid/app/customerservice/service/NoticeService.java
@@ -1,0 +1,98 @@
+package com.phonebid.app.customerservice.service;
+
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.customerservice.domain.Notice;
+import com.phonebid.app.customerservice.dto.request.NoticeCreateRequestDto;
+import com.phonebid.app.customerservice.dto.request.NoticeUpdateRequestDto;
+import com.phonebid.app.customerservice.dto.response.NoticeDetailResponseDto;
+import com.phonebid.app.customerservice.dto.response.NoticeResponseDto;
+import com.phonebid.app.customerservice.errorcode.CustomerServiceErrorCode;
+import com.phonebid.app.customerservice.repository.NoticeRepository;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public Page<NoticeResponseDto> getAllNotices(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Notice> notices = noticeRepository.findAllOrdered(pageable);
+        return notices.map(NoticeResponseDto::from);
+    }
+
+    @Transactional
+    public NoticeDetailResponseDto getNoticeDetail(UUID noticeId) {
+        Notice notice = noticeRepository.findByIdForView(noticeId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.NOTICE_NOT_FOUND));
+
+        notice.incrementViewCount();
+        return NoticeDetailResponseDto.from(notice);
+    }
+
+    @Transactional
+    public void createNotice(String adminUsername, NoticeCreateRequestDto requestDto) {
+        User admin = loadActiveAdmin(adminUsername);
+
+        Notice notice = Notice.builder()
+                .admin(admin)
+                .title(requestDto.getTitle().trim())
+                .content(requestDto.getContent().trim())
+                .isImportant(requestDto.getIsImportant())
+                .build();
+
+        noticeRepository.save(notice);
+    }
+
+    @Transactional
+    public void updateNotice(String adminUsername, UUID noticeId, NoticeUpdateRequestDto requestDto) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.NOTICE_NOT_FOUND));
+
+        if (requestDto.getTitle() != null && !requestDto.getTitle().trim().isEmpty()) {
+            notice.updateTitle(requestDto.getTitle().trim());
+        }
+        if (requestDto.getContent() != null && !requestDto.getContent().trim().isEmpty()) {
+            notice.updateContent(requestDto.getContent().trim());
+        }
+        if (requestDto.getIsImportant() != null) {
+            notice.updateIsImportant(requestDto.getIsImportant());
+        }
+    }
+
+    @Transactional
+    public void deleteNotice(String adminUsername, UUID noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new CustomException(CustomerServiceErrorCode.NOTICE_NOT_FOUND));
+
+        notice.softDelete(adminUsername);
+    }
+
+    private User loadActiveUser(String username) {
+        return userRepository.findByUsername(username)
+                .filter(user -> !user.isDeleted())
+                .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+    }
+
+    private User loadActiveAdmin(String username) {
+        User user = loadActiveUser(username);
+        if (!user.isAdmin()) {
+            throw new CustomException(CustomerServiceErrorCode.ONLY_ADMIN_ALLOWED);
+        }
+        return user;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/member/controller/UserController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/UserController.java
@@ -11,15 +11,12 @@ import com.phonebid.app.common.dto.ApiResponse;
 import com.phonebid.app.jwt.JwtUtil;
 import com.phonebid.app.member.dto.request.SignupRequestDto;
 import com.phonebid.app.member.dto.request.LoginRequestDto;
-import com.phonebid.app.member.dto.request.ProfileUpdateRequestDto;
 import com.phonebid.app.member.dto.request.PasswordChangeRequestDto;
 import com.phonebid.app.member.dto.response.LoginResponseDto;
-import com.phonebid.app.member.dto.response.ProfileResponseDto;
 import com.phonebid.app.member.service.UserService;
 
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.security.core.Authentication;
@@ -69,24 +66,6 @@ public class UserController {
         return ResponseEntity.ok()
                 .header("Set-Cookie", cookie.toString())
                 .body(ApiResponse.success(HttpStatus.OK, "로그인이 성공적으로 완료되었습니다.", responseDto));
-    }
-
-    @GetMapping("/profile")
-    public ResponseEntity<ApiResponse<ProfileResponseDto>> getProfile() {
-        String username = getCurrentUsername();
-        ProfileResponseDto responseDto = userService.getProfile(username);
-        
-        return ResponseEntity.ok()
-                .body(ApiResponse.success(HttpStatus.OK, "내 정보 조회가 성공적으로 완료되었습니다.", responseDto));
-    }
-
-    @PutMapping("/profile")
-    public ResponseEntity<ApiResponse<Void>> updateProfile(@Valid @RequestBody ProfileUpdateRequestDto requestDto) {
-        String username = getCurrentUsername();
-        userService.updateProfile(username, requestDto);
-        
-        return ResponseEntity.ok()
-                .body(ApiResponse.success(HttpStatus.OK, "내 정보 수정이 성공적으로 완료되었습니다.", null));
     }
 
     @DeleteMapping("/profile")

--- a/backend/src/main/java/com/phonebid/app/member/service/UserService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/UserService.java
@@ -7,10 +7,8 @@ import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.member.dto.request.SignupRequestDto;
 import com.phonebid.app.member.dto.request.LoginRequestDto;
-import com.phonebid.app.member.dto.request.ProfileUpdateRequestDto;
 import com.phonebid.app.member.dto.request.PasswordChangeRequestDto;
 import com.phonebid.app.member.dto.response.LoginResponseDto;
-import com.phonebid.app.member.dto.response.ProfileResponseDto;
 import com.phonebid.app.member.domain.User;
 import com.phonebid.app.member.domain.Role;
 import com.phonebid.app.member.repository.UserRepository;
@@ -99,34 +97,6 @@ public class UserService {
             user.getNickname(), 
             user.getRole().name()
         );
-    }
-
-    /**
-     * 내 정보 조회
-     */
-    @Transactional(readOnly = true)
-    public ProfileResponseDto getProfile(String username) {
-        User user = loadActiveUser(username);
-        
-        return ProfileResponseDto.from(user);
-    }
-
-    /**
-     * 내 정보 수정 (닉네임만 수정 가능)
-     */
-    @Transactional
-    public void updateProfile(String username, ProfileUpdateRequestDto requestDto) {
-        User user = loadActiveUser(username);
-
-        String newNickname = requestDto.getNickname();
-        
-        // 닉네임 중복 확인 (자신의 기존 닉네임은 제외)
-        Optional<User> checkNickname = userRepository.findByNickname(newNickname);
-        if (checkNickname.isPresent() && !checkNickname.get().getId().equals(user.getId())) {
-            throw new CustomException(CommonErrorCode.DUPLICATE_NICKNAME);
-        }
-
-        user.updateNickname(newNickname);
     }
 
     /**

--- a/backend/src/main/java/com/phonebid/app/mypage/controller/MyPageController.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/controller/MyPageController.java
@@ -1,0 +1,52 @@
+package com.phonebid.app.mypage.controller;
+
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.mypage.dto.request.ProfileUpdateRequestDto;
+import com.phonebid.app.mypage.dto.response.ProfileResponseDto;
+import com.phonebid.app.mypage.service.MyPageService;
+import com.phonebid.app.security.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    /**
+     * 프로필 조회
+     * 로그인한 사용자의 프로필 정보(아이디, 닉네임, 휴대폰 번호, 이름)를 조회합니다.
+     */
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<ProfileResponseDto>> getProfile(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        
+        ProfileResponseDto responseDto = myPageService.getProfile(userDetails.getUsername());
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "프로필 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    /**
+     * 프로필 수정
+     * 로그인한 사용자의 프로필 정보(이름, 닉네임, 휴대폰 번호)를 수정합니다.
+     * 각 필드는 선택적으로 수정 가능하며, 닉네임 중복 검증을 수행합니다.
+     */
+    @PutMapping("/profile")
+    public ResponseEntity<ApiResponse<Void>> updateProfile(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody ProfileUpdateRequestDto requestDto) {
+        
+        myPageService.updateProfile(userDetails.getUsername(), requestDto);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "프로필 수정이 성공적으로 완료되었습니다.", null));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/controller/MyPageController.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/controller/MyPageController.java
@@ -3,14 +3,19 @@ package com.phonebid.app.mypage.controller;
 import com.phonebid.app.common.dto.ApiResponse;
 import com.phonebid.app.mypage.dto.request.ProfileUpdateRequestDto;
 import com.phonebid.app.mypage.dto.response.ProfileResponseDto;
+import com.phonebid.app.mypage.dto.response.PurchaseDetailResponseDto;
+import com.phonebid.app.mypage.dto.response.PurchaseHistoryResponseDto;
 import com.phonebid.app.mypage.service.MyPageService;
 import com.phonebid.app.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,8 +29,7 @@ public class MyPageController {
      * 로그인한 사용자의 프로필 정보(아이디, 닉네임, 휴대폰 번호, 이름)를 조회합니다.
      */
     @GetMapping("/profile")
-    public ResponseEntity<ApiResponse<ProfileResponseDto>> getProfile(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<ProfileResponseDto>> getProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         
         ProfileResponseDto responseDto = myPageService.getProfile(userDetails.getUsername());
         
@@ -39,14 +43,43 @@ public class MyPageController {
      * 각 필드는 선택적으로 수정 가능하며, 닉네임 중복 검증을 수행합니다.
      */
     @PutMapping("/profile")
-    public ResponseEntity<ApiResponse<Void>> updateProfile(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Valid @RequestBody ProfileUpdateRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<Void>> updateProfile(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                           @Valid @RequestBody ProfileUpdateRequestDto requestDto) {
         
         myPageService.updateProfile(userDetails.getUsername(), requestDto);
         
         return ResponseEntity.ok()
                 .body(ApiResponse.success(HttpStatus.OK, "프로필 수정이 성공적으로 완료되었습니다.", null));
+    }
+
+    /**
+     * 구매내역 목록 조회
+     * 구매완료 또는 취소/환불 상태의 구매내역을 페이징하여 조회합니다.
+     */
+    @GetMapping("/purchases")
+    public ResponseEntity<ApiResponse<Page<PurchaseHistoryResponseDto>>> getPurchaseHistory(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(defaultValue = "COMPLETED") String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        
+        Page<PurchaseHistoryResponseDto> responseDto = myPageService.getPurchaseHistory(userDetails.getUsername(), status, page, size);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "구매내역 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    /**
+     * 구매내역 상세 조회
+     * 특정 계약의 상세 정보를 조회합니다.
+     */
+    @GetMapping("/purchases/{contractId}")
+    public ResponseEntity<ApiResponse<PurchaseDetailResponseDto>> getPurchaseDetail(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                    @PathVariable UUID contractId) {
+        PurchaseDetailResponseDto responseDto = myPageService.getPurchaseDetail(userDetails.getUsername(), contractId);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "구매내역 상세 조회가 성공적으로 완료되었습니다.", responseDto));
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/mypage/controller/MyPageController.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/controller/MyPageController.java
@@ -1,7 +1,9 @@
 package com.phonebid.app.mypage.controller;
 
 import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.mypage.dto.request.AccountCreateRequestDto;
 import com.phonebid.app.mypage.dto.request.ProfileUpdateRequestDto;
+import com.phonebid.app.mypage.dto.response.AccountResponseDto;
 import com.phonebid.app.mypage.dto.response.ProfileResponseDto;
 import com.phonebid.app.mypage.dto.response.PurchaseDetailResponseDto;
 import com.phonebid.app.mypage.dto.response.PurchaseHistoryResponseDto;
@@ -80,6 +82,51 @@ public class MyPageController {
         
         return ResponseEntity.ok()
                 .body(ApiResponse.success(HttpStatus.OK, "구매내역 상세 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    /**
+     * 계좌 등록
+     * 사용자의 계좌 정보를 등록합니다. 동일한 은행과 계좌번호 조합은 중복 등록할 수 없습니다.
+     */
+    @PostMapping("/accounts")
+    public ResponseEntity<ApiResponse<Void>> createAccount(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                           @Valid @RequestBody AccountCreateRequestDto requestDto) {
+        
+        myPageService.createAccount(userDetails.getUsername(), requestDto);
+        
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, "계좌 등록이 성공적으로 완료되었습니다.", null));
+    }
+
+    /**
+     * 계좌 목록 조회
+     * 사용자의 등록된 계좌 목록을 페이징하여 조회합니다. 등록일 기준 내림차순으로 정렬하여 반환합니다.
+     */
+    @GetMapping("/accounts")
+    public ResponseEntity<ApiResponse<Page<AccountResponseDto>>> getAccounts(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        
+        Page<AccountResponseDto> responseDto = myPageService.getAccounts(
+            userDetails.getUsername(), page, size);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "계좌 목록 조회가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    /**
+     * 계좌 삭제
+     * 사용자의 계좌를 삭제합니다. 본인의 계좌만 삭제할 수 있습니다.
+     */
+    @DeleteMapping("/accounts/{accountId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAccount(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                           @PathVariable UUID accountId) {
+        
+        myPageService.deleteAccount(userDetails.getUsername(), accountId);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "계좌 삭제가 성공적으로 완료되었습니다.", null));
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/mypage/domain/Account.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/domain/Account.java
@@ -1,0 +1,82 @@
+package com.phonebid.app.mypage.domain;
+
+import com.phonebid.app.common.domain.BaseEntity;
+import com.phonebid.app.member.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "accounts", indexes = {
+    @Index(name = "idx_accounts_user_id", columnList = "user_id"),
+    @Index(name = "idx_accounts_bank", columnList = "bank")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Account extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    @Comment("계좌 고유 ID (UUID)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("계좌 소유자")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "bank", nullable = false)
+    @Comment("은행명")
+    private Bank bank;
+
+    @Column(name = "account_number", nullable = false)
+    @Comment("계좌번호")
+    private String accountNumber;
+
+    @Column(name = "account_holder_name", nullable = false)
+    @Comment("예금주명")
+    private String accountHolderName;
+
+    @Builder
+    public Account(User user, Bank bank, String accountNumber, String accountHolderName) {
+        this.user = user;
+        this.bank = bank;
+        this.accountNumber = accountNumber;
+        this.accountHolderName = accountHolderName;
+    }
+
+    public void updateAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+    }
+
+    public void updateAccountHolderName(String accountHolderName) {
+        this.accountHolderName = accountHolderName;
+    }
+
+    public String getMaskedAccountNumber() {
+        if (accountNumber == null || accountNumber.length() < 4) {
+            return accountNumber;
+        }
+        int length = accountNumber.length();
+        return accountNumber.substring(0, 4) + "-****-" + accountNumber.substring(length - 4);
+    }
+
+    public void softDelete(String deletedBy) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+        this.isDelete = true;
+    }
+
+    public boolean isDeleted() {
+        return Boolean.TRUE.equals(this.isDelete);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/domain/Bank.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/domain/Bank.java
@@ -1,0 +1,48 @@
+package com.phonebid.app.mypage.domain;
+
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Bank {
+    KB("KB국민은행", "KB"),
+    SHINHAN("신한은행", "SHINHAN"),
+    HANA("하나은행", "HANA"),
+    WOORI("우리은행", "WOORI"),
+    NH("NH농협은행", "NH"),
+    IBK("IBK기업은행", "IBK"),
+    KAKAO("카카오뱅크", "KAKAO"),
+    TOSS("토스뱅크", "TOSS"),
+    KEB("KEB하나은행", "KEB"),
+    SC("SC제일은행", "SC"),
+    CITI("한국씨티은행", "CITI"),
+    KDB("KDB산업은행", "KDB"),
+    SAVINGS("저축은행", "SAVINGS"),
+    POST("우체국", "POST"),
+    SUHYUP("수협은행", "SUHYUP");
+
+    private final String displayName;
+    private final String code;
+
+    public static Bank fromDisplayName(String displayName) {
+        for (Bank bank : values()) {
+            if (bank.displayName.equals(displayName)) {
+                return bank;
+            }
+        }
+        throw new CustomException(CommonErrorCode.INVALID_BANK_NAME);
+    }
+
+    public static Bank fromCode(String code) {
+        for (Bank bank : values()) {
+            if (bank.code.equals(code)) {
+                return bank;
+            }
+        }
+        throw new CustomException(CommonErrorCode.INVALID_BANK_CODE);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/dto/request/AccountCreateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/dto/request/AccountCreateRequestDto.java
@@ -1,0 +1,31 @@
+package com.phonebid.app.mypage.dto.request;
+
+import com.phonebid.app.mypage.domain.Bank;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccountCreateRequestDto {
+
+    @NotBlank(message = "은행명을 입력해주세요.")
+    private String bankName;
+
+    @NotBlank(message = "계좌번호를 입력해주세요.")
+    @Pattern(regexp = "^[0-9-]+$", message = "계좌번호는 숫자와 하이픈(-)만 입력 가능합니다.")
+    @Size(min = 10, max = 20, message = "계좌번호는 10자 이상 20자 이하여야 합니다.")
+    private String accountNumber;
+
+    @NotBlank(message = "예금주명을 입력해주세요.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]+$", message = "예금주명은 한글, 영문, 숫자, 공백만 입력 가능합니다.")
+    @Size(min = 2, max = 50, message = "예금주명은 2자 이상 50자 이하여야 합니다.")
+    private String accountHolderName;
+
+    public Bank getBank() {
+        return Bank.fromDisplayName(bankName);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/dto/request/ProfileUpdateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/dto/request/ProfileUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package com.phonebid.app.mypage.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProfileUpdateRequestDto {
+
+    @Size(min = 1, max = 50, message = "이름은 1자 이상 50자 이하여야 합니다")
+    private String name;
+
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9_-]+$", message = "닉네임은 한글, 영문, 숫자, _, -만 사용 가능합니다")
+    private String nickname;
+
+    @Pattern(regexp = "^[0-9]+$", message = "휴대전화번호는 숫자만 입력 가능합니다")
+    @Size(min = 10, max = 11, message = "휴대전화번호는 10자리 또는 11자리여야 합니다")
+    private String phone;
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/dto/response/AccountResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/dto/response/AccountResponseDto.java
@@ -1,0 +1,30 @@
+package com.phonebid.app.mypage.dto.response;
+
+import com.phonebid.app.mypage.domain.Account;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class AccountResponseDto {
+
+    private UUID accountId;
+    private String bankName;
+    private String accountNumber;
+    private String accountHolderName;
+    private LocalDateTime createdAt;
+
+    public static AccountResponseDto from(Account account) {
+        AccountResponseDto dto = new AccountResponseDto();
+        dto.accountId = account.getId();
+        dto.bankName = account.getBank().getDisplayName();
+        dto.accountNumber = account.getAccountNumber();
+        dto.accountHolderName = account.getAccountHolderName();
+        dto.createdAt = account.getCreatedAt();
+        return dto;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/dto/response/ProfileResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/dto/response/ProfileResponseDto.java
@@ -1,0 +1,25 @@
+package com.phonebid.app.mypage.dto.response;
+
+import com.phonebid.app.member.domain.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProfileResponseDto {
+
+    private String username;
+    private String nickname;
+    private String phone;
+    private String name;
+
+    public static ProfileResponseDto from(User user) {
+        ProfileResponseDto dto = new ProfileResponseDto();
+        dto.username = user.getUsername();
+        dto.nickname = user.getNickname();
+        dto.phone = user.getPhone();
+        dto.name = user.getName();
+        return dto;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/dto/response/PurchaseDetailResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/dto/response/PurchaseDetailResponseDto.java
@@ -1,0 +1,110 @@
+package com.phonebid.app.mypage.dto.response;
+
+import com.phonebid.app.trade.domain.Contract;
+import com.phonebid.app.trade.domain.Delivery;
+import com.phonebid.app.trade.domain.Payment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class PurchaseDetailResponseDto {
+
+    private UUID contractId;
+    private String productName;
+    private LocalDateTime transactionDate;
+    private String productImageUrl;
+    private PurchaseHistoryResponseDto.ProductInfoDto productInfo;
+    private Integer price;
+    private String status;
+    private SellerInfoDto sellerInfo;
+    private PaymentInfoDto paymentInfo;
+    private DeliveryInfoDto deliveryInfo;
+    private Boolean canReview;
+
+    public static PurchaseDetailResponseDto from(Contract contract, Payment payment, Delivery delivery) {
+        PurchaseDetailResponseDto dto = new PurchaseDetailResponseDto();
+        
+        dto.contractId = contract.getId();
+        dto.productName = contract.getQuote().getPhoneModel().getFullModelName();
+        dto.transactionDate = contract.getSignedAt() != null 
+            ? contract.getSignedAt() 
+            : (payment != null && payment.getPaidAt() != null ? payment.getPaidAt() : contract.getCreatedAt());
+        dto.productImageUrl = null; // 추후 이미지 URL 추가 예정
+        dto.productInfo = PurchaseHistoryResponseDto.ProductInfoDto.from(contract);
+        dto.price = contract.getContractAmount();
+        dto.status = determineStatus(contract, payment);
+        dto.sellerInfo = SellerInfoDto.from(contract);
+        dto.paymentInfo = payment != null ? PaymentInfoDto.from(payment) : null;
+        dto.deliveryInfo = delivery != null ? DeliveryInfoDto.from(delivery) : null;
+        dto.canReview = canReview(contract, payment);
+        
+        return dto;
+    }
+
+    private static String determineStatus(Contract contract, Payment payment) {
+        if (contract.getStatus().isCancelled()) {
+            return "취소/환불";
+        }
+        if (payment != null && payment.getStatus().isPaid()) {
+            return "거래완료";
+        }
+        return "진행중";
+    }
+
+    private static Boolean canReview(Contract contract, Payment payment) {
+        return contract.getStatus().isSigned() 
+            && payment != null 
+            && payment.getStatus().isPaid();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SellerInfoDto {
+        private String sellerName;
+        private Double rating;
+
+        public static SellerInfoDto from(Contract contract) {
+            SellerInfoDto dto = new SellerInfoDto();
+            var seller = contract.getSelectedBid().getSeller();
+            
+            dto.sellerName = seller.getStoreName();
+            // TODO: Seller 엔티티에 rating 필드 추가 후 사용
+            dto.rating = contract.getSelectedBid().getRatingSnapshot();
+            
+            return dto;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class PaymentInfoDto {
+        private String method;
+        private LocalDateTime paidAt;
+
+        public static PaymentInfoDto from(Payment payment) {
+            PaymentInfoDto dto = new PaymentInfoDto();
+            dto.method = payment.getMethod().getDisplayName();
+            dto.paidAt = payment.getPaidAt();
+            return dto;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class DeliveryInfoDto {
+        private String status;
+        private String trackingNumber;
+
+        public static DeliveryInfoDto from(Delivery delivery) {
+            DeliveryInfoDto dto = new DeliveryInfoDto();
+            dto.status = delivery.getStatus().getDisplayName();
+            dto.trackingNumber = delivery.getInvoiceNumber();
+            return dto;
+        }
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/dto/response/PurchaseHistoryResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/dto/response/PurchaseHistoryResponseDto.java
@@ -1,0 +1,83 @@
+package com.phonebid.app.mypage.dto.response;
+
+import com.phonebid.app.trade.domain.Contract;
+import com.phonebid.app.trade.domain.Payment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class PurchaseHistoryResponseDto {
+
+    private UUID contractId;
+    private String productName;
+    private LocalDateTime transactionDate;
+    private String productImageUrl;
+    private ProductInfoDto productInfo;
+    private Integer price;
+    private String status;
+    private Boolean canReview;
+
+    public static PurchaseHistoryResponseDto from(Contract contract, Payment payment) {
+        PurchaseHistoryResponseDto dto = new PurchaseHistoryResponseDto();
+        
+        dto.contractId = contract.getId();
+        dto.productName = contract.getQuote().getPhoneModel().getFullModelName();
+        dto.transactionDate = contract.getSignedAt() != null 
+            ? contract.getSignedAt() 
+            : (payment != null && payment.getPaidAt() != null ? payment.getPaidAt() : contract.getCreatedAt());
+        dto.productImageUrl = null; // 추후 이미지 URL 추가 예정
+        dto.productInfo = ProductInfoDto.from(contract);
+        dto.price = contract.getContractAmount();
+        dto.status = determineStatus(contract, payment);
+        dto.canReview = canReview(contract, payment);
+        
+        return dto;
+    }
+
+    private static String determineStatus(Contract contract, Payment payment) {
+        if (contract.getStatus().isCancelled()) {
+            return "취소/환불";
+        }
+        if (payment != null && payment.getStatus().isPaid()) {
+            return "거래완료";
+        }
+        return "진행중";
+    }
+
+    private static Boolean canReview(Contract contract, Payment payment) {
+        // 구매완료 상태이고 결제가 완료된 경우에만 후기 작성 가능
+        // TODO: 리뷰 엔티티 확인 후 실제 리뷰 존재 여부 체크
+        return contract.getStatus().isSigned() 
+            && payment != null 
+            && payment.getStatus().isPaid();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ProductInfoDto {
+        private String brand;
+        private String model;
+        private String storage;
+        private String color;
+        private String carrier;
+
+        public static ProductInfoDto from(Contract contract) {
+            ProductInfoDto dto = new ProductInfoDto();
+            var phoneModel = contract.getQuote().getPhoneModel();
+            var quote = contract.getQuote();
+            
+            dto.brand = phoneModel.getBrand().getDisplayName();
+            dto.model = phoneModel.getModel();
+            dto.storage = quote.getStorage() != null ? quote.getStorage().getDisplayLabel() : null;
+            dto.color = quote.getColor() != null ? quote.getColor().getDisplayLabel() : null;
+            dto.carrier = quote.getCarrier().getDisplayName();
+            
+            return dto;
+        }
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/repository/AccountRepository.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/repository/AccountRepository.java
@@ -1,0 +1,57 @@
+package com.phonebid.app.mypage.repository;
+
+import com.phonebid.app.mypage.domain.Account;
+import com.phonebid.app.mypage.domain.Bank;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AccountRepository extends JpaRepository<Account, UUID> {
+
+    /**
+     * 사용자명으로 계좌 목록을 페이징 조회
+     * 등록일 기준 내림차순으로 정렬하여 반환
+     */
+    @Query(value = "SELECT a FROM Account a " +
+           "JOIN FETCH a.user u " +
+           "WHERE u.username = :username " +
+           "AND (a.isDelete = false OR a.isDelete IS NULL) " +
+           "ORDER BY a.createdAt DESC",
+           countQuery = "SELECT COUNT(a) FROM Account a " +
+           "JOIN a.user u " +
+           "WHERE u.username = :username " +
+           "AND (a.isDelete = false OR a.isDelete IS NULL)")
+    Page<Account> findByUsername(@Param("username") String username, Pageable pageable);
+
+    /**
+     * 계좌 ID와 사용자명으로 특정 계좌를 조회
+     * 본인의 계좌만 조회할 수 있도록 사용자명으로 필터링
+     */
+    @Query("SELECT a FROM Account a " +
+           "JOIN FETCH a.user u " +
+           "WHERE a.id = :accountId " +
+           "AND u.username = :username " +
+           "AND (a.isDelete = false OR a.isDelete IS NULL)")
+    Optional<Account> findByIdAndUsername(@Param("accountId") UUID accountId, @Param("username") String username);
+
+    /**
+     * 사용자명, 계좌번호, 은행으로 계좌 중복 여부 확인
+     * 동일 사용자의 동일 은행, 동일 계좌번호 조합이 이미 존재하는지 확인
+     */
+    @Query("SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END FROM Account a " +
+           "JOIN a.user u " +
+           "WHERE u.username = :username " +
+           "AND a.accountNumber = :accountNumber " +
+           "AND a.bank = :bank " +
+           "AND (a.isDelete = false OR a.isDelete IS NULL)")
+    boolean existsByUsernameAndAccountNumberAndBank(
+            @Param("username") String username,
+            @Param("accountNumber") String accountNumber,
+            @Param("bank") Bank bank);
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
@@ -4,10 +4,15 @@ import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.member.domain.User;
 import com.phonebid.app.member.repository.UserRepository;
+import com.phonebid.app.mypage.domain.Account;
+import com.phonebid.app.mypage.domain.Bank;
+import com.phonebid.app.mypage.dto.request.AccountCreateRequestDto;
 import com.phonebid.app.mypage.dto.request.ProfileUpdateRequestDto;
+import com.phonebid.app.mypage.dto.response.AccountResponseDto;
 import com.phonebid.app.mypage.dto.response.ProfileResponseDto;
 import com.phonebid.app.mypage.dto.response.PurchaseDetailResponseDto;
 import com.phonebid.app.mypage.dto.response.PurchaseHistoryResponseDto;
+import com.phonebid.app.mypage.repository.AccountRepository;
 import com.phonebid.app.trade.domain.Contract;
 import com.phonebid.app.trade.domain.ContractStatus;
 import com.phonebid.app.trade.domain.Delivery;
@@ -33,6 +38,7 @@ public class MyPageService {
     private final ContractRepository contractRepository;
     private final PaymentRepository paymentRepository;
     private final DeliveryRepository deliveryRepository;
+    private final AccountRepository accountRepository;
 
     /**
      * 프로필 조회
@@ -111,6 +117,59 @@ public class MyPageService {
             payment.orElse(null), 
             delivery.orElse(null)
         );
+    }
+
+    /**
+     * 계좌 등록
+     * 사용자의 계좌 정보를 등록합니다. 동일한 은행과 계좌번호 조합은 중복 등록할 수 없습니다.
+     */
+    @Transactional
+    public void createAccount(String username, AccountCreateRequestDto requestDto) {
+        User user = loadActiveUser(username);
+        
+        Bank bank = requestDto.getBank();
+        String accountNumber = requestDto.getAccountNumber().trim();
+        String accountHolderName = requestDto.getAccountHolderName().trim();
+        
+        // 동일 사용자의 동일 은행, 동일 계좌번호 중복 확인
+        boolean exists = accountRepository.existsByUsernameAndAccountNumberAndBank(
+            username, accountNumber, bank);
+        if (exists) {
+            throw new CustomException(CommonErrorCode.DUPLICATE_ACCOUNT);
+        }
+        
+        Account account = Account.builder()
+            .user(user)
+            .bank(bank)
+            .accountNumber(accountNumber)
+            .accountHolderName(accountHolderName)
+            .build();
+        
+        accountRepository.save(account);
+    }
+
+    /**
+     * 계좌 목록 조회
+     * 사용자의 등록된 계좌 목록을 페이징하여 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public Page<AccountResponseDto> getAccounts(String username, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Account> accounts = accountRepository.findByUsername(username, pageable);
+        
+        return accounts.map(AccountResponseDto::from);
+    }
+
+    /**
+     * 계좌 삭제
+     * 사용자의 계좌를 소프트 삭제합니다. 본인의 계좌만 삭제할 수 있습니다.
+     */
+    @Transactional
+    public void deleteAccount(String username, UUID accountId) {
+        Account account = accountRepository.findByIdAndUsername(accountId, username)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        
+        account.softDelete(username);
     }
 
     /**

--- a/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
@@ -1,0 +1,72 @@
+package com.phonebid.app.mypage.service;
+
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.repository.UserRepository;
+import com.phonebid.app.mypage.dto.request.ProfileUpdateRequestDto;
+import com.phonebid.app.mypage.dto.response.ProfileResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 프로필 조회
+     * 활성 사용자의 프로필 정보를 조회하여 DTO로 변환하여 반환합니다.
+     */
+    @Transactional(readOnly = true)
+    public ProfileResponseDto getProfile(String username) {
+        User user = loadActiveUser(username);
+        return ProfileResponseDto.from(user);
+    }
+
+    /**
+     * 프로필 수정
+     * 사용자의 이름, 닉네임, 휴대폰 번호를 선택적으로 수정합니다.
+     * 닉네임의 경우 중복 검증을 수행하며, 자신의 기존 닉네임은 제외합니다.
+     */
+    @Transactional
+    public void updateProfile(String username, ProfileUpdateRequestDto requestDto) {
+        User user = loadActiveUser(username);
+
+        String newName = requestDto.getName();
+        String newNickname = requestDto.getNickname();
+        String newPhone = requestDto.getPhone();
+
+        if (newName != null && !newName.trim().isEmpty()) {
+            user.updateName(newName.trim());
+        }
+
+        if (newNickname != null && !newNickname.trim().isEmpty()) {
+            String trimmedNickname = newNickname.trim();
+            Optional<User> checkNickname = userRepository.findByNickname(trimmedNickname);
+            if (checkNickname.isPresent() && !checkNickname.get().getId().equals(user.getId())) {
+                throw new CustomException(CommonErrorCode.DUPLICATE_NICKNAME);
+            }
+            user.updateNickname(trimmedNickname);
+        }
+
+        if (newPhone != null && !newPhone.trim().isEmpty()) {
+            user.updatePhone(newPhone.trim());
+        }
+    }
+
+    /**
+     * 활성 사용자 조회
+     * 삭제되지 않은 활성 사용자만 조회하며, 사용자가 없거나 삭제된 경우 예외를 발생시킵니다.
+     */
+    private User loadActiveUser(String username) {
+        return userRepository.findByUsername(username)
+            .filter(user -> !user.isDeleted())
+            .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
@@ -6,17 +6,33 @@ import com.phonebid.app.member.domain.User;
 import com.phonebid.app.member.repository.UserRepository;
 import com.phonebid.app.mypage.dto.request.ProfileUpdateRequestDto;
 import com.phonebid.app.mypage.dto.response.ProfileResponseDto;
+import com.phonebid.app.mypage.dto.response.PurchaseDetailResponseDto;
+import com.phonebid.app.mypage.dto.response.PurchaseHistoryResponseDto;
+import com.phonebid.app.trade.domain.Contract;
+import com.phonebid.app.trade.domain.ContractStatus;
+import com.phonebid.app.trade.domain.Delivery;
+import com.phonebid.app.trade.domain.Payment;
+import com.phonebid.app.trade.repository.ContractRepository;
+import com.phonebid.app.trade.repository.DeliveryRepository;
+import com.phonebid.app.trade.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
 
     private final UserRepository userRepository;
+    private final ContractRepository contractRepository;
+    private final PaymentRepository paymentRepository;
+    private final DeliveryRepository deliveryRepository;
 
     /**
      * 프로필 조회
@@ -57,6 +73,44 @@ public class MyPageService {
         if (newPhone != null && !newPhone.trim().isEmpty()) {
             user.updatePhone(newPhone.trim());
         }
+    }
+
+    /**
+     * 구매내역 목록 조회
+     * 구매완료 또는 취소/환불 상태의 구매내역을 페이징하여 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public Page<PurchaseHistoryResponseDto> getPurchaseHistory(String username, String status, int page, int size) {
+        ContractStatus contractStatus = "CANCELLED".equals(status) 
+            ? ContractStatus.CANCELLED 
+            : ContractStatus.SIGNED;
+        
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Contract> contracts = contractRepository.findByUsernameAndStatus(username, contractStatus, pageable);
+        
+        return contracts.map(contract -> {
+            Optional<Payment> payment = paymentRepository.findByContractId(contract.getId());
+            return PurchaseHistoryResponseDto.from(contract, payment.orElse(null));
+        });
+    }
+
+    /**
+     * 구매내역 상세 조회
+     * 특정 계약의 상세 정보를 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public PurchaseDetailResponseDto getPurchaseDetail(String username, UUID contractId) {
+        Contract contract = contractRepository.findByIdAndUsername(contractId, username)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        
+        Optional<Payment> payment = paymentRepository.findByContractId(contractId);
+        Optional<Delivery> delivery = deliveryRepository.findByContractId(contractId);
+        
+        return PurchaseDetailResponseDto.from(
+            contract, 
+            payment.orElse(null), 
+            delivery.orElse(null)
+        );
     }
 
     /**

--- a/backend/src/main/java/com/phonebid/app/trade/repository/ContractRepository.java
+++ b/backend/src/main/java/com/phonebid/app/trade/repository/ContractRepository.java
@@ -52,18 +52,24 @@ public interface ContractRepository extends JpaRepository<Contract, UUID> {
     Optional<Contract> findByIdAndUsername(@Param("contractId") UUID contractId, @Param("username") String username);
 
     /**
-     * 사용자명으로 구매완료 또는 취소 상태의 모든 계약을 조회
+     * 사용자명과 상태 목록으로 계약 목록을 페이징 조회
      * 구매완료와 취소를 함께 조회할 때 사용됨
      */
-    @Query("SELECT c FROM Contract c " +
+    @Query(value = "SELECT c FROM Contract c " +
            "JOIN FETCH c.quote q " +
            "JOIN FETCH q.user u " +
            "JOIN FETCH c.selectedBid b " +
            "JOIN FETCH q.phoneModel pm " +
            "WHERE u.username = :username " +
-           "AND (c.status = 'SIGNED' OR c.status = 'CANCELLED') " +
+           "AND c.status IN :statuses " +
            "AND (c.isDelete = false OR c.isDelete IS NULL) " +
-           "ORDER BY c.signedAt DESC")
-    List<Contract> findAllByUsername(@Param("username") String username, Pageable pageable);
+           "ORDER BY c.signedAt DESC",
+           countQuery = "SELECT COUNT(c) FROM Contract c " +
+           "JOIN c.quote q " +
+           "JOIN q.user u " +
+           "WHERE u.username = :username " +
+           "AND c.status IN :statuses " +
+           "AND (c.isDelete = false OR c.isDelete IS NULL)")
+    Page<Contract> findAllByUsername(@Param("username") String username, @Param("statuses") List<ContractStatus> statuses, Pageable pageable);
 }
 

--- a/backend/src/main/java/com/phonebid/app/trade/repository/ContractRepository.java
+++ b/backend/src/main/java/com/phonebid/app/trade/repository/ContractRepository.java
@@ -1,0 +1,69 @@
+package com.phonebid.app.trade.repository;
+
+import com.phonebid.app.trade.domain.Contract;
+import com.phonebid.app.trade.domain.ContractStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ContractRepository extends JpaRepository<Contract, UUID> {
+
+    /**
+     * 사용자명과 계약 상태로 계약 목록을 페이징 조회
+     * 구매완료(SIGNED) 또는 취소(CANCELLED) 상태의 계약을 조회할 때 사용됨
+     */
+    @Query(value = "SELECT c FROM Contract c " +
+           "JOIN FETCH c.quote q " +
+           "JOIN FETCH q.user u " +
+           "JOIN FETCH c.selectedBid b " +
+           "JOIN FETCH q.phoneModel pm " +
+           "WHERE u.username = :username " +
+           "AND c.status = :status " +
+           "AND (c.isDelete = false OR c.isDelete IS NULL) " +
+           "ORDER BY c.signedAt DESC",
+           countQuery = "SELECT COUNT(c) FROM Contract c " +
+           "JOIN c.quote q " +
+           "JOIN q.user u " +
+           "WHERE u.username = :username " +
+           "AND c.status = :status " +
+           "AND (c.isDelete = false OR c.isDelete IS NULL)")
+    Page<Contract> findByUsernameAndStatus(@Param("username") String username, @Param("status") ContractStatus status, Pageable pageable);
+
+    /**
+     * 계약 ID와 사용자명으로 특정 계약을 조회
+     * 구매내역 상세 조회 시 사용되며, 본인의 계약만 조회할 수 있도록 사용자명으로 필터링함
+     */
+    @Query("SELECT c FROM Contract c " +
+           "JOIN FETCH c.quote q " +
+           "JOIN FETCH q.user u " +
+           "JOIN FETCH c.selectedBid b " +
+           "JOIN FETCH q.phoneModel pm " +
+           "LEFT JOIN FETCH q.storage " +
+           "LEFT JOIN FETCH q.color " +
+           "WHERE c.id = :contractId " +
+           "AND u.username = :username " +
+           "AND (c.isDelete = false OR c.isDelete IS NULL)")
+    Optional<Contract> findByIdAndUsername(@Param("contractId") UUID contractId, @Param("username") String username);
+
+    /**
+     * 사용자명으로 구매완료 또는 취소 상태의 모든 계약을 조회
+     * 구매완료와 취소를 함께 조회할 때 사용됨
+     */
+    @Query("SELECT c FROM Contract c " +
+           "JOIN FETCH c.quote q " +
+           "JOIN FETCH q.user u " +
+           "JOIN FETCH c.selectedBid b " +
+           "JOIN FETCH q.phoneModel pm " +
+           "WHERE u.username = :username " +
+           "AND (c.status = 'SIGNED' OR c.status = 'CANCELLED') " +
+           "AND (c.isDelete = false OR c.isDelete IS NULL) " +
+           "ORDER BY c.signedAt DESC")
+    List<Contract> findAllByUsername(@Param("username") String username, Pageable pageable);
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/repository/DeliveryRepository.java
+++ b/backend/src/main/java/com/phonebid/app/trade/repository/DeliveryRepository.java
@@ -1,0 +1,23 @@
+package com.phonebid.app.trade.repository;
+
+import com.phonebid.app.trade.domain.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
+
+    /**
+     * 계약 ID로 배송 정보를 조회
+     * 계약에 연결된 배송 정보(송장번호, 배송 상태 등)를 가져올 때 사용됨
+     */
+    @Query("SELECT d FROM Delivery d " +
+           "JOIN FETCH d.contract c " +
+           "WHERE c.id = :contractId " +
+           "AND (d.isDelete = false OR d.isDelete IS NULL)")
+    Optional<Delivery> findByContractId(@Param("contractId") UUID contractId);
+}
+

--- a/backend/src/main/java/com/phonebid/app/trade/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/phonebid/app/trade/repository/PaymentRepository.java
@@ -1,0 +1,41 @@
+package com.phonebid.app.trade.repository;
+
+import com.phonebid.app.trade.domain.Payment;
+import com.phonebid.app.trade.domain.PaymentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 결제(Payment) 엔티티에 대한 데이터 접근을 담당하는 Repository
+ * 계약별 결제 정보 조회 기능을 제공합니다.
+ */
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+
+    /**
+     * 계약 ID로 결제 정보를 조회합니다.
+     * 계약에 연결된 결제 정보를 가져올 때 사용됩니다.
+     */
+    @Query("SELECT p FROM Payment p " +
+           "JOIN FETCH p.contract c " +
+           "WHERE c.id = :contractId " +
+           "AND (p.isDelete = false OR p.isDelete IS NULL)")
+    Optional<Payment> findByContractId(@Param("contractId") UUID contractId);
+
+    /**
+     * 계약 ID와 결제 상태로 결제 정보를 조회합니다.
+     * 특정 상태의 결제만 조회할 때 사용됩니다.
+     */
+    @Query("SELECT p FROM Payment p " +
+           "JOIN FETCH p.contract c " +
+           "WHERE c.id = :contractId " +
+           "AND p.status = :status " +
+           "AND (p.isDelete = false OR p.isDelete IS NULL)")
+    Optional<Payment> findByContractIdAndStatus(
+            @Param("contractId") UUID contractId,
+            @Param("status") PaymentStatus status);
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #75.

## 📝작업 내용

> 각 권한 별 마이페이지 도메인 백엔드 기능 구현

- [x] 프로필
- [x] 구매내역
- [x] 계좌 관리
- [x] 고객센터
- [x] 회원탈퇴

지원하는 은행명 목록:

- KB국민은행
- 신한은행
- 하나은행
- 우리은행
- NH농협은행
- IBK기업은행
- 카카오뱅크
- 토스뱅크
- KEB하나은행
- SC제일은행
- 한국씨티은행
- KDB산업은행
- 저축은행
- 우체국
- 수협은행

## 참고사항
- 배송 주소록 -> 와이어프레임 나오면 구현 시작
- 리뷰관리 -> 와이어프레임 나오면 구현 시작
- 판매자 바로가기 (판매자로 기존에 등록된 계정인 경우 마이페이지단에서 바로 이동하게 할 것인지 페이지 하나를 만들어서 안내 후 이동할 것인지 협의 필요) -> 협의 완료 시 구현 시작