### PR TITLE
Frontend implementation of Buyer and Seller MyPage functionality feat implement new feature

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -19,6 +19,14 @@ import ProfilePage from "pages/ProfilePage";
 import PurchaseHistoryPage from "pages/PurchaseHistoryPage";
 import PurchaseDetailPage from "pages/PurchaseDetailPage";
 import AccountManagementPage from "pages/AccountManagementPage";
+import CustomerServicePage from "pages/CustomerServicePage";
+import InquiryPage from "pages/InquiryPage";
+import MyInquiriesPage from "pages/MyInquiriesPage";
+import InquiryDetailPage from "pages/InquiryDetailPage";
+import NoticeListPage from "pages/NoticeListPage";
+import NoticeDetailPage from "pages/NoticeDetailPage";
+import FAQListPage from "pages/FAQListPage";
+import FAQDetailPage from "pages/FAQDetailPage";
 
 export const AppRouter: React.FC = () => {
   return (
@@ -41,6 +49,14 @@ export const AppRouter: React.FC = () => {
           element={<PurchaseDetailPage />}
         />
         <Route path="/mypage/accounts" element={<AccountManagementPage />} />
+        <Route path="/mypage/customer-service" element={<CustomerServicePage />} />
+        <Route path="/mypage/customer-service/inquiry" element={<InquiryPage />} />
+        <Route path="/mypage/customer-service/inquiries/my" element={<MyInquiriesPage />} />
+        <Route path="/mypage/customer-service/inquiries/:inquiryId" element={<InquiryDetailPage />} />
+        <Route path="/mypage/customer-service/notices" element={<NoticeListPage />} />
+        <Route path="/mypage/customer-service/notices/:noticeId" element={<NoticeDetailPage />} />
+        <Route path="/mypage/customer-service/faqs" element={<FAQListPage />} />
+        <Route path="/mypage/customer-service/faqs/:faqId" element={<FAQDetailPage />} />
 
         {/* Layout이 포함된 일반 페이지들 */}
         <Route

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -16,6 +16,8 @@ import ChatListPage from "pages/ChatListPage";
 import ChatRoomPage from "pages/ChatRoomPage";
 import MyPage from "pages/MyPage";
 import ProfilePage from "pages/ProfilePage";
+import PurchaseHistoryPage from "pages/PurchaseHistoryPage";
+import PurchaseDetailPage from "pages/PurchaseDetailPage";
 
 export const AppRouter: React.FC = () => {
   return (
@@ -32,6 +34,11 @@ export const AppRouter: React.FC = () => {
         <Route path="/chat" element={<ChatListPage />} />
         <Route path="/chat/:chatRoomId" element={<ChatRoomPage />} />
         <Route path="/mypage/profile" element={<ProfilePage />} />
+        <Route path="/mypage/purchases" element={<PurchaseHistoryPage />} />
+        <Route
+          path="/mypage/purchases/:contractId"
+          element={<PurchaseDetailPage />}
+        />
 
         {/* Layout이 포함된 일반 페이지들 */}
         <Route

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -14,6 +14,8 @@ import PaymentFailPage from "pages/PaymentFailPage";
 import QuoteCreateWizardPage from "@/pages/QuoteCreateWizardPage";
 import ChatListPage from "pages/ChatListPage";
 import ChatRoomPage from "pages/ChatRoomPage";
+import MyPage from "pages/MyPage";
+import ProfilePage from "pages/ProfilePage";
 
 export const AppRouter: React.FC = () => {
   return (
@@ -29,6 +31,7 @@ export const AppRouter: React.FC = () => {
         <Route path="/payment/fail" element={<PaymentFailPage />} />
         <Route path="/chat" element={<ChatListPage />} />
         <Route path="/chat/:chatRoomId" element={<ChatRoomPage />} />
+        <Route path="/mypage/profile" element={<ProfilePage />} />
 
         {/* Layout이 포함된 일반 페이지들 */}
         <Route
@@ -43,6 +46,7 @@ export const AppRouter: React.FC = () => {
                   path="/admin/phone-models"
                   element={<PhoneModelManagePage />}
                 />
+                <Route path="/mypage" element={<MyPage />} />
               </Routes>
             </Layout>
           }

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -18,6 +18,7 @@ import MyPage from "pages/MyPage";
 import ProfilePage from "pages/ProfilePage";
 import PurchaseHistoryPage from "pages/PurchaseHistoryPage";
 import PurchaseDetailPage from "pages/PurchaseDetailPage";
+import AccountManagementPage from "pages/AccountManagementPage";
 
 export const AppRouter: React.FC = () => {
   return (
@@ -39,6 +40,7 @@ export const AppRouter: React.FC = () => {
           path="/mypage/purchases/:contractId"
           element={<PurchaseDetailPage />}
         />
+        <Route path="/mypage/accounts" element={<AccountManagementPage />} />
 
         {/* Layout이 포함된 일반 페이지들 */}
         <Route

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -49,12 +49,20 @@ const Header: React.FC = () => {
               이용방법
             </Link>
             {isAuthenticated && (
-              <Link
-                to="/chat"
-                className="text-gray-700 hover:text-indigo-500 px-3 py-2 rounded-md text-sm font-medium transition-colors"
-              >
-                채팅
-              </Link>
+              <>
+                <Link
+                  to="/chat"
+                  className="text-gray-700 hover:text-indigo-500 px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                >
+                  채팅
+                </Link>
+                <Link
+                  to="/mypage"
+                  className="text-gray-700 hover:text-indigo-500 px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                >
+                  마이페이지
+                </Link>
+              </>
             )}
             <Link
               to="/admin/phone-models"
@@ -171,13 +179,22 @@ const Header: React.FC = () => {
               이용방법
             </Link>
             {isAuthenticated && (
-              <Link
-                to="/chat"
-                className="block px-2 py-2 rounded-md text-gray-700 hover:bg-gray-100"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                채팅
-              </Link>
+              <>
+                <Link
+                  to="/chat"
+                  className="block px-2 py-2 rounded-md text-gray-700 hover:bg-gray-100"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  채팅
+                </Link>
+                <Link
+                  to="/mypage"
+                  className="block px-2 py-2 rounded-md text-gray-700 hover:bg-gray-100"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  마이페이지
+                </Link>
+              </>
             )}
 
             <div className="border-t pt-2 mt-2">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,6 +76,16 @@
   }
 }
 
+/* Scrollbar hide utility */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* Toast notifications styling */
 .Toastify__toast {
   font-family: inherit;

--- a/frontend/src/pages/AccountManagementPage.tsx
+++ b/frontend/src/pages/AccountManagementPage.tsx
@@ -8,6 +8,7 @@ import type {
   Page,
 } from "types/MyPageTypes";
 import { BANK_LIST } from "types/MyPageTypes";
+import { getErrorMessage, logError } from "utils/errorUtils";
 
 const AccountManagementPage = () => {
   const navigate = useNavigate();
@@ -45,9 +46,10 @@ const AccountManagementPage = () => {
       setIsLoadingAccounts(true);
       const data = await mypageService.getAccounts(currentPage, 1);
       setAccountsPage(data);
-    } catch (error: any) {
-      console.error("계좌 목록 조회 실패:", error);
-      toast.error("계좌 목록을 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      logError("계좌 목록 조회 실패:", error);
+      const errorMessage = getErrorMessage(error) || "계좌 목록을 불러오는데 실패했습니다.";
+      toast.error(errorMessage);
     } finally {
       setIsLoadingAccounts(false);
     }
@@ -139,10 +141,9 @@ const AccountManagementPage = () => {
         accountHolderName: "",
       });
       loadAccounts();
-    } catch (error: any) {
-      console.error("계좌 등록 실패:", error);
-      const errorMessage =
-        error.response?.data?.message || "계좌 등록에 실패했습니다.";
+    } catch (error: unknown) {
+      logError("계좌 등록 실패:", error);
+      const errorMessage = getErrorMessage(error) || "계좌 등록에 실패했습니다.";
       toast.error(errorMessage);
     } finally {
       setIsLoading(false);
@@ -158,10 +159,9 @@ const AccountManagementPage = () => {
       await mypageService.deleteAccount(accountId);
       toast.success("계좌가 삭제되었습니다.");
       loadAccounts();
-    } catch (error: any) {
-      console.error("계좌 삭제 실패:", error);
-      const errorMessage =
-        error.response?.data?.message || "계좌 삭제에 실패했습니다.";
+    } catch (error: unknown) {
+      logError("계좌 삭제 실패:", error);
+      const errorMessage = getErrorMessage(error) || "계좌 삭제에 실패했습니다.";
       toast.error(errorMessage);
     }
   };

--- a/frontend/src/pages/AccountManagementPage.tsx
+++ b/frontend/src/pages/AccountManagementPage.tsx
@@ -283,7 +283,7 @@ const AccountManagementPage = () => {
               </label>
               <input
                 type="text"
-                placeholder="Enter your name"
+                placeholder="이름을 입력하세요"
                 value={formData.accountHolderName}
                 onChange={(e) =>
                   handleInputChange("accountHolderName", e.target.value)

--- a/frontend/src/pages/AccountManagementPage.tsx
+++ b/frontend/src/pages/AccountManagementPage.tsx
@@ -8,7 +8,7 @@ import type {
   Page,
 } from "types/MyPageTypes";
 import { BANK_LIST } from "types/MyPageTypes";
-import { getErrorMessage, logError } from "utils/errorUtils";
+import { logError } from "utils/errorUtils";
 
 const AccountManagementPage = () => {
   const navigate = useNavigate();
@@ -48,8 +48,6 @@ const AccountManagementPage = () => {
       setAccountsPage(data);
     } catch (error: unknown) {
       logError("계좌 목록 조회 실패:", error);
-      const errorMessage = getErrorMessage(error) || "계좌 목록을 불러오는데 실패했습니다.";
-      toast.error(errorMessage);
     } finally {
       setIsLoadingAccounts(false);
     }
@@ -143,8 +141,6 @@ const AccountManagementPage = () => {
       loadAccounts();
     } catch (error: unknown) {
       logError("계좌 등록 실패:", error);
-      const errorMessage = getErrorMessage(error) || "계좌 등록에 실패했습니다.";
-      toast.error(errorMessage);
     } finally {
       setIsLoading(false);
     }
@@ -161,8 +157,6 @@ const AccountManagementPage = () => {
       loadAccounts();
     } catch (error: unknown) {
       logError("계좌 삭제 실패:", error);
-      const errorMessage = getErrorMessage(error) || "계좌 삭제에 실패했습니다.";
-      toast.error(errorMessage);
     }
   };
 

--- a/frontend/src/pages/AccountManagementPage.tsx
+++ b/frontend/src/pages/AccountManagementPage.tsx
@@ -277,7 +277,7 @@ const AccountManagementPage = () => {
               </label>
               <input
                 type="text"
-                placeholder="이름을 입력하세요"
+                placeholder="예금주명을 입력하세요"
                 value={formData.accountHolderName}
                 onChange={(e) =>
                   handleInputChange("accountHolderName", e.target.value)

--- a/frontend/src/pages/AccountManagementPage.tsx
+++ b/frontend/src/pages/AccountManagementPage.tsx
@@ -48,6 +48,8 @@ const AccountManagementPage = () => {
       setAccountsPage(data);
     } catch (error: unknown) {
       logError("계좌 목록 조회 실패:", error);
+      toast.error("계좌 목록을 불러오는 데 실패했습니다.");
+      throw error;
     } finally {
       setIsLoadingAccounts(false);
     }

--- a/frontend/src/pages/AccountManagementPage.tsx
+++ b/frontend/src/pages/AccountManagementPage.tsx
@@ -1,0 +1,425 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { mypageService } from "services/mypageService";
+import { toast } from "react-toastify";
+import type {
+  AccountCreateRequestDto,
+  AccountResponseDto,
+  Page,
+} from "types/MyPageTypes";
+import { BANK_LIST } from "types/MyPageTypes";
+
+const AccountManagementPage = () => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingAccounts, setIsLoadingAccounts] = useState(true);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [accountsPage, setAccountsPage] = useState<Page<AccountResponseDto>>({
+    content: [],
+    totalElements: 0,
+    totalPages: 0,
+    size: 10,
+    number: 0,
+    first: true,
+    last: true,
+  });
+
+  const [formData, setFormData] = useState<AccountCreateRequestDto>({
+    bankName: "",
+    accountNumber: "",
+    accountHolderName: "",
+  });
+
+  const [errors, setErrors] = useState({
+    bankName: "",
+    accountNumber: "",
+    accountHolderName: "",
+  });
+
+  useEffect(() => {
+    loadAccounts();
+  }, [currentPage]);
+
+  const loadAccounts = async () => {
+    try {
+      setIsLoadingAccounts(true);
+      const data = await mypageService.getAccounts(currentPage, 1);
+      setAccountsPage(data);
+    } catch (error: any) {
+      console.error("계좌 목록 조회 실패:", error);
+      toast.error("계좌 목록을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoadingAccounts(false);
+    }
+  };
+
+  const validateBankName = (bankName: string): string => {
+    if (!bankName.trim()) return "은행명을 선택해주세요.";
+    return "";
+  };
+
+  const validateAccountNumber = (accountNumber: string): string => {
+    const accountNumberRegex = /^[0-9-]+$/;
+    if (!accountNumber.trim()) return "계좌번호를 입력해주세요.";
+    if (accountNumber.length < 10 || accountNumber.length > 20) {
+      return "계좌번호는 10자 이상 20자 이하여야 합니다.";
+    }
+    if (!accountNumberRegex.test(accountNumber)) {
+      return "계좌번호는 숫자와 하이픈(-)만 입력 가능합니다.";
+    }
+    return "";
+  };
+
+  const validateAccountHolderName = (accountHolderName: string): string => {
+    const accountHolderRegex = /^[가-힣a-zA-Z0-9\s]+$/;
+    if (!accountHolderName.trim()) return "예금주명을 입력해주세요.";
+    if (accountHolderName.length < 2 || accountHolderName.length > 50) {
+      return "예금주명은 2자 이상 50자 이하여야 합니다.";
+    }
+    if (!accountHolderRegex.test(accountHolderName)) {
+      return "예금주명은 한글, 영문, 숫자, 공백만 입력 가능합니다.";
+    }
+    return "";
+  };
+
+  const handleInputChange = (
+    field: keyof AccountCreateRequestDto,
+    value: string
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+
+    let error = "";
+    switch (field) {
+      case "bankName":
+        error = validateBankName(value);
+        break;
+      case "accountNumber":
+        error = validateAccountNumber(value);
+        break;
+      case "accountHolderName":
+        error = validateAccountHolderName(value);
+        break;
+    }
+
+    setErrors((prev) => ({ ...prev, [field]: error }));
+  };
+
+  const handleSubmit = async () => {
+    const bankNameError = validateBankName(formData.bankName);
+    const accountNumberError = validateAccountNumber(formData.accountNumber);
+    const accountHolderNameError = validateAccountHolderName(
+      formData.accountHolderName
+    );
+
+    if (bankNameError || accountNumberError || accountHolderNameError) {
+      setErrors({
+        bankName: bankNameError,
+        accountNumber: accountNumberError,
+        accountHolderName: accountHolderNameError,
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await mypageService.createAccount({
+        bankName: formData.bankName.trim(),
+        accountNumber: formData.accountNumber.trim(),
+        accountHolderName: formData.accountHolderName.trim(),
+      });
+      toast.success("계좌가 등록되었습니다.");
+      setFormData({
+        bankName: "",
+        accountNumber: "",
+        accountHolderName: "",
+      });
+      setErrors({
+        bankName: "",
+        accountNumber: "",
+        accountHolderName: "",
+      });
+      loadAccounts();
+    } catch (error: any) {
+      console.error("계좌 등록 실패:", error);
+      const errorMessage =
+        error.response?.data?.message || "계좌 등록에 실패했습니다.";
+      toast.error(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDelete = async (accountId: string) => {
+    if (!window.confirm("정말 이 계좌를 삭제하시겠습니까?")) {
+      return;
+    }
+
+    try {
+      await mypageService.deleteAccount(accountId);
+      toast.success("계좌가 삭제되었습니다.");
+      loadAccounts();
+    } catch (error: any) {
+      console.error("계좌 삭제 실패:", error);
+      const errorMessage =
+        error.response?.data?.message || "계좌 삭제에 실패했습니다.";
+      toast.error(errorMessage);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage");
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 0 && newPage < accountsPage.totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            계좌 관리
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 계좌 등록 폼 */}
+        <div className="bg-white rounded-lg p-4 mb-6 shadow-sm border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            계좌 등록
+          </h2>
+
+          <div className="space-y-4">
+            {/* 은행명 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                은행명
+              </label>
+              <div className="relative">
+                <select
+                  value={formData.bankName}
+                  onChange={(e) => handleInputChange("bankName", e.target.value)}
+                  className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                    errors.bankName ? "border-red-500" : "border-gray-300"
+                  }`}
+                >
+                  <option value="">은행을 선택해주세요</option>
+                  {BANK_LIST.map((bank) => (
+                    <option key={bank} value={bank}>
+                      {bank}
+                    </option>
+                  ))}
+                </select>
+                <div className="absolute right-3 top-1/2 transform -translate-y-1/2 pointer-events-none">
+                  <svg
+                    className="w-4 h-4 text-gray-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </div>
+              </div>
+              {errors.bankName && (
+                <p className="mt-1 text-xs text-red-600">{errors.bankName}</p>
+              )}
+            </div>
+
+            {/* 계좌번호 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                계좌번호
+              </label>
+              <input
+                type="text"
+                placeholder="000-000-000"
+                value={formData.accountNumber}
+                onChange={(e) =>
+                  handleInputChange("accountNumber", e.target.value)
+                }
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                  errors.accountNumber ? "border-red-500" : "border-gray-300"
+                }`}
+              />
+              {errors.accountNumber && (
+                <p className="mt-1 text-xs text-red-600">
+                  {errors.accountNumber}
+                </p>
+              )}
+            </div>
+
+            {/* 예금주 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                예금주
+              </label>
+              <input
+                type="text"
+                placeholder="Enter your name"
+                value={formData.accountHolderName}
+                onChange={(e) =>
+                  handleInputChange("accountHolderName", e.target.value)
+                }
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                  errors.accountHolderName ? "border-red-500" : "border-gray-300"
+                }`}
+              />
+              {errors.accountHolderName && (
+                <p className="mt-1 text-xs text-red-600">
+                  {errors.accountHolderName}
+                </p>
+              )}
+            </div>
+
+            {/* 계좌 등록 버튼 */}
+            <button
+              onClick={handleSubmit}
+              disabled={isLoading}
+              className="w-full px-4 py-2 border border-black rounded-lg text-black font-medium hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isLoading ? "등록 중..." : "계좌 등록"}
+            </button>
+          </div>
+        </div>
+
+        {/* 등록된 계좌 목록 */}
+        <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            등록된 계좌
+          </h2>
+
+          {isLoadingAccounts ? (
+            <div className="text-center py-8 text-gray-500">로딩 중...</div>
+          ) : accountsPage.content.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              등록된 계좌가 없습니다.
+            </div>
+          ) : (
+            <>
+              {/* 계좌 목록 (한 개씩 표시) */}
+              <div className="mb-4">
+                {accountsPage.content.map((account) => (
+                  <div
+                    key={account.accountId}
+                    className="bg-gray-50 rounded-lg p-4 relative min-h-[120px]"
+                  >
+                    <div className="flex-1">
+                      <div className="font-medium text-gray-900">
+                        {account.bankName}
+                      </div>
+                      <div className="text-sm text-gray-600 mt-1">
+                        {account.accountNumber}
+                      </div>
+                      <div className="text-xs text-gray-500 mt-1">
+                        예금주 : {account.accountHolderName}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => handleDelete(account.accountId)}
+                      className="absolute top-4 right-4 p-2 text-gray-400 hover:text-red-600 transition-colors"
+                      aria-label="계좌 삭제"
+                    >
+                      <svg
+                        className="w-5 h-5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              {/* 페이징 컨트롤 */}
+              {accountsPage.totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 pt-4 border-t border-gray-200">
+                  <button
+                    onClick={() => handlePageChange(currentPage - 1)}
+                    disabled={accountsPage.first}
+                    className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    aria-label="이전 페이지"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 19l-7-7 7-7"
+                      />
+                    </svg>
+                  </button>
+                  <span className="text-sm text-gray-700">
+                    {currentPage + 1}/{accountsPage.totalPages}
+                  </span>
+                  <button
+                    onClick={() => handlePageChange(currentPage + 1)}
+                    disabled={accountsPage.last}
+                    className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    aria-label="다음 페이지"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AccountManagementPage;
+

--- a/frontend/src/pages/CustomerServicePage.tsx
+++ b/frontend/src/pages/CustomerServicePage.tsx
@@ -1,0 +1,151 @@
+import { useNavigate } from "react-router-dom";
+
+const CustomerServicePage = () => {
+  const navigate = useNavigate();
+
+  const menuItems = [
+    {
+      id: "inquiry",
+      label: "1:1 문의",
+      path: "/mypage/customer-service/inquiries/my",
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+          />
+        </svg>
+      ),
+    },
+    {
+      id: "notices",
+      label: "공지사항",
+      path: "/mypage/customer-service/notices",
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+          />
+        </svg>
+      ),
+    },
+    {
+      id: "faq",
+      label: "FAQ",
+      path: "/mypage/customer-service/faqs",
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      ),
+    },
+  ];
+
+  const handleMenuClick = (path: string) => {
+    navigate(path);
+  };
+
+  const handleBack = () => {
+    navigate("/mypage");
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            고객센터
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 메뉴 목록 */}
+        <div className="bg-white rounded-lg overflow-hidden border border-gray-200">
+          {menuItems.map((item, index) => (
+            <button
+              key={item.id}
+              onClick={() => handleMenuClick(item.path)}
+              className={`
+                w-full flex items-center px-4 py-4
+                transition-colors duration-200
+                hover:bg-gray-50 cursor-pointer
+                ${
+                  index !== menuItems.length - 1
+                    ? "border-b border-gray-200"
+                    : ""
+                }
+              `}
+            >
+              <div className="flex items-center justify-center w-6 mr-3 text-black">
+                {item.icon}
+              </div>
+              <span className="flex-1 text-base text-black text-left">
+                {item.label}
+              </span>
+              <svg
+                className="w-5 h-5 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CustomerServicePage;
+

--- a/frontend/src/pages/FAQDetailPage.tsx
+++ b/frontend/src/pages/FAQDetailPage.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { customerService } from "services/customerService";
+import { toast } from "react-toastify";
+import type { FaqDetailResponseDto } from "types/CustomerServiceTypes";
+import { FAQ_CATEGORY_LABELS } from "types/CustomerServiceTypes";
+
+const FAQDetailPage = () => {
+  const navigate = useNavigate();
+  const { faqId } = useParams<{ faqId: string }>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [faq, setFaq] = useState<FaqDetailResponseDto | null>(null);
+
+  useEffect(() => {
+    if (faqId) {
+      loadFaqDetail();
+    }
+  }, [faqId]);
+
+  const loadFaqDetail = async () => {
+    if (!faqId) return;
+
+    try {
+      setIsLoading(true);
+      const data = await customerService.getFaqDetail(faqId);
+      setFaq(data);
+    } catch (error: any) {
+      console.error("FAQ 상세 조회 실패:", error);
+      toast.error("FAQ 상세 정보를 불러오는데 실패했습니다.");
+      navigate("/mypage/customer-service/faqs");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage/customer-service/faqs");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (!faq) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            고객센터 - FAQ
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* FAQ 상세 */}
+        <div className="bg-gray-50 rounded-lg p-4 shadow-sm border border-gray-200">
+          <div className="text-xs px-2 py-1 bg-indigo-100 text-indigo-700 rounded inline-block mb-4">
+            {FAQ_CATEGORY_LABELS[faq.category]}
+          </div>
+
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            {faq.question}
+          </h2>
+
+          <div className="text-sm text-gray-700 whitespace-pre-wrap">
+            {faq.answer}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FAQDetailPage;
+

--- a/frontend/src/pages/FAQDetailPage.tsx
+++ b/frontend/src/pages/FAQDetailPage.tsx
@@ -4,6 +4,7 @@ import { customerService } from "services/customerService";
 import { toast } from "react-toastify";
 import type { FaqDetailResponseDto } from "types/CustomerServiceTypes";
 import { FAQ_CATEGORY_LABELS } from "types/CustomerServiceTypes";
+import { getErrorMessage, logError } from "utils/errorUtils";
 
 const FAQDetailPage = () => {
   const navigate = useNavigate();
@@ -24,9 +25,10 @@ const FAQDetailPage = () => {
       setIsLoading(true);
       const data = await customerService.getFaqDetail(faqId);
       setFaq(data);
-    } catch (error: any) {
-      console.error("FAQ 상세 조회 실패:", error);
-      toast.error("FAQ 상세 정보를 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      logError("FAQ 상세 조회 실패:", error);
+      const errorMessage = getErrorMessage(error) || "FAQ 상세 정보를 불러오는데 실패했습니다.";
+      toast.error(errorMessage);
       navigate("/mypage/customer-service/faqs");
     } finally {
       setIsLoading(false);

--- a/frontend/src/pages/FAQListPage.tsx
+++ b/frontend/src/pages/FAQListPage.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { customerService } from "services/customerService";
 import { toast } from "react-toastify";
-import type { FaqResponseDto, Page } from "types/CustomerServiceTypes";
-import { FaqCategory, FAQ_CATEGORY_LABELS } from "types/CustomerServiceTypes";
+import type { FaqResponseDto, Page, FaqCategory } from "types/CustomerServiceTypes";
+import { FAQ_CATEGORY, FAQ_CATEGORY_LABELS } from "types/CustomerServiceTypes";
 import { getErrorMessage, logError } from "utils/errorUtils";
 
 const FAQListPage = () => {
@@ -100,7 +100,7 @@ const FAQListPage = () => {
           >
             전체
           </button>
-          {Object.values(FaqCategory).map((category) => (
+          {Object.values(FAQ_CATEGORY).map((category) => (
             <button
               key={category}
               onClick={() => handleCategoryChange(category)}

--- a/frontend/src/pages/FAQListPage.tsx
+++ b/frontend/src/pages/FAQListPage.tsx
@@ -4,6 +4,7 @@ import { customerService } from "services/customerService";
 import { toast } from "react-toastify";
 import type { FaqResponseDto, Page } from "types/CustomerServiceTypes";
 import { FaqCategory, FAQ_CATEGORY_LABELS } from "types/CustomerServiceTypes";
+import { getErrorMessage, logError } from "utils/errorUtils";
 
 const FAQListPage = () => {
   const navigate = useNavigate();
@@ -29,9 +30,11 @@ const FAQListPage = () => {
       setIsLoading(true);
       const data = await customerService.getFaqs(selectedCategory, currentPage, 10);
       setFaqsPage(data);
-    } catch (error: any) {
-      console.error("FAQ 목록 조회 실패:", error);
-      toast.error("FAQ 목록을 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logError("FAQ 목록 조회 실패:", err);
+      const errorMessage = getErrorMessage(error);
+      toast.error(`FAQ 목록을 불러오는데 실패했습니다: ${errorMessage}`);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/pages/FAQListPage.tsx
+++ b/frontend/src/pages/FAQListPage.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { customerService } from "services/customerService";
+import { toast } from "react-toastify";
+import type { FaqResponseDto, Page } from "types/CustomerServiceTypes";
+import { FaqCategory, FAQ_CATEGORY_LABELS } from "types/CustomerServiceTypes";
+
+const FAQListPage = () => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [selectedCategory, setSelectedCategory] = useState<FaqCategory | null>(null);
+  const [faqsPage, setFaqsPage] = useState<Page<FaqResponseDto>>({
+    content: [],
+    totalElements: 0,
+    totalPages: 0,
+    size: 10,
+    number: 0,
+    first: true,
+    last: true,
+  });
+
+  useEffect(() => {
+    loadFaqs();
+  }, [currentPage, selectedCategory]);
+
+  const loadFaqs = async () => {
+    try {
+      setIsLoading(true);
+      const data = await customerService.getFaqs(selectedCategory, currentPage, 10);
+      setFaqsPage(data);
+    } catch (error: any) {
+      console.error("FAQ 목록 조회 실패:", error);
+      toast.error("FAQ 목록을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage/customer-service");
+  };
+
+  const handleFaqClick = (faqId: string) => {
+    navigate(`/mypage/customer-service/faqs/${faqId}`);
+  };
+
+  const handleCategoryChange = (category: FaqCategory | null) => {
+    setSelectedCategory(category);
+    setCurrentPage(0);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 0 && newPage < faqsPage.totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            고객센터 - FAQ
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 카테고리 필터 */}
+        <div className="mb-4 flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+          <button
+            onClick={() => handleCategoryChange(null)}
+            className={`px-3 py-1 rounded-lg text-sm whitespace-nowrap ${
+              selectedCategory === null
+                ? "bg-black text-white"
+                : "bg-white text-gray-700 border border-gray-300"
+            }`}
+          >
+            전체
+          </button>
+          {Object.values(FaqCategory).map((category) => (
+            <button
+              key={category}
+              onClick={() => handleCategoryChange(category)}
+              className={`px-3 py-1 rounded-lg text-sm whitespace-nowrap ${
+                selectedCategory === category
+                  ? "bg-black text-white"
+                  : "bg-white text-gray-700 border border-gray-300"
+              }`}
+            >
+              {FAQ_CATEGORY_LABELS[category]}
+            </button>
+          ))}
+        </div>
+
+        {/* FAQ 목록 */}
+        <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
+          {isLoading ? (
+            <div className="text-center py-8 text-gray-500">로딩 중...</div>
+          ) : faqsPage.content.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              등록된 FAQ가 없습니다.
+            </div>
+          ) : (
+            <>
+              <div className="space-y-3 mb-4">
+                {faqsPage.content.map((faq) => (
+                  <div
+                    key={faq.id}
+                    onClick={() => handleFaqClick(faq.id)}
+                    className="bg-gray-50 rounded-lg p-4 cursor-pointer hover:bg-gray-100 transition-colors"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1">
+                        <div className="text-xs px-2 py-1 bg-indigo-100 text-indigo-700 rounded inline-block mb-2">
+                          {FAQ_CATEGORY_LABELS[faq.category]}
+                        </div>
+                        <div className="font-medium text-gray-900">
+                          {faq.question}
+                        </div>
+                      </div>
+                      <svg
+                        className="w-5 h-5 text-gray-400 ml-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 페이징 컨트롤 */}
+              {faqsPage.totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 pt-4 border-t border-gray-200">
+                  <button
+                    onClick={() => handlePageChange(currentPage - 1)}
+                    disabled={faqsPage.first}
+                    className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    aria-label="이전 페이지"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 19l-7-7 7-7"
+                      />
+                    </svg>
+                  </button>
+                  <span className="text-sm text-gray-700">
+                    {currentPage + 1}/{faqsPage.totalPages}
+                  </span>
+                  <button
+                    onClick={() => handlePageChange(currentPage + 1)}
+                    disabled={faqsPage.last}
+                    className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    aria-label="다음 페이지"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FAQListPage;
+

--- a/frontend/src/pages/InquiryDetailPage.tsx
+++ b/frontend/src/pages/InquiryDetailPage.tsx
@@ -103,7 +103,7 @@ const InquiryDetailPage = () => {
             </span>
           </div>
 
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">
+          <h2 className="text-base font-semibold text-gray-900 mb-2">
             {inquiry.title}
           </h2>
 

--- a/frontend/src/pages/InquiryDetailPage.tsx
+++ b/frontend/src/pages/InquiryDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   INQUIRY_STATUS_LABELS,
 } from "types/CustomerServiceTypes";
 import { formatDateSimple } from "utils/formatters";
+import { getErrorMessage, logError } from "utils/errorUtils";
 
 const InquiryDetailPage = () => {
   const navigate = useNavigate();
@@ -28,9 +29,10 @@ const InquiryDetailPage = () => {
       setIsLoading(true);
       const data = await customerService.getInquiryDetail(inquiryId);
       setInquiry(data);
-    } catch (error: any) {
-      console.error("문의 상세 조회 실패:", error);
-      toast.error("문의 상세 정보를 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      logError("문의 상세 조회 실패:", error);
+      const errorMessage = getErrorMessage(error) || "문의 상세 정보를 불러오는데 실패했습니다.";
+      toast.error(errorMessage);
       navigate("/mypage/customer-service/inquiries/my");
     } finally {
       setIsLoading(false);

--- a/frontend/src/pages/InquiryDetailPage.tsx
+++ b/frontend/src/pages/InquiryDetailPage.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { customerService } from "services/customerService";
+import { toast } from "react-toastify";
+import type { InquiryDetailResponseDto } from "types/CustomerServiceTypes";
+import {
+  INQUIRY_CATEGORY_LABELS,
+  INQUIRY_STATUS_LABELS,
+} from "types/CustomerServiceTypes";
+import { formatDateSimple } from "utils/formatters";
+
+const InquiryDetailPage = () => {
+  const navigate = useNavigate();
+  const { inquiryId } = useParams<{ inquiryId: string }>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [inquiry, setInquiry] = useState<InquiryDetailResponseDto | null>(null);
+
+  useEffect(() => {
+    if (inquiryId) {
+      loadInquiryDetail();
+    }
+  }, [inquiryId]);
+
+  const loadInquiryDetail = async () => {
+    if (!inquiryId) return;
+
+    try {
+      setIsLoading(true);
+      const data = await customerService.getInquiryDetail(inquiryId);
+      setInquiry(data);
+    } catch (error: any) {
+      console.error("문의 상세 조회 실패:", error);
+      toast.error("문의 상세 정보를 불러오는데 실패했습니다.");
+      navigate("/mypage/customer-service/inquiries/my");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage/customer-service/inquiries/my");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (!inquiry) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            문의 상세
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 문의 내용 */}
+        <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200 mb-4">
+          <div className="flex items-center gap-2 mb-4">
+            <span className="text-xs px-2 py-1 bg-indigo-100 text-indigo-700 rounded">
+              {INQUIRY_CATEGORY_LABELS[inquiry.category]}
+            </span>
+            <span
+              className={`text-xs px-2 py-1 rounded ${
+                inquiry.status === "ANSWERED"
+                  ? "bg-green-100 text-green-700"
+                  : inquiry.status === "PENDING"
+                  ? "bg-yellow-100 text-yellow-700"
+                  : "bg-gray-100 text-gray-700"
+              }`}
+            >
+              {INQUIRY_STATUS_LABELS[inquiry.status]}
+            </span>
+          </div>
+
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">
+            {inquiry.title}
+          </h2>
+
+          <div className="text-sm text-gray-500 mb-4">
+            {formatDateSimple(inquiry.createdAt)}
+          </div>
+
+          <div className="text-sm text-gray-700 whitespace-pre-wrap">
+            {inquiry.content}
+          </div>
+        </div>
+
+        {/* 답변 */}
+        {inquiry.reply ? (
+          <div className="bg-green-50 rounded-lg p-4 shadow-sm border border-green-200">
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-sm font-semibold text-green-800">답변</h3>
+              <div className="text-xs text-green-600">
+                {inquiry.reply.adminNickname || "관리자"} ·{" "}
+                {formatDateSimple(inquiry.reply.createdAt)}
+              </div>
+            </div>
+            <div className="text-sm text-gray-700 whitespace-pre-wrap">
+              {inquiry.reply.content}
+            </div>
+          </div>
+        ) : (
+          <div className="bg-gray-50 rounded-lg p-4 shadow-sm border border-gray-200">
+            <div className="text-center text-gray-500 text-sm">
+              아직 답변이 없습니다.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InquiryDetailPage;
+

--- a/frontend/src/pages/InquiryPage.tsx
+++ b/frontend/src/pages/InquiryPage.tsx
@@ -5,15 +5,17 @@ import { toast } from "react-toastify";
 import type { InquiryCreateRequestDto } from "types/CustomerServiceTypes";
 import {
   InquiryCategory,
+  INQUIRY_CATEGORY,
   INQUIRY_CATEGORY_LABELS,
 } from "types/CustomerServiceTypes";
+import { getErrorMessage, logError } from "utils/errorUtils";
 
 const InquiryPage = () => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
 
   const [formData, setFormData] = useState<InquiryCreateRequestDto>({
-    category: InquiryCategory.PAYMENT,
+    category: INQUIRY_CATEGORY.PAYMENT,
     title: "",
     content: "",
   });
@@ -76,10 +78,9 @@ const InquiryPage = () => {
       });
       toast.success("문의가 등록되었습니다.");
       navigate("/mypage/customer-service/inquiries/my");
-    } catch (error: any) {
-      console.error("문의 등록 실패:", error);
-      const errorMessage =
-        error.response?.data?.message || "문의 등록에 실패했습니다.";
+    } catch (error: unknown) {
+      logError("문의 등록 실패:", error);
+      const errorMessage = getErrorMessage(error) || "문의 등록에 실패했습니다.";
       toast.error(errorMessage);
     } finally {
       setIsLoading(false);
@@ -134,7 +135,7 @@ const InquiryPage = () => {
                 }
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >
-                {Object.values(InquiryCategory).map((category) => (
+                {Object.values(INQUIRY_CATEGORY).map((category) => (
                   <option key={category} value={category}>
                     {INQUIRY_CATEGORY_LABELS[category]}
                   </option>

--- a/frontend/src/pages/InquiryPage.tsx
+++ b/frontend/src/pages/InquiryPage.tsx
@@ -1,0 +1,199 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { customerService } from "services/customerService";
+import { toast } from "react-toastify";
+import type { InquiryCreateRequestDto } from "types/CustomerServiceTypes";
+import {
+  InquiryCategory,
+  INQUIRY_CATEGORY_LABELS,
+} from "types/CustomerServiceTypes";
+
+const InquiryPage = () => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [formData, setFormData] = useState<InquiryCreateRequestDto>({
+    category: InquiryCategory.PAYMENT,
+    title: "",
+    content: "",
+  });
+
+  const [errors, setErrors] = useState({
+    category: "",
+    title: "",
+    content: "",
+  });
+
+  const validateTitle = (title: string): string => {
+    if (!title.trim()) return "제목을 입력해주세요.";
+    if (title.length > 200) return "제목은 200자 이하여야 합니다.";
+    return "";
+  };
+
+  const validateContent = (content: string): string => {
+    if (!content.trim()) return "내용을 입력해주세요.";
+    return "";
+  };
+
+  const handleInputChange = (
+    field: keyof InquiryCreateRequestDto,
+    value: string | InquiryCategory
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+
+    let error = "";
+    switch (field) {
+      case "title":
+        error = validateTitle(value as string);
+        break;
+      case "content":
+        error = validateContent(value as string);
+        break;
+    }
+
+    setErrors((prev) => ({ ...prev, [field]: error }));
+  };
+
+  const handleSubmit = async () => {
+    const titleError = validateTitle(formData.title);
+    const contentError = validateContent(formData.content);
+
+    if (titleError || contentError) {
+      setErrors({
+        category: "",
+        title: titleError,
+        content: contentError,
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await customerService.createInquiry({
+        category: formData.category,
+        title: formData.title.trim(),
+        content: formData.content.trim(),
+      });
+      toast.success("문의가 등록되었습니다.");
+      navigate("/mypage/customer-service/inquiries/my");
+    } catch (error: any) {
+      console.error("문의 등록 실패:", error);
+      const errorMessage =
+        error.response?.data?.message || "문의 등록에 실패했습니다.";
+      toast.error(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage/customer-service");
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            고객센터 - 1:1 문의
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 문의 작성 폼 */}
+        <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
+          <div className="space-y-4">
+            {/* 카테고리 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                카테고리
+              </label>
+              <select
+                value={formData.category}
+                onChange={(e) =>
+                  handleInputChange("category", e.target.value as InquiryCategory)
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                {Object.values(InquiryCategory).map((category) => (
+                  <option key={category} value={category}>
+                    {INQUIRY_CATEGORY_LABELS[category]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* 제목 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                제목
+              </label>
+              <input
+                type="text"
+                placeholder="문의 제목을 입력해주세요"
+                value={formData.title}
+                onChange={(e) => handleInputChange("title", e.target.value)}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                  errors.title ? "border-red-500" : "border-gray-300"
+                }`}
+              />
+              {errors.title && (
+                <p className="mt-1 text-xs text-red-600">{errors.title}</p>
+              )}
+            </div>
+
+            {/* 내용 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                내용
+              </label>
+              <textarea
+                placeholder="문의 내용을 입력해주세요"
+                value={formData.content}
+                onChange={(e) => handleInputChange("content", e.target.value)}
+                rows={10}
+                className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none ${
+                  errors.content ? "border-red-500" : "border-gray-300"
+                }`}
+              />
+              {errors.content && (
+                <p className="mt-1 text-xs text-red-600">{errors.content}</p>
+              )}
+            </div>
+
+            {/* 제출 버튼 */}
+            <button
+              onClick={handleSubmit}
+              disabled={isLoading}
+              className="w-full px-4 py-2 bg-indigo-500 text-white rounded-lg font-medium hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isLoading ? "등록 중..." : "문의 등록"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InquiryPage;
+

--- a/frontend/src/pages/MyInquiriesPage.tsx
+++ b/frontend/src/pages/MyInquiriesPage.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { customerService } from "services/customerService";
+import { toast } from "react-toastify";
+import type {
+  InquiryResponseDto,
+  Page,
+} from "types/CustomerServiceTypes";
+import {
+  INQUIRY_CATEGORY_LABELS,
+  INQUIRY_STATUS_LABELS,
+} from "types/CustomerServiceTypes";
+import { formatDateSimple } from "utils/formatters";
+
+const MyInquiriesPage = () => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [inquiriesPage, setInquiriesPage] = useState<Page<InquiryResponseDto>>({
+    content: [],
+    totalElements: 0,
+    totalPages: 0,
+    size: 10,
+    number: 0,
+    first: true,
+    last: true,
+  });
+
+  useEffect(() => {
+    loadInquiries();
+  }, [currentPage]);
+
+  const loadInquiries = async () => {
+    try {
+      setIsLoading(true);
+      const data = await customerService.getMyInquiries(currentPage, 10);
+      setInquiriesPage(data);
+    } catch (error: any) {
+      console.error("문의 목록 조회 실패:", error);
+      toast.error("문의 목록을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage/customer-service");
+  };
+
+  const handleInquiryClick = (inquiryId: string) => {
+    navigate(`/mypage/customer-service/inquiries/${inquiryId}`);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 0 && newPage < inquiriesPage.totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            나의 문의내역
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 문의 목록 */}
+        <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
+          {isLoading ? (
+            <div className="text-center py-8 text-gray-500">로딩 중...</div>
+          ) : inquiriesPage.content.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              등록된 문의가 없습니다.
+            </div>
+          ) : (
+            <>
+              <div className="space-y-3 mb-4">
+                {inquiriesPage.content.map((inquiry) => (
+                  <div
+                    key={inquiry.id}
+                    onClick={() => handleInquiryClick(inquiry.id)}
+                    className="bg-gray-50 rounded-lg p-4 cursor-pointer hover:bg-gray-100 transition-colors"
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="text-xs px-2 py-1 bg-indigo-100 text-indigo-700 rounded">
+                            {INQUIRY_CATEGORY_LABELS[inquiry.category]}
+                          </span>
+                          <span
+                            className={`text-xs px-2 py-1 rounded ${
+                              inquiry.status === "ANSWERED"
+                                ? "bg-green-100 text-green-700"
+                                : inquiry.status === "PENDING"
+                                ? "bg-yellow-100 text-yellow-700"
+                                : "bg-gray-100 text-gray-700"
+                            }`}
+                          >
+                            {INQUIRY_STATUS_LABELS[inquiry.status]}
+                          </span>
+                        </div>
+                        <div className="font-medium text-gray-900 mb-1">
+                          {inquiry.title}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {formatDateSimple(inquiry.createdAt)}
+                        </div>
+                      </div>
+                      <svg
+                        className="w-5 h-5 text-gray-400 ml-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 페이징 컨트롤 */}
+              {inquiriesPage.totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 pt-4 border-t border-gray-200">
+                  <button
+                    onClick={() => handlePageChange(currentPage - 1)}
+                    disabled={inquiriesPage.first}
+                    className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    aria-label="이전 페이지"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 19l-7-7 7-7"
+                      />
+                    </svg>
+                  </button>
+                  <span className="text-sm text-gray-700">
+                    {currentPage + 1}/{inquiriesPage.totalPages}
+                  </span>
+                  <button
+                    onClick={() => handlePageChange(currentPage + 1)}
+                    disabled={inquiriesPage.last}
+                    className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    aria-label="다음 페이지"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* 문의 작성 버튼 */}
+        <button
+          onClick={() => navigate("/mypage/customer-service/inquiry")}
+          className="w-full mt-4 px-4 py-3 bg-indigo-500 text-white rounded-lg font-medium hover:bg-indigo-600 transition-colors"
+        >
+          새 문의 작성
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MyInquiriesPage;
+

--- a/frontend/src/pages/MyInquiriesPage.tsx
+++ b/frontend/src/pages/MyInquiriesPage.tsx
@@ -11,6 +11,7 @@ import {
   INQUIRY_STATUS_LABELS,
 } from "types/CustomerServiceTypes";
 import { formatDateSimple } from "utils/formatters";
+import { getErrorMessage, logError } from "utils/errorUtils";
 
 const MyInquiriesPage = () => {
   const navigate = useNavigate();
@@ -35,9 +36,10 @@ const MyInquiriesPage = () => {
       setIsLoading(true);
       const data = await customerService.getMyInquiries(currentPage, 10);
       setInquiriesPage(data);
-    } catch (error: any) {
-      console.error("문의 목록 조회 실패:", error);
-      toast.error("문의 목록을 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logError("문의 목록 조회 실패:", error);
+      toast.error(`문의 목록을 불러오는데 실패했습니다: ${errorMessage}`);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -9,48 +9,174 @@ const MyPage = () => {
       label: "프로필",
       path: "/mypage/profile",
       enabled: true,
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+          />
+        </svg>
+      ),
     },
     {
       id: "purchases",
       label: "구매내역",
       path: "/mypage/purchases",
       enabled: false,
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"
+          />
+        </svg>
+      ),
     },
     {
       id: "accounts",
       label: "계좌관리",
       path: "/mypage/accounts",
       enabled: false,
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
+          />
+        </svg>
+      ),
     },
     {
       id: "addresses",
       label: "배송주소록",
       path: "/mypage/addresses",
       enabled: false,
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+      ),
     },
     {
       id: "customer-service",
       label: "고객센터",
       path: "/mypage/customer-service",
       enabled: false,
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"
+          />
+        </svg>
+      ),
     },
     {
       id: "reviews",
       label: "리뷰관리",
       path: "/mypage/reviews",
       enabled: false,
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
+          />
+        </svg>
+      ),
     },
     {
       id: "seller",
       label: "판매자 바로가기",
       path: "/seller",
       enabled: false,
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+          />
+        </svg>
+      ),
     },
     {
       id: "withdraw",
       label: "회원탈퇴",
       path: "/mypage/withdraw",
       enabled: false,
+      icon: (
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+          />
+        </svg>
+      ),
     },
   ];
 
@@ -65,30 +191,46 @@ const MyPage = () => {
       <div className="max-w-md mx-auto px-4 py-8">
         <h1 className="text-2xl font-bold text-gray-900 mb-8">마이페이지</h1>
 
-        <div className="space-y-2">
-          {menuItems.map((item) => (
+        <div className="bg-white rounded-lg overflow-hidden border border-gray-200">
+          {menuItems.map((item, index) => (
             <button
               key={item.id}
               onClick={() => handleMenuClick(item)}
               disabled={!item.enabled}
               className={`
-                w-full text-left px-4 py-4 bg-white rounded-lg
-                border border-gray-200
-                transition-all duration-200
+                w-full flex items-center px-4 py-4
+                transition-colors duration-200
+                ${
+                  index !== menuItems.length - 1
+                    ? "border-b border-gray-200"
+                    : ""
+                }
                 ${
                   item.enabled
-                    ? "hover:bg-indigo-50 hover:border-indigo-200 cursor-pointer"
+                    ? "hover:bg-gray-50 cursor-pointer"
                     : "opacity-60 cursor-not-allowed"
                 }
               `}
             >
-              <span
-                className={`text-base ${
-                  item.enabled ? "text-gray-900" : "text-gray-500"
-                }`}
-              >
+              <div className="flex items-center justify-center w-6 mr-3 text-black">
+                {item.icon}
+              </div>
+              <span className="flex-1 text-base text-black text-left">
                 {item.label}
               </span>
+              <svg
+                className="w-5 h-5 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
             </button>
           ))}
         </div>
@@ -98,4 +240,3 @@ const MyPage = () => {
 };
 
 export default MyPage;
-

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -98,7 +98,7 @@ const MyPage = () => {
       id: "customer-service",
       label: "고객센터",
       path: "/mypage/customer-service",
-      enabled: false,
+      enabled: true,
       icon: (
         <svg
           className="w-5 h-5"

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -29,7 +29,7 @@ const MyPage = () => {
       id: "purchases",
       label: "구매내역",
       path: "/mypage/purchases",
-      enabled: false,
+      enabled: true,
       icon: (
         <svg
           className="w-5 h-5"

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -1,0 +1,101 @@
+import { useNavigate } from "react-router-dom";
+
+const MyPage = () => {
+  const navigate = useNavigate();
+
+  const menuItems = [
+    {
+      id: "profile",
+      label: "프로필",
+      path: "/mypage/profile",
+      enabled: true,
+    },
+    {
+      id: "purchases",
+      label: "구매내역",
+      path: "/mypage/purchases",
+      enabled: false,
+    },
+    {
+      id: "accounts",
+      label: "계좌관리",
+      path: "/mypage/accounts",
+      enabled: false,
+    },
+    {
+      id: "addresses",
+      label: "배송주소록",
+      path: "/mypage/addresses",
+      enabled: false,
+    },
+    {
+      id: "customer-service",
+      label: "고객센터",
+      path: "/mypage/customer-service",
+      enabled: false,
+    },
+    {
+      id: "reviews",
+      label: "리뷰관리",
+      path: "/mypage/reviews",
+      enabled: false,
+    },
+    {
+      id: "seller",
+      label: "판매자 바로가기",
+      path: "/seller",
+      enabled: false,
+    },
+    {
+      id: "withdraw",
+      label: "회원탈퇴",
+      path: "/mypage/withdraw",
+      enabled: false,
+    },
+  ];
+
+  const handleMenuClick = (item: typeof menuItems[0]) => {
+    if (item.enabled) {
+      navigate(item.path);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-8">마이페이지</h1>
+
+        <div className="space-y-2">
+          {menuItems.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => handleMenuClick(item)}
+              disabled={!item.enabled}
+              className={`
+                w-full text-left px-4 py-4 bg-white rounded-lg
+                border border-gray-200
+                transition-all duration-200
+                ${
+                  item.enabled
+                    ? "hover:bg-indigo-50 hover:border-indigo-200 cursor-pointer"
+                    : "opacity-60 cursor-not-allowed"
+                }
+              `}
+            >
+              <span
+                className={`text-base ${
+                  item.enabled ? "text-gray-900" : "text-gray-500"
+                }`}
+              >
+                {item.label}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyPage;
+

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -50,7 +50,7 @@ const MyPage = () => {
       id: "accounts",
       label: "계좌관리",
       path: "/mypage/accounts",
-      enabled: false,
+      enabled: true,
       icon: (
         <svg
           className="w-5 h-5"

--- a/frontend/src/pages/NoticeDetailPage.tsx
+++ b/frontend/src/pages/NoticeDetailPage.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { customerService } from "services/customerService";
+import { toast } from "react-toastify";
+import type { NoticeDetailResponseDto } from "types/CustomerServiceTypes";
+import { formatDateSimple } from "utils/formatters";
+
+const NoticeDetailPage = () => {
+  const navigate = useNavigate();
+  const { noticeId } = useParams<{ noticeId: string }>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [notice, setNotice] = useState<NoticeDetailResponseDto | null>(null);
+
+  useEffect(() => {
+    if (noticeId) {
+      loadNoticeDetail();
+    }
+  }, [noticeId]);
+
+  const loadNoticeDetail = async () => {
+    if (!noticeId) return;
+
+    try {
+      setIsLoading(true);
+      const data = await customerService.getNoticeDetail(noticeId);
+      setNotice(data);
+    } catch (error: any) {
+      console.error("공지사항 상세 조회 실패:", error);
+      toast.error("공지사항 상세 정보를 불러오는데 실패했습니다.");
+      navigate("/mypage/customer-service/notices");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage/customer-service/notices");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (!notice) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            고객센터 - 공지사항
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 공지사항 상세 */}
+        <div className="bg-gray-50 rounded-lg p-4 shadow-sm border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            {notice.title}
+          </h2>
+
+          <div className="text-xs text-gray-500 mb-4 space-y-1">
+            <div>게시일 {formatDateSimple(notice.createdAt)}</div>
+            {notice.adminNickname && (
+              <div>작성자 {notice.adminNickname}</div>
+            )}
+          </div>
+
+          <div className="text-sm text-gray-700 whitespace-pre-wrap">
+            {notice.content}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NoticeDetailPage;
+

--- a/frontend/src/pages/NoticeDetailPage.tsx
+++ b/frontend/src/pages/NoticeDetailPage.tsx
@@ -4,6 +4,7 @@ import { customerService } from "services/customerService";
 import { toast } from "react-toastify";
 import type { NoticeDetailResponseDto } from "types/CustomerServiceTypes";
 import { formatDateSimple } from "utils/formatters";
+import { logError } from "utils/errorUtils";
 
 const NoticeDetailPage = () => {
   const navigate = useNavigate();
@@ -24,9 +25,13 @@ const NoticeDetailPage = () => {
       setIsLoading(true);
       const data = await customerService.getNoticeDetail(noticeId);
       setNotice(data);
-    } catch (error: any) {
-      console.error("공지사항 상세 조회 실패:", error);
-      toast.error("공지사항 상세 정보를 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      logError("공지사항 상세 조회 실패:", error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("공지사항 상세 정보를 불러오는데 실패했습니다.");
+      }
       navigate("/mypage/customer-service/notices");
     } finally {
       setIsLoading(false);

--- a/frontend/src/pages/NoticeListPage.tsx
+++ b/frontend/src/pages/NoticeListPage.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { customerService } from "services/customerService";
+import { toast } from "react-toastify";
+import type { NoticeResponseDto, Page } from "types/CustomerServiceTypes";
+import { formatDateSimple } from "utils/formatters";
+
+const NoticeListPage = () => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [noticesPage, setNoticesPage] = useState<Page<NoticeResponseDto>>({
+    content: [],
+    totalElements: 0,
+    totalPages: 0,
+    size: 10,
+    number: 0,
+    first: true,
+    last: true,
+  });
+
+  useEffect(() => {
+    loadNotices();
+  }, [currentPage]);
+
+  const loadNotices = async () => {
+    try {
+      setIsLoading(true);
+      const data = await customerService.getNotices(currentPage, 10);
+      setNoticesPage(data);
+    } catch (error: any) {
+      console.error("공지사항 목록 조회 실패:", error);
+      toast.error("공지사항 목록을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage/customer-service");
+  };
+
+  const handleNoticeClick = (noticeId: string) => {
+    navigate(`/mypage/customer-service/notices/${noticeId}`);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 0 && newPage < noticesPage.totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-8">
+        {/* 헤더 */}
+        <div className="flex items-center mb-8">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            고객센터 - 공지사항
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 공지사항 목록 */}
+        <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
+          {isLoading ? (
+            <div className="text-center py-8 text-gray-500">로딩 중...</div>
+          ) : noticesPage.content.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              등록된 공지사항이 없습니다.
+            </div>
+          ) : (
+            <>
+              <div className="space-y-3 mb-4">
+                {noticesPage.content.map((notice) => (
+                  <div
+                    key={notice.id}
+                    onClick={() => handleNoticeClick(notice.id)}
+                    className="bg-gray-50 rounded-lg p-4 cursor-pointer hover:bg-gray-100 transition-colors"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1">
+                        <div className="font-medium text-gray-900 mb-1">
+                          {notice.title}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {formatDateSimple(notice.createdAt)}
+                        </div>
+                      </div>
+                      <svg
+                        className="w-5 h-5 text-gray-400 ml-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 페이징 컨트롤 */}
+              {noticesPage.totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 pt-4 border-t border-gray-200">
+                  <button
+                    onClick={() => handlePageChange(currentPage - 1)}
+                    disabled={noticesPage.first}
+                    className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    aria-label="이전 페이지"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 19l-7-7 7-7"
+                      />
+                    </svg>
+                  </button>
+                  <span className="text-sm text-gray-700">
+                    {currentPage + 1}/{noticesPage.totalPages}
+                  </span>
+                  <button
+                    onClick={() => handlePageChange(currentPage + 1)}
+                    disabled={noticesPage.last}
+                    className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    aria-label="다음 페이지"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NoticeListPage;
+

--- a/frontend/src/pages/NoticeListPage.tsx
+++ b/frontend/src/pages/NoticeListPage.tsx
@@ -4,6 +4,7 @@ import { customerService } from "services/customerService";
 import { toast } from "react-toastify";
 import type { NoticeResponseDto, Page } from "types/CustomerServiceTypes";
 import { formatDateSimple } from "utils/formatters";
+import { logError } from "utils/errorUtils";
 
 const NoticeListPage = () => {
   const navigate = useNavigate();
@@ -28,9 +29,13 @@ const NoticeListPage = () => {
       setIsLoading(true);
       const data = await customerService.getNotices(currentPage, 10);
       setNoticesPage(data);
-    } catch (error: any) {
-      console.error("공지사항 목록 조회 실패:", error);
-      toast.error("공지사항 목록을 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      logError("공지사항 목록 조회 실패:", error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("공지사항 목록을 불러오는데 실패했습니다.");
+      }
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -14,7 +14,6 @@ const ProfilePage = () => {
     username: "",
     name: "",
     nickname: "",
-    email: "",
     phone: "",
   });
 
@@ -39,7 +38,6 @@ const ProfilePage = () => {
         username: data.username || "",
         name: data.name || "",
         nickname: data.nickname || "",
-        email: "",
         phone: data.phone || "",
       });
     } catch (error: unknown) {
@@ -339,38 +337,6 @@ const ProfilePage = () => {
                 {errors.nickname && (
                   <p className="mt-0.5 text-xs text-red-600">{errors.nickname}</p>
                 )}
-              </div>
-            </div>
-          </div>
-
-          {/* 이메일 */}
-          <div className="bg-white rounded-lg p-2.5 shadow-sm border border-purple-100">
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center flex-shrink-0">
-                <svg
-                  className="w-4 h-4 text-indigo-500"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                  />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <label className="block text-xs font-medium text-gray-700 mb-0.5">
-                  이메일
-                </label>
-                <input
-                  type="email"
-                  value={formData.email || "이메일 정보 없음"}
-                  disabled
-                  className="w-full bg-gray-50 text-gray-500 border-0 focus:outline-none cursor-not-allowed text-sm"
-                />
               </div>
             </div>
           </div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,496 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { mypageService } from "services/mypageService";
+import { toast } from "react-toastify";
+import type { ProfileUpdateRequestDto } from "types/MyPageTypes";
+
+const ProfilePage = () => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingProfile, setIsLoadingProfile] = useState(true);
+
+  const [formData, setFormData] = useState({
+    username: "",
+    name: "",
+    nickname: "",
+    email: "",
+    phone: "",
+  });
+
+  const [errors, setErrors] = useState({
+    name: "",
+    nickname: "",
+    phone: "",
+  });
+
+  const [verificationCode, setVerificationCode] = useState("");
+  const [isVerificationSent, setIsVerificationSent] = useState(false);
+
+  useEffect(() => {
+    loadProfile();
+  }, []);
+
+  const loadProfile = async () => {
+    try {
+      setIsLoadingProfile(true);
+      const data = await mypageService.getProfile();
+      setFormData({
+        username: data.username || "",
+        name: data.name || "",
+        nickname: data.nickname || "",
+        email: "",
+        phone: data.phone || "",
+      });
+    } catch (error: any) {
+      console.error("프로필 조회 실패:", error);
+      toast.error("프로필 정보를 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoadingProfile(false);
+    }
+  };
+
+  const validateName = (name: string): string => {
+    if (!name.trim()) return "이름을 입력해주세요.";
+    if (name.trim().length > 50) return "이름은 50자 이하여야 합니다.";
+    return "";
+  };
+
+  const validateNickname = (nickname: string): string => {
+    const nicknameRegex = /^[가-힣a-zA-Z0-9_-]+$/;
+    if (!nickname.trim()) return "닉네임을 입력해주세요.";
+    if (nickname.length < 2 || nickname.length > 10) {
+      return "닉네임은 2자 이상 10자 이하여야 합니다.";
+    }
+    if (!nicknameRegex.test(nickname)) {
+      return "닉네임은 한글, 영문, 숫자, _, -만 사용 가능합니다.";
+    }
+    return "";
+  };
+
+  const validatePhone = (phone: string): string => {
+    const phoneRegex = /^[0-9]+$/;
+    if (phone && phone.trim()) {
+      if (phone.length < 10 || phone.length > 11) {
+        return "휴대폰 번호는 10자리 또는 11자리여야 합니다.";
+      }
+      if (!phoneRegex.test(phone)) {
+        return "휴대폰 번호는 숫자만 입력 가능합니다.";
+      }
+    }
+    return "";
+  };
+
+  const handleInputChange = (field: keyof typeof formData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+
+    let error = "";
+    switch (field) {
+      case "name":
+        error = validateName(value);
+        break;
+      case "nickname":
+        error = validateNickname(value);
+        break;
+      case "phone":
+        error = validatePhone(value);
+        break;
+    }
+
+    setErrors((prev) => ({ ...prev, [field]: error }));
+  };
+
+  const handleSendVerification = () => {
+    const phoneError = validatePhone(formData.phone);
+    if (phoneError) {
+      setErrors((prev) => ({ ...prev, phone: phoneError }));
+      toast.error("올바른 휴대폰 번호를 입력해주세요.");
+      return;
+    }
+
+    toast.info("문자인증 기능은 준비 중입니다.");
+    setIsVerificationSent(true);
+  };
+
+  const handleVerifyCode = () => {
+    toast.info("인증확인 기능은 준비 중입니다.");
+  };
+
+  const handleUpdate = async () => {
+    const nameError = validateName(formData.name);
+    const nicknameError = validateNickname(formData.nickname);
+    const phoneError = validatePhone(formData.phone);
+
+    if (nameError || nicknameError || phoneError) {
+      setErrors({
+        name: nameError,
+        nickname: nicknameError,
+        phone: phoneError,
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const updateData: ProfileUpdateRequestDto = {
+        name: formData.name.trim() || null,
+        nickname: formData.nickname.trim() || null,
+        phone: formData.phone.trim() || null,
+      };
+
+      await mypageService.updateProfile(updateData);
+      toast.success("프로필이 수정되었습니다.");
+      navigate("/mypage");
+    } catch (error: any) {
+      console.error("프로필 수정 실패:", error);
+      const errorMessage =
+        error.response?.data?.message || "프로필 수정에 실패했습니다.";
+      toast.error(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage");
+  };
+
+  if (isLoadingProfile) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-200 via-purple-100 to-blue-200 flex items-center justify-center">
+        <div className="text-gray-600">로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-200 via-purple-100 to-blue-200">
+      <div className="max-w-md mx-auto px-4 py-4">
+        {/* 헤더 */}
+        <div className="flex items-center mb-10">
+          <button
+            onClick={handleBack}
+            className="text-indigo-600 hover:text-indigo-700 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            프로필
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 프로필 사진 영역 */}
+        <div className="flex justify-center mb-10">
+          <div className="relative">
+            <div className="w-32 h-32 bg-white rounded-full flex items-center justify-center shadow-lg">
+              <svg
+                className="w-20 h-20 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                />
+              </svg>
+            </div>
+            <button
+              className="absolute bottom-0 right-0 w-10 h-10 bg-indigo-500 rounded-full flex items-center justify-center shadow-lg hover:bg-indigo-600 transition-colors"
+              onClick={() => toast.info("프로필 사진 변경 기능은 준비 중입니다.")}
+            >
+              <svg
+                className="w-5 h-5 text-white"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* 입력 필드들 */}
+        <div className="space-y-2">
+          {/* 아이디 */}
+          <div className="bg-white rounded-lg p-2.5 shadow-sm border border-purple-100">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <svg
+                  className="w-4 h-4 text-indigo-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gray-700 mb-0.5">
+                  아이디
+                </label>
+                <input
+                  type="text"
+                  value={formData.username}
+                  disabled
+                  className="w-full bg-gray-50 text-gray-500 border-0 focus:outline-none cursor-not-allowed text-sm"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 이름 */}
+          <div className="bg-white rounded-lg p-2.5 shadow-sm border border-purple-100">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <svg
+                  className="w-4 h-4 text-indigo-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gray-700 mb-0.5">
+                  이름
+                </label>
+                <input
+                  type="text"
+                  placeholder="이름을 입력해주세요"
+                  value={formData.name}
+                  onChange={(e) => handleInputChange("name", e.target.value)}
+                  className={`w-full border-0 focus:outline-none focus:ring-0 p-0 text-sm ${
+                    errors.name ? "text-red-600" : ""
+                  }`}
+                />
+                {errors.name && (
+                  <p className="mt-0.5 text-xs text-red-600">{errors.name}</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 닉네임 */}
+          <div className="bg-white rounded-lg p-2.5 shadow-sm border border-purple-100">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <svg
+                  className="w-4 h-4 text-indigo-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gray-700 mb-0.5">
+                  닉네임
+                </label>
+                <input
+                  type="text"
+                  placeholder="닉네임을 입력해주세요"
+                  value={formData.nickname}
+                  onChange={(e) => handleInputChange("nickname", e.target.value)}
+                  className={`w-full border-0 focus:outline-none focus:ring-0 p-0 text-sm ${
+                    errors.nickname ? "text-red-600" : ""
+                  }`}
+                />
+                {errors.nickname && (
+                  <p className="mt-0.5 text-xs text-red-600">{errors.nickname}</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 이메일 */}
+          <div className="bg-white rounded-lg p-2.5 shadow-sm border border-purple-100">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <svg
+                  className="w-4 h-4 text-indigo-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gray-700 mb-0.5">
+                  이메일
+                </label>
+                <input
+                  type="email"
+                  value={formData.email || "이메일 정보 없음"}
+                  disabled
+                  className="w-full bg-gray-50 text-gray-500 border-0 focus:outline-none cursor-not-allowed text-sm"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 휴대폰 번호 */}
+          <div className="bg-white rounded-lg p-2.5 shadow-sm border border-purple-100">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <svg
+                  className="w-4 h-4 text-indigo-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gray-700 mb-0.5">
+                  휴대폰 번호
+                </label>
+                <div className="flex gap-1.5">
+                  <input
+                    type="tel"
+                    placeholder="00000000000"
+                    value={formData.phone}
+                    onChange={(e) => handleInputChange("phone", e.target.value)}
+                    className={`flex-1 border-0 focus:outline-none focus:ring-0 p-0 text-sm ${
+                      errors.phone ? "text-red-600" : ""
+                    }`}
+                  />
+                  <button
+                    onClick={handleSendVerification}
+                    className="px-2 py-1 bg-indigo-500 text-white rounded-md text-xs font-medium hover:bg-indigo-600 transition-colors whitespace-nowrap"
+                  >
+                    문자인증
+                  </button>
+                </div>
+                {errors.phone && (
+                  <p className="mt-0.5 text-xs text-red-600">{errors.phone}</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 인증 번호 */}
+          <div className="bg-white rounded-lg p-2.5 shadow-sm border border-purple-100">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center flex-shrink-0">
+                <svg
+                  className="w-4 h-4 text-indigo-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                  />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gray-700 mb-0.5">
+                  인증 번호
+                </label>
+                <div className="flex gap-1.5">
+                  <input
+                    type="text"
+                    placeholder="000000"
+                    value={verificationCode}
+                    onChange={(e) => setVerificationCode(e.target.value)}
+                    disabled={!isVerificationSent}
+                    className={`flex-1 border-0 focus:outline-none focus:ring-0 p-0 text-sm ${
+                      !isVerificationSent
+                        ? "bg-gray-50 text-gray-400 cursor-not-allowed"
+                        : ""
+                    }`}
+                  />
+                  <button
+                    onClick={handleVerifyCode}
+                    disabled={!isVerificationSent}
+                    className="px-2 py-1 bg-indigo-500 text-white rounded-md text-xs font-medium hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                  >
+                    인증확인
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 버튼들 */}
+        <div className="flex gap-2 mt-4">
+          <button
+            onClick={handleBack}
+            className="flex-1 px-3 py-2 bg-white text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors border border-gray-200"
+          >
+            뒤로가기
+          </button>
+          <button
+            onClick={handleUpdate}
+            disabled={isLoading}
+            className="flex-1 px-3 py-2 bg-indigo-500 text-white rounded-lg text-sm font-medium hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? "수정 중..." : "수정"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { mypageService } from "services/mypageService";
 import { toast } from "react-toastify";
 import type { ProfileUpdateRequestDto } from "types/MyPageTypes";
+import { logError } from "utils/errorUtils";
 
 const ProfilePage = () => {
   const navigate = useNavigate();
@@ -41,9 +42,10 @@ const ProfilePage = () => {
         email: "",
         phone: data.phone || "",
       });
-    } catch (error: any) {
-      console.error("프로필 조회 실패:", error);
-      toast.error("프로필 정보를 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      logError("프로필 조회 실패:", error);
+      const msg = error instanceof Error ? error.message : String(error);
+      toast.error(msg || "프로필 정보를 불러오는데 실패했습니다.");
     } finally {
       setIsLoadingProfile(false);
     }
@@ -140,10 +142,25 @@ const ProfilePage = () => {
       await mypageService.updateProfile(updateData);
       toast.success("프로필이 수정되었습니다.");
       navigate("/mypage");
-    } catch (error: any) {
-      console.error("프로필 수정 실패:", error);
-      const errorMessage =
-        error.response?.data?.message || "프로필 수정에 실패했습니다.";
+    } catch (error: unknown) {
+      logError("프로필 수정 실패:", error);
+      let errorMessage = "프로필 수정에 실패했습니다.";
+      if (
+        error &&
+        typeof error === "object" &&
+        "response" in error &&
+        error.response &&
+        typeof error.response === "object" &&
+        "data" in error.response &&
+        error.response.data &&
+        typeof error.response.data === "object" &&
+        "message" in error.response.data &&
+        typeof error.response.data.message === "string"
+      ) {
+        errorMessage = error.response.data.message;
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
       toast.error(errorMessage);
     } finally {
       setIsLoading(false);

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -44,8 +44,6 @@ const ProfilePage = () => {
       });
     } catch (error: unknown) {
       logError("프로필 조회 실패:", error);
-      const msg = error instanceof Error ? error.message : String(error);
-      toast.error(msg || "프로필 정보를 불러오는데 실패했습니다.");
     } finally {
       setIsLoadingProfile(false);
     }
@@ -144,24 +142,6 @@ const ProfilePage = () => {
       navigate("/mypage");
     } catch (error: unknown) {
       logError("프로필 수정 실패:", error);
-      let errorMessage = "프로필 수정에 실패했습니다.";
-      if (
-        error &&
-        typeof error === "object" &&
-        "response" in error &&
-        error.response &&
-        typeof error.response === "object" &&
-        "data" in error.response &&
-        error.response.data &&
-        typeof error.response.data === "object" &&
-        "message" in error.response.data &&
-        typeof error.response.data.message === "string"
-      ) {
-        errorMessage = error.response.data.message;
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      toast.error(errorMessage);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -55,11 +55,12 @@ const ProfilePage = () => {
 
   const validateNickname = (nickname: string): string => {
     const nicknameRegex = /^[가-힣a-zA-Z0-9_-]+$/;
-    if (!nickname.trim()) return "닉네임을 입력해주세요.";
-    if (nickname.length < 2 || nickname.length > 10) {
+    const trimmedNickname = nickname.trim();
+    if (!trimmedNickname) return "닉네임을 입력해주세요.";
+    if (trimmedNickname.length < 2 || trimmedNickname.length > 10) {
       return "닉네임은 2자 이상 10자 이하여야 합니다.";
     }
-    if (!nicknameRegex.test(nickname)) {
+    if (!nicknameRegex.test(trimmedNickname)) {
       return "닉네임은 한글, 영문, 숫자, _, -만 사용 가능합니다.";
     }
     return "";

--- a/frontend/src/pages/PurchaseDetailPage.tsx
+++ b/frontend/src/pages/PurchaseDetailPage.tsx
@@ -27,8 +27,6 @@ const PurchaseDetailPage = () => {
       setPurchaseDetail(data);
     } catch (error: unknown) {
       logError("구매내역 상세 조회 실패:", error);
-      const msg = error instanceof Error ? error.message : String(error);
-      toast.error(`구매내역 상세 정보를 불러오는데 실패했습니다: ${msg}`);
       navigate("/mypage/purchases");
     } finally {
       setIsLoading(false);

--- a/frontend/src/pages/PurchaseDetailPage.tsx
+++ b/frontend/src/pages/PurchaseDetailPage.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { mypageService } from "services/mypageService";
+import { toast } from "react-toastify";
+import type { PurchaseDetailResponseDto } from "types/MyPageTypes";
+
+const PurchaseDetailPage = () => {
+  const navigate = useNavigate();
+  const { contractId } = useParams<{ contractId: string }>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [purchaseDetail, setPurchaseDetail] =
+    useState<PurchaseDetailResponseDto | null>(null);
+
+  useEffect(() => {
+    if (contractId) {
+      loadPurchaseDetail();
+    }
+  }, [contractId]);
+
+  const loadPurchaseDetail = async () => {
+    if (!contractId) return;
+
+    try {
+      setIsLoading(true);
+      const data = await mypageService.getPurchaseDetail(contractId);
+      setPurchaseDetail(data);
+    } catch (error: any) {
+      console.error("구매내역 상세 조회 실패:", error);
+      toast.error("구매내역 상세 정보를 불러오는데 실패했습니다.");
+      navigate("/mypage/purchases");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage/purchases");
+  };
+
+  const handleReviewClick = () => {
+    if (!purchaseDetail?.canReview) {
+      toast.info("후기를 작성할 수 없는 구매내역입니다.");
+      return;
+    }
+    navigate(`/mypage/purchases/${contractId}/review`);
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${year}년${month}월${day}일 ${hours}:${minutes}`;
+  };
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat("ko-KR").format(price) + "원";
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-600">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (!purchaseDetail) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-600">구매내역을 찾을 수 없습니다.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-4">
+        {/* 헤더 */}
+        <div className="flex items-center mb-6">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            구매내역 상세
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        <div className="space-y-4">
+          {/* 거래 상태 */}
+          <div className="bg-white rounded-lg p-4 border border-gray-200">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-gray-600">거래 상태</span>
+              <span
+                className={`px-3 py-1 rounded-full text-sm font-medium ${
+                  purchaseDetail.status === "거래완료"
+                    ? "bg-green-100 text-green-700"
+                    : purchaseDetail.status === "취소/환불"
+                    ? "bg-red-100 text-red-700"
+                    : "bg-yellow-100 text-yellow-700"
+                }`}
+              >
+                {purchaseDetail.status}
+              </span>
+            </div>
+          </div>
+
+          {/* 상품 정보 */}
+          <div className="bg-white rounded-lg p-4 border border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              상품 정보
+            </h2>
+            <div className="flex gap-4 mb-4">
+              {/* 상품 이미지 */}
+              <div className="w-24 h-24 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                {purchaseDetail.productImageUrl ? (
+                  <img
+                    src={purchaseDetail.productImageUrl}
+                    alt={purchaseDetail.productName}
+                    className="w-full h-full object-cover rounded-lg"
+                  />
+                ) : (
+                  <svg
+                    className="w-12 h-12 text-gray-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
+                  </svg>
+                )}
+              </div>
+
+              {/* 상품 상세 정보 */}
+              <div className="flex-1">
+                <div className="text-base font-semibold text-gray-900 mb-2">
+                  {purchaseDetail.productName}
+                </div>
+                <div className="space-y-1 text-sm text-gray-600">
+                  <div>
+                    브랜드: {purchaseDetail.productInfo.brand}{" "}
+                    {purchaseDetail.productInfo.model}
+                  </div>
+                  {purchaseDetail.productInfo.storage && (
+                    <div>용량: {purchaseDetail.productInfo.storage}</div>
+                  )}
+                  {purchaseDetail.productInfo.color && (
+                    <div>색상: {purchaseDetail.productInfo.color}</div>
+                  )}
+                  <div>통신사: {purchaseDetail.productInfo.carrier}</div>
+                </div>
+                <div className="text-lg font-bold text-gray-900 mt-3">
+                  {formatPrice(purchaseDetail.price)}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 거래 정보 */}
+          <div className="bg-white rounded-lg p-4 border border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              거래 정보
+            </h2>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">거래일시</span>
+                <span className="text-sm text-gray-900">
+                  {formatDate(purchaseDetail.transactionDate)}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">계약번호</span>
+                <span className="text-sm text-gray-900 font-mono">
+                  {purchaseDetail.contractId.substring(0, 8)}...
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* 판매자 정보 */}
+          {purchaseDetail.sellerInfo && (
+            <div className="bg-white rounded-lg p-4 border border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                판매자 정보
+              </h2>
+              <div className="space-y-3">
+                <div className="flex justify-between">
+                  <span className="text-sm text-gray-600">판매자명</span>
+                  <span className="text-sm text-gray-900">
+                    {purchaseDetail.sellerInfo.sellerName}
+                  </span>
+                </div>
+                {purchaseDetail.sellerInfo.rating !== null && (
+                  <div className="flex justify-between">
+                    <span className="text-sm text-gray-600">평점</span>
+                    <span className="text-sm text-gray-900">
+                      ⭐ {purchaseDetail.sellerInfo.rating.toFixed(1)}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* 결제 정보 */}
+          {purchaseDetail.paymentInfo && (
+            <div className="bg-white rounded-lg p-4 border border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                결제 정보
+              </h2>
+              <div className="space-y-3">
+                <div className="flex justify-between">
+                  <span className="text-sm text-gray-600">결제 수단</span>
+                  <span className="text-sm text-gray-900">
+                    {purchaseDetail.paymentInfo.method}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-sm text-gray-600">결제일시</span>
+                  <span className="text-sm text-gray-900">
+                    {formatDate(purchaseDetail.paymentInfo.paidAt)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-sm text-gray-600">결제 금액</span>
+                  <span className="text-sm font-semibold text-gray-900">
+                    {formatPrice(purchaseDetail.price)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* 배송 정보 */}
+          {purchaseDetail.deliveryInfo && (
+            <div className="bg-white rounded-lg p-4 border border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">
+                배송 정보
+              </h2>
+              <div className="space-y-3">
+                <div className="flex justify-between">
+                  <span className="text-sm text-gray-600">배송 상태</span>
+                  <span className="text-sm text-gray-900">
+                    {purchaseDetail.deliveryInfo.status}
+                  </span>
+                </div>
+                {purchaseDetail.deliveryInfo.trackingNumber && (
+                  <div className="flex justify-between">
+                    <span className="text-sm text-gray-600">송장번호</span>
+                    <span className="text-sm text-gray-900 font-mono">
+                      {purchaseDetail.deliveryInfo.trackingNumber}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* 후기 남기기 버튼 */}
+          {purchaseDetail.canReview && (
+            <button
+              onClick={handleReviewClick}
+              className="w-full px-4 py-3 bg-indigo-500 text-white rounded-lg text-base font-medium hover:bg-indigo-600 transition-colors"
+            >
+              후기 남기기
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PurchaseDetailPage;
+

--- a/frontend/src/pages/PurchaseDetailPage.tsx
+++ b/frontend/src/pages/PurchaseDetailPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { mypageService } from "services/mypageService";
 import { toast } from "react-toastify";
 import type { PurchaseDetailResponseDto } from "types/MyPageTypes";
+import { logError } from "utils/errorUtils";
 
 const PurchaseDetailPage = () => {
   const navigate = useNavigate();
@@ -24,9 +25,10 @@ const PurchaseDetailPage = () => {
       setIsLoading(true);
       const data = await mypageService.getPurchaseDetail(contractId);
       setPurchaseDetail(data);
-    } catch (error: any) {
-      console.error("구매내역 상세 조회 실패:", error);
-      toast.error("구매내역 상세 정보를 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      logError("구매내역 상세 조회 실패:", error);
+      const msg = error instanceof Error ? error.message : String(error);
+      toast.error(`구매내역 상세 정보를 불러오는데 실패했습니다: ${msg}`);
       navigate("/mypage/purchases");
     } finally {
       setIsLoading(false);

--- a/frontend/src/pages/PurchaseHistoryPage.tsx
+++ b/frontend/src/pages/PurchaseHistoryPage.tsx
@@ -7,6 +7,7 @@ import type {
   Page,
 } from "types/MyPageTypes";
 import { logError } from "utils/errorUtils";
+import { formatDateKorean, formatPrice } from "utils/formatters";
 
 const PurchaseHistoryPage = () => {
   const navigate = useNavigate();
@@ -52,18 +53,6 @@ const PurchaseHistoryPage = () => {
       return;
     }
     navigate(`/mypage/purchases/${contractId}/review`);
-  };
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}년${month}월${day}일`;
-  };
-
-  const formatPrice = (price: number) => {
-    return new Intl.NumberFormat("ko-KR").format(price) + "원";
   };
 
   if (isLoading) {
@@ -143,7 +132,7 @@ const PurchaseHistoryPage = () => {
                       {purchase.productName}
                     </div>
                     <div className="text-sm text-gray-500">
-                      {formatDate(purchase.transactionDate)}
+                      {formatDateKorean(purchase.transactionDate)}
                     </div>
                   </div>
                   <span

--- a/frontend/src/pages/PurchaseHistoryPage.tsx
+++ b/frontend/src/pages/PurchaseHistoryPage.tsx
@@ -28,8 +28,6 @@ const PurchaseHistoryPage = () => {
       setPurchaseHistory(data);
     } catch (error: unknown) {
       logError("구매내역 조회 실패:", error);
-      const msg = error instanceof Error ? error.message : String(error);
-      toast.error(`구매내역을 불러오는데 실패했습니다: ${msg}`);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/pages/PurchaseHistoryPage.tsx
+++ b/frontend/src/pages/PurchaseHistoryPage.tsx
@@ -6,6 +6,7 @@ import type {
   PurchaseHistoryResponseDto,
   Page,
 } from "types/MyPageTypes";
+import { logError } from "utils/errorUtils";
 
 const PurchaseHistoryPage = () => {
   const navigate = useNavigate();
@@ -25,9 +26,10 @@ const PurchaseHistoryPage = () => {
       setIsLoading(true);
       const data = await mypageService.getPurchaseHistory(activeFilter);
       setPurchaseHistory(data);
-    } catch (error: any) {
-      console.error("구매내역 조회 실패:", error);
-      toast.error("구매내역을 불러오는데 실패했습니다.");
+    } catch (error: unknown) {
+      logError("구매내역 조회 실패:", error);
+      const msg = error instanceof Error ? error.message : String(error);
+      toast.error(`구매내역을 불러오는데 실패했습니다: ${msg}`);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/pages/PurchaseHistoryPage.tsx
+++ b/frontend/src/pages/PurchaseHistoryPage.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { mypageService } from "services/mypageService";
+import { toast } from "react-toastify";
+import type {
+  PurchaseHistoryResponseDto,
+  Page,
+} from "types/MyPageTypes";
+
+const PurchaseHistoryPage = () => {
+  const navigate = useNavigate();
+  const [activeFilter, setActiveFilter] = useState<"COMPLETED" | "CANCELLED">(
+    "COMPLETED"
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [purchaseHistory, setPurchaseHistory] =
+    useState<Page<PurchaseHistoryResponseDto> | null>(null);
+
+  useEffect(() => {
+    loadPurchaseHistory();
+  }, [activeFilter]);
+
+  const loadPurchaseHistory = async () => {
+    try {
+      setIsLoading(true);
+      const data = await mypageService.getPurchaseHistory(activeFilter);
+      setPurchaseHistory(data);
+    } catch (error: any) {
+      console.error("구매내역 조회 실패:", error);
+      toast.error("구매내역을 불러오는데 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage");
+  };
+
+  const handlePurchaseClick = (contractId: string) => {
+    navigate(`/mypage/purchases/${contractId}`);
+  };
+
+  const handleReviewClick = (
+    e: React.MouseEvent,
+    contractId: string,
+    canReview: boolean
+  ) => {
+    e.stopPropagation();
+    if (!canReview) {
+      toast.info("후기를 작성할 수 없는 구매내역입니다.");
+      return;
+    }
+    navigate(`/mypage/purchases/${contractId}/review`);
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}년${month}월${day}일`;
+  };
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat("ko-KR").format(price) + "원";
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-600">로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto px-4 py-4">
+        {/* 헤더 */}
+        <div className="flex items-center mb-6">
+          <button
+            onClick={handleBack}
+            className="text-gray-700 hover:text-gray-900 mr-4"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className="text-xl font-bold text-gray-900 flex-1 text-center">
+            구매내역
+          </h1>
+          <div className="w-9"></div>
+        </div>
+
+        {/* 필터 버튼 */}
+        <div className="flex gap-2 mb-6">
+          <button
+            onClick={() => setActiveFilter("COMPLETED")}
+            className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              activeFilter === "COMPLETED"
+                ? "bg-gray-800 text-white"
+                : "bg-white text-gray-700 border border-gray-300"
+            }`}
+          >
+            구매완료
+          </button>
+          <button
+            onClick={() => setActiveFilter("CANCELLED")}
+            className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              activeFilter === "CANCELLED"
+                ? "bg-gray-800 text-white"
+                : "bg-white text-gray-700 border border-gray-300"
+            }`}
+          >
+            취소/환불
+          </button>
+        </div>
+
+        {/* 구매내역 목록 */}
+        {purchaseHistory && purchaseHistory.content.length > 0 ? (
+          <div className="space-y-4">
+            {purchaseHistory.content.map((purchase) => (
+              <div
+                key={purchase.contractId}
+                onClick={() => handlePurchaseClick(purchase.contractId)}
+                className="bg-white rounded-lg p-4 border border-gray-200 cursor-pointer hover:shadow-md transition-shadow"
+              >
+                {/* 상품명과 날짜, 상태 */}
+                <div className="flex items-start justify-between mb-3">
+                  <div className="flex-1">
+                    <div className="text-base font-semibold text-gray-900 mb-1">
+                      {purchase.productName}
+                    </div>
+                    <div className="text-sm text-gray-500">
+                      {formatDate(purchase.transactionDate)}
+                    </div>
+                  </div>
+                  <span
+                    className={`px-2 py-1 rounded text-xs font-medium ${
+                      purchase.status === "거래완료"
+                        ? "bg-gray-100 text-gray-700"
+                        : "bg-red-100 text-red-700"
+                    }`}
+                  >
+                    {purchase.status}
+                  </span>
+                </div>
+
+                {/* 상품 이미지 및 정보 */}
+                <div className="flex gap-3 mb-3">
+                  {/* 상품 이미지 */}
+                  <div className="w-20 h-20 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                    {purchase.productImageUrl ? (
+                      <img
+                        src={purchase.productImageUrl}
+                        alt={purchase.productName}
+                        className="w-full h-full object-cover rounded-lg"
+                      />
+                    ) : (
+                      <svg
+                        className="w-10 h-10 text-gray-400"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                        />
+                      </svg>
+                    )}
+                  </div>
+
+                  {/* 상품 정보 */}
+                  <div className="flex-1 bg-gray-50 rounded-lg p-3">
+                    <div className="text-sm text-gray-700 mb-1">
+                      {purchase.productInfo.brand} {purchase.productInfo.model}
+                    </div>
+                    {purchase.productInfo.storage && (
+                      <div className="text-sm text-gray-600 mb-1">
+                        용량: {purchase.productInfo.storage}
+                      </div>
+                    )}
+                    {purchase.productInfo.color && (
+                      <div className="text-sm text-gray-600 mb-1">
+                        색상: {purchase.productInfo.color}
+                      </div>
+                    )}
+                    <div className="text-sm text-gray-600 mb-1">
+                      통신사: {purchase.productInfo.carrier}
+                    </div>
+                    <div className="text-base font-semibold text-gray-900 mt-2">
+                      {formatPrice(purchase.price)}
+                    </div>
+                  </div>
+                </div>
+
+                {/* 후기 남기기 버튼 */}
+                {purchase.canReview && (
+                  <button
+                    onClick={(e) =>
+                      handleReviewClick(e, purchase.contractId, purchase.canReview)
+                    }
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    후기 남기기
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-lg p-8 text-center">
+            <div className="text-gray-500 text-sm">
+              {activeFilter === "COMPLETED"
+                ? "구매완료된 내역이 없습니다."
+                : "취소/환불된 내역이 없습니다."}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PurchaseHistoryPage;
+

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -49,8 +49,8 @@ class ApiClient {
 
         // 토큰 관련 에러 처리 (401, 403)
         if (errorCode === 401 || errorCode === 403) {
-          // 인증 확인용 요청(/users/profile)이거나 이미 로그인 페이지에 있으면 forceLogout 호출 안 함
-          const isAuthCheckRequest = requestUrl.includes("/users/profile");
+          // 인증 확인용 요청(/mypage/profile)이거나 이미 로그인 페이지에 있으면 forceLogout 호출 안 함
+          const isAuthCheckRequest = requestUrl.includes("/mypage/profile");
           const isOnLoginPage = window.location.pathname === "/login";
 
           if (!isAuthCheckRequest && !isOnLoginPage) {

--- a/frontend/src/services/customerService.ts
+++ b/frontend/src/services/customerService.ts
@@ -1,0 +1,92 @@
+import { apiClient } from "./apiClient";
+import type {
+  InquiryCreateRequestDto,
+  InquiryResponseDto,
+  InquiryDetailResponseDto,
+  NoticeResponseDto,
+  NoticeDetailResponseDto,
+  FaqResponseDto,
+  FaqDetailResponseDto,
+  Page,
+  FaqCategory,
+} from "types/CustomerServiceTypes";
+
+export const customerService = {
+  // 1:1 문의
+  createInquiry: async (
+    data: InquiryCreateRequestDto
+  ): Promise<void> => {
+    return await apiClient.post<void>(
+      "/mypage/customerservice/inquiries",
+      data
+    );
+  },
+
+  getMyInquiries: async (
+    page: number = 0,
+    size: number = 10
+  ): Promise<Page<InquiryResponseDto>> => {
+    const params = new URLSearchParams({
+      page: page.toString(),
+      size: size.toString(),
+    });
+    return await apiClient.get<Page<InquiryResponseDto>>(
+      `/mypage/customerservice/inquiries/my?${params.toString()}`
+    );
+  },
+
+  getInquiryDetail: async (
+    inquiryId: string
+  ): Promise<InquiryDetailResponseDto> => {
+    return await apiClient.get<InquiryDetailResponseDto>(
+      `/mypage/customerservice/inquiries/${inquiryId}`
+    );
+  },
+
+  // 공지사항
+  getNotices: async (
+    page: number = 0,
+    size: number = 10
+  ): Promise<Page<NoticeResponseDto>> => {
+    const params = new URLSearchParams({
+      page: page.toString(),
+      size: size.toString(),
+    });
+    return await apiClient.get<Page<NoticeResponseDto>>(
+      `/mypage/customerservice/notices?${params.toString()}`
+    );
+  },
+
+  getNoticeDetail: async (
+    noticeId: string
+  ): Promise<NoticeDetailResponseDto> => {
+    return await apiClient.get<NoticeDetailResponseDto>(
+      `/mypage/customerservice/notices/${noticeId}`
+    );
+  },
+
+  // FAQ
+  getFaqs: async (
+    category: FaqCategory | null = null,
+    page: number = 0,
+    size: number = 10
+  ): Promise<Page<FaqResponseDto>> => {
+    const params = new URLSearchParams({
+      page: page.toString(),
+      size: size.toString(),
+    });
+    if (category) {
+      params.append("category", category);
+    }
+    return await apiClient.get<Page<FaqResponseDto>>(
+      `/mypage/customerservice/faqs?${params.toString()}`
+    );
+  },
+
+  getFaqDetail: async (faqId: string): Promise<FaqDetailResponseDto> => {
+    return await apiClient.get<FaqDetailResponseDto>(
+      `/mypage/customerservice/faqs/${faqId}`
+    );
+  },
+};
+

--- a/frontend/src/services/mypageService.ts
+++ b/frontend/src/services/mypageService.ts
@@ -2,6 +2,9 @@ import { apiClient } from "./apiClient";
 import type {
   ProfileResponseDto,
   ProfileUpdateRequestDto,
+  PurchaseHistoryResponseDto,
+  PurchaseDetailResponseDto,
+  Page,
 } from "types/MyPageTypes";
 
 export const mypageService = {
@@ -13,6 +16,29 @@ export const mypageService = {
     data: ProfileUpdateRequestDto
   ): Promise<void> => {
     return await apiClient.put<void>("/mypage/profile", data);
+  },
+
+  getPurchaseHistory: async (
+    status: "COMPLETED" | "CANCELLED" = "COMPLETED",
+    page: number = 0,
+    size: number = 10
+  ): Promise<Page<PurchaseHistoryResponseDto>> => {
+    const params = new URLSearchParams({
+      status,
+      page: page.toString(),
+      size: size.toString(),
+    });
+    return await apiClient.get<Page<PurchaseHistoryResponseDto>>(
+      `/mypage/purchases?${params.toString()}`
+    );
+  },
+
+  getPurchaseDetail: async (
+    contractId: string
+  ): Promise<PurchaseDetailResponseDto> => {
+    return await apiClient.get<PurchaseDetailResponseDto>(
+      `/mypage/purchases/${contractId}`
+    );
   },
 };
 

--- a/frontend/src/services/mypageService.ts
+++ b/frontend/src/services/mypageService.ts
@@ -4,6 +4,8 @@ import type {
   ProfileUpdateRequestDto,
   PurchaseHistoryResponseDto,
   PurchaseDetailResponseDto,
+  AccountCreateRequestDto,
+  AccountResponseDto,
   Page,
 } from "types/MyPageTypes";
 
@@ -39,6 +41,29 @@ export const mypageService = {
     return await apiClient.get<PurchaseDetailResponseDto>(
       `/mypage/purchases/${contractId}`
     );
+  },
+
+  createAccount: async (
+    data: AccountCreateRequestDto
+  ): Promise<void> => {
+    return await apiClient.post<void>("/mypage/accounts", data);
+  },
+
+  getAccounts: async (
+    page: number = 0,
+    size: number = 10
+  ): Promise<Page<AccountResponseDto>> => {
+    const params = new URLSearchParams({
+      page: page.toString(),
+      size: size.toString(),
+    });
+    return await apiClient.get<Page<AccountResponseDto>>(
+      `/mypage/accounts?${params.toString()}`
+    );
+  },
+
+  deleteAccount: async (accountId: string): Promise<void> => {
+    return await apiClient.delete<void>(`/mypage/accounts/${accountId}`);
   },
 };
 

--- a/frontend/src/services/mypageService.ts
+++ b/frontend/src/services/mypageService.ts
@@ -1,0 +1,18 @@
+import { apiClient } from "./apiClient";
+import type {
+  ProfileResponseDto,
+  ProfileUpdateRequestDto,
+} from "types/MyPageTypes";
+
+export const mypageService = {
+  getProfile: async (): Promise<ProfileResponseDto> => {
+    return await apiClient.get<ProfileResponseDto>("/mypage/profile");
+  },
+
+  updateProfile: async (
+    data: ProfileUpdateRequestDto
+  ): Promise<void> => {
+    return await apiClient.put<void>("/mypage/profile", data);
+  },
+};
+

--- a/frontend/src/services/mypageService.ts
+++ b/frontend/src/services/mypageService.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "./apiClient";
+import { toast } from "react-toastify";
 import type {
   ProfileResponseDto,
   ProfileUpdateRequestDto,
@@ -8,16 +9,36 @@ import type {
   AccountResponseDto,
   Page,
 } from "types/MyPageTypes";
+import { logError } from "utils/errorUtils";
+
+// API 엔드포인트 상수화
+const ENDPOINTS = {
+  PROFILE: "/mypage/profile",
+  PURCHASES: "/mypage/purchases",
+  ACCOUNTS: "/mypage/accounts",
+} as const;
 
 export const mypageService = {
   getProfile: async (): Promise<ProfileResponseDto> => {
-    return await apiClient.get<ProfileResponseDto>("/mypage/profile");
+    try {
+      return await apiClient.get<ProfileResponseDto>(ENDPOINTS.PROFILE);
+    } catch (error: unknown) {
+      logError("프로필 조회 실패:", error);
+      toast.error("프로필 정보를 불러오는데 실패했습니다.");
+      throw error;
+    }
   },
 
   updateProfile: async (
     data: ProfileUpdateRequestDto
   ): Promise<void> => {
-    return await apiClient.put<void>("/mypage/profile", data);
+    try {
+      return await apiClient.put<void>(ENDPOINTS.PROFILE, data);
+    } catch (error: unknown) {
+      logError("프로필 수정 실패:", error);
+      toast.error("프로필 수정에 실패했습니다.");
+      throw error;
+    }
   },
 
   getPurchaseHistory: async (
@@ -25,45 +46,75 @@ export const mypageService = {
     page: number = 0,
     size: number = 10
   ): Promise<Page<PurchaseHistoryResponseDto>> => {
-    const params = new URLSearchParams({
-      status,
-      page: page.toString(),
-      size: size.toString(),
-    });
-    return await apiClient.get<Page<PurchaseHistoryResponseDto>>(
-      `/mypage/purchases?${params.toString()}`
-    );
+    try {
+      const params = new URLSearchParams({
+        status,
+        page: page.toString(),
+        size: size.toString(),
+      });
+      return await apiClient.get<Page<PurchaseHistoryResponseDto>>(
+        `${ENDPOINTS.PURCHASES}?${params.toString()}`
+      );
+    } catch (error: unknown) {
+      logError("구매내역 조회 실패:", error);
+      toast.error("구매내역을 불러오는데 실패했습니다.");
+      throw error;
+    }
   },
 
   getPurchaseDetail: async (
     contractId: string
   ): Promise<PurchaseDetailResponseDto> => {
-    return await apiClient.get<PurchaseDetailResponseDto>(
-      `/mypage/purchases/${contractId}`
-    );
+    try {
+      return await apiClient.get<PurchaseDetailResponseDto>(
+        `${ENDPOINTS.PURCHASES}/${contractId}`
+      );
+    } catch (error: unknown) {
+      logError("구매내역 상세 조회 실패:", error);
+      toast.error("구매내역 상세 정보를 불러오는데 실패했습니다.");
+      throw error;
+    }
   },
 
   createAccount: async (
     data: AccountCreateRequestDto
   ): Promise<void> => {
-    return await apiClient.post<void>("/mypage/accounts", data);
+    try {
+      return await apiClient.post<void>(ENDPOINTS.ACCOUNTS, data);
+    } catch (error: unknown) {
+      logError("계좌 등록 실패:", error);
+      toast.error("계좌 등록에 실패했습니다.");
+      throw error;
+    }
   },
 
   getAccounts: async (
     page: number = 0,
     size: number = 10
   ): Promise<Page<AccountResponseDto>> => {
-    const params = new URLSearchParams({
-      page: page.toString(),
-      size: size.toString(),
-    });
-    return await apiClient.get<Page<AccountResponseDto>>(
-      `/mypage/accounts?${params.toString()}`
-    );
+    try {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        size: size.toString(),
+      });
+      return await apiClient.get<Page<AccountResponseDto>>(
+        `${ENDPOINTS.ACCOUNTS}?${params.toString()}`
+      );
+    } catch (error: unknown) {
+      logError("계좌 목록 조회 실패:", error);
+      toast.error("계좌 목록을 불러오는데 실패했습니다.");
+      throw error;
+    }
   },
 
   deleteAccount: async (accountId: string): Promise<void> => {
-    return await apiClient.delete<void>(`/mypage/accounts/${accountId}`);
+    try {
+      return await apiClient.delete<void>(`${ENDPOINTS.ACCOUNTS}/${accountId}`);
+    } catch (error: unknown) {
+      logError("계좌 삭제 실패:", error);
+      toast.error("계좌 삭제에 실패했습니다.");
+      throw error;
+    }
   },
 };
 

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -97,7 +97,7 @@ export const useAuthStore = create<AuthStore>()(
         checkAuth: async () => {
           try {
             // 쿠키에 토큰이 있는지 확인하기 위해 프로필 API 호출
-            const profile = await apiClient.get<ProfileResponseDto>("/users/profile");
+            const profile = await apiClient.get<ProfileResponseDto>("/mypage/profile");
             
             const user: User = {
               username: profile.username,

--- a/frontend/src/types/CustomerServiceTypes.ts
+++ b/frontend/src/types/CustomerServiceTypes.ts
@@ -1,47 +1,54 @@
-export enum InquiryCategory {
-  PAYMENT = "PAYMENT",
-  DELIVERY = "DELIVERY",
-  ACCOUNT = "ACCOUNT",
-  PRODUCT = "PRODUCT",
-  ETC = "ETC",
-}
+export const INQUIRY_CATEGORY = {
+  PAYMENT: "PAYMENT",
+  DELIVERY: "DELIVERY",
+  ACCOUNT: "ACCOUNT",
+  PRODUCT: "PRODUCT",
+  ETC: "ETC",
+} as const;
+
+export type InquiryCategory =
+  typeof INQUIRY_CATEGORY[keyof typeof INQUIRY_CATEGORY];
 
 export const INQUIRY_CATEGORY_LABELS: Record<InquiryCategory, string> = {
-  [InquiryCategory.PAYMENT]: "결제",
-  [InquiryCategory.DELIVERY]: "배송",
-  [InquiryCategory.ACCOUNT]: "계정",
-  [InquiryCategory.PRODUCT]: "상품",
-  [InquiryCategory.ETC]: "기타",
+  [INQUIRY_CATEGORY.PAYMENT]: "결제",
+  [INQUIRY_CATEGORY.DELIVERY]: "배송",
+  [INQUIRY_CATEGORY.ACCOUNT]: "계정",
+  [INQUIRY_CATEGORY.PRODUCT]: "상품",
+  [INQUIRY_CATEGORY.ETC]: "기타",
 };
 
-export enum InquiryStatus {
-  PENDING = "PENDING",
-  ANSWERED = "ANSWERED",
-  CLOSED = "CLOSED",
-}
+export const INQUIRY_STATUS = {
+  PENDING: "PENDING",
+  ANSWERED: "ANSWERED",
+  CLOSED: "CLOSED",
+} as const;
+
+export type InquiryStatus = typeof INQUIRY_STATUS[keyof typeof INQUIRY_STATUS];
 
 export const INQUIRY_STATUS_LABELS: Record<InquiryStatus, string> = {
-  [InquiryStatus.PENDING]: "대기중",
-  [InquiryStatus.ANSWERED]: "답변완료",
-  [InquiryStatus.CLOSED]: "종료",
+  [INQUIRY_STATUS.PENDING]: "대기중",
+  [INQUIRY_STATUS.ANSWERED]: "답변완료",
+  [INQUIRY_STATUS.CLOSED]: "종료",
 };
 
-export enum FaqCategory {
-  SERVICE = "SERVICE",
-  PAYMENT = "PAYMENT",
-  DELIVERY = "DELIVERY",
-  ACCOUNT = "ACCOUNT",
-  PRODUCT = "PRODUCT",
-  ETC = "ETC",
-}
+export const FAQ_CATEGORY = {
+  SERVICE: "SERVICE",
+  PAYMENT: "PAYMENT",
+  DELIVERY: "DELIVERY",
+  ACCOUNT: "ACCOUNT",
+  PRODUCT: "PRODUCT",
+  ETC: "ETC",
+} as const;
+
+export type FaqCategory = typeof FAQ_CATEGORY[keyof typeof FAQ_CATEGORY];
 
 export const FAQ_CATEGORY_LABELS: Record<FaqCategory, string> = {
-  [FaqCategory.SERVICE]: "서비스 이용",
-  [FaqCategory.PAYMENT]: "결제/환불",
-  [FaqCategory.DELIVERY]: "배송",
-  [FaqCategory.ACCOUNT]: "계정",
-  [FaqCategory.PRODUCT]: "상품",
-  [FaqCategory.ETC]: "기타",
+  [FAQ_CATEGORY.SERVICE]: "서비스 이용",
+  [FAQ_CATEGORY.PAYMENT]: "결제/환불",
+  [FAQ_CATEGORY.DELIVERY]: "배송",
+  [FAQ_CATEGORY.ACCOUNT]: "계정",
+  [FAQ_CATEGORY.PRODUCT]: "상품",
+  [FAQ_CATEGORY.ETC]: "기타",
 };
 
 export interface InquiryCreateRequestDto {

--- a/frontend/src/types/CustomerServiceTypes.ts
+++ b/frontend/src/types/CustomerServiceTypes.ts
@@ -1,0 +1,129 @@
+export enum InquiryCategory {
+  PAYMENT = "PAYMENT",
+  DELIVERY = "DELIVERY",
+  ACCOUNT = "ACCOUNT",
+  PRODUCT = "PRODUCT",
+  ETC = "ETC",
+}
+
+export const INQUIRY_CATEGORY_LABELS: Record<InquiryCategory, string> = {
+  [InquiryCategory.PAYMENT]: "결제",
+  [InquiryCategory.DELIVERY]: "배송",
+  [InquiryCategory.ACCOUNT]: "계정",
+  [InquiryCategory.PRODUCT]: "상품",
+  [InquiryCategory.ETC]: "기타",
+};
+
+export enum InquiryStatus {
+  PENDING = "PENDING",
+  ANSWERED = "ANSWERED",
+  CLOSED = "CLOSED",
+}
+
+export const INQUIRY_STATUS_LABELS: Record<InquiryStatus, string> = {
+  [InquiryStatus.PENDING]: "대기중",
+  [InquiryStatus.ANSWERED]: "답변완료",
+  [InquiryStatus.CLOSED]: "종료",
+};
+
+export enum FaqCategory {
+  SERVICE = "SERVICE",
+  PAYMENT = "PAYMENT",
+  DELIVERY = "DELIVERY",
+  ACCOUNT = "ACCOUNT",
+  PRODUCT = "PRODUCT",
+  ETC = "ETC",
+}
+
+export const FAQ_CATEGORY_LABELS: Record<FaqCategory, string> = {
+  [FaqCategory.SERVICE]: "서비스 이용",
+  [FaqCategory.PAYMENT]: "결제/환불",
+  [FaqCategory.DELIVERY]: "배송",
+  [FaqCategory.ACCOUNT]: "계정",
+  [FaqCategory.PRODUCT]: "상품",
+  [FaqCategory.ETC]: "기타",
+};
+
+export interface InquiryCreateRequestDto {
+  category: InquiryCategory;
+  title: string;
+  content: string;
+}
+
+export interface InquiryResponseDto {
+  id: string;
+  category: InquiryCategory;
+  title: string;
+  status: InquiryStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InquiryReplyDto {
+  id: string;
+  content: string;
+  adminNickname: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InquiryDetailResponseDto {
+  id: string;
+  category: InquiryCategory;
+  title: string;
+  content: string;
+  status: InquiryStatus;
+  createdAt: string;
+  updatedAt: string;
+  reply: InquiryReplyDto | null;
+}
+
+export interface NoticeResponseDto {
+  id: string;
+  title: string;
+  isImportant: boolean;
+  viewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NoticeDetailResponseDto {
+  id: string;
+  title: string;
+  content: string;
+  isImportant: boolean;
+  viewCount: number;
+  adminNickname: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FaqResponseDto {
+  id: string;
+  category: FaqCategory;
+  question: string;
+  viewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FaqDetailResponseDto {
+  id: string;
+  category: FaqCategory;
+  question: string;
+  answer: string;
+  viewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Page<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+}
+

--- a/frontend/src/types/MyPageTypes.ts
+++ b/frontend/src/types/MyPageTypes.ts
@@ -1,0 +1,13 @@
+export interface ProfileResponseDto {
+  username: string;
+  nickname: string;
+  phone: string | null;
+  name: string;
+}
+
+export interface ProfileUpdateRequestDto {
+  name?: string | null;
+  nickname?: string | null;
+  phone?: string | null;
+}
+

--- a/frontend/src/types/MyPageTypes.ts
+++ b/frontend/src/types/MyPageTypes.ts
@@ -11,3 +11,61 @@ export interface ProfileUpdateRequestDto {
   phone?: string | null;
 }
 
+export interface ProductInfoDto {
+  brand: string;
+  model: string;
+  storage: string | null;
+  color: string | null;
+  carrier: string;
+}
+
+export interface PurchaseHistoryResponseDto {
+  contractId: string;
+  productName: string;
+  transactionDate: string;
+  productImageUrl: string | null;
+  productInfo: ProductInfoDto;
+  price: number;
+  status: string;
+  canReview: boolean;
+}
+
+export interface Page<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+}
+
+export interface SellerInfoDto {
+  sellerName: string;
+  rating: number | null;
+}
+
+export interface PaymentInfoDto {
+  method: string;
+  paidAt: string;
+}
+
+export interface DeliveryInfoDto {
+  status: string;
+  trackingNumber: string | null;
+}
+
+export interface PurchaseDetailResponseDto {
+  contractId: string;
+  productName: string;
+  transactionDate: string;
+  productImageUrl: string | null;
+  productInfo: ProductInfoDto;
+  price: number;
+  status: string;
+  sellerInfo: SellerInfoDto;
+  paymentInfo: PaymentInfoDto | null;
+  deliveryInfo: DeliveryInfoDto | null;
+  canReview: boolean;
+}
+

--- a/frontend/src/types/MyPageTypes.ts
+++ b/frontend/src/types/MyPageTypes.ts
@@ -69,3 +69,35 @@ export interface PurchaseDetailResponseDto {
   canReview: boolean;
 }
 
+export interface AccountCreateRequestDto {
+  bankName: string;
+  accountNumber: string;
+  accountHolderName: string;
+}
+
+export interface AccountResponseDto {
+  accountId: string;
+  bankName: string;
+  accountNumber: string;
+  accountHolderName: string;
+  createdAt: string;
+}
+
+export const BANK_LIST = [
+  "KB국민은행",
+  "신한은행",
+  "하나은행",
+  "우리은행",
+  "NH농협은행",
+  "IBK기업은행",
+  "카카오뱅크",
+  "토스뱅크",
+  "KEB하나은행",
+  "SC제일은행",
+  "한국씨티은행",
+  "KDB산업은행",
+  "저축은행",
+  "우체국",
+  "수협은행",
+] as const;
+

--- a/frontend/src/utils/errorUtils.ts
+++ b/frontend/src/utils/errorUtils.ts
@@ -1,0 +1,53 @@
+/**
+ * 에러 메시지를 안전하게 추출하는 헬퍼 함수
+ * @param error - 알 수 없는 타입의 에러 객체
+ * @returns 사용자에게 표시할 안전한 에러 메시지
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || "알 수 없는 오류가 발생했습니다.";
+  }
+  
+  if (typeof error === "string") {
+    return error;
+  }
+  
+  // Axios 에러 응답 처리
+  if (
+    error &&
+    typeof error === "object" &&
+    "response" in error &&
+    error.response &&
+    typeof error.response === "object" &&
+    "data" in error.response &&
+    error.response.data &&
+    typeof error.response.data === "object" &&
+    "message" in error.response.data &&
+    typeof error.response.data.message === "string"
+  ) {
+    return error.response.data.message;
+  }
+  
+  try {
+    return String(error);
+  } catch {
+    return "알 수 없는 오류가 발생했습니다.";
+  }
+}
+
+/**
+ * 에러를 로깅하는 함수
+ * 프로덕션 환경에서는 Sentry 등으로 교체 가능
+ * @param message - 로그 메시지
+ * @param error - 에러 객체
+ */
+export function logError(message: string, error: unknown): void {
+  // 개발 환경에서는 console.error 사용
+  if (process.env.NODE_ENV === "development") {
+    console.error(message, error);
+  }
+  
+  // 프로덕션 환경에서는 여기에 Sentry.captureException 등을 추가할 수 있습니다
+  // 예: if (window.Sentry) { window.Sentry.captureException(error); }
+}
+

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -119,3 +119,14 @@ export const formatChatDate = (dateString: string): string => {
     });
   }
 };
+
+/**
+ * 날짜를 yyyy.MM.dd 형식으로 포맷팅
+ */
+export const formatDateSimple = (date: string | Date): string => {
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  const year = dateObj.getFullYear();
+  const month = String(dateObj.getMonth() + 1).padStart(2, "0");
+  const day = String(dateObj.getDate()).padStart(2, "0");
+  return `${year}.${month}.${day}`;
+};

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -130,3 +130,21 @@ export const formatDateSimple = (date: string | Date): string => {
   const day = String(dateObj.getDate()).padStart(2, "0");
   return `${year}.${month}.${day}`;
 };
+
+/**
+ * 날짜를 yyyy년MM월dd일 형식으로 포맷팅
+ */
+export const formatDateKorean = (date: string | Date): string => {
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  const year = dateObj.getFullYear();
+  const month = String(dateObj.getMonth() + 1).padStart(2, "0");
+  const day = String(dateObj.getDate()).padStart(2, "0");
+  return `${year}년${month}월${day}일`;
+};
+
+/**
+ * 가격을 한국 통화 형식으로 포맷팅 (숫자 + "원")
+ */
+export const formatPrice = (price: number): string => {
+  return new Intl.NumberFormat("ko-KR").format(price) + "원";
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #77.

## 📝작업 내용

> 각 권한 별 마이페이지 도메인 프론트엔드 화면 구현

**1. 프로필 화면**
프로필 조회 및 수정 가능 (이름, 닉네임, 핸드폰 번호 필드만 수정 가능)

**2. 계좌 관리 기능**
- AccountManagementPage.tsx: 계좌 등록/삭제/조회
- 은행명 드롭다운 (15개 은행)
- 계좌번호, 예금주 입력 필드
- 입력 유효성 검사 (백엔드 규칙과 일치)
- 계좌 목록 페이징 (페이지당 1개, 좌우 화살표로 이동)
- 계좌 삭제 기능 (확인 다이얼로그)

**3. 고객센터 기능**
- CustomerServicePage.tsx: 고객센터 메인 메뉴
- 1:1 문의, 공지사항, FAQ 메뉴 존재

**4. 타입 및 서비스**
- CustomerServiceTypes.ts: 고객센터 관련 타입 정의
- Inquiry, Notice, FAQ DTO 타입
- 카테고리 및 상태 enum
- customerService.ts: 고객센터 API 서비스 함수
- MyPageTypes.ts: 계좌 관련 타입 추가
- mypageService.ts: 계좌 API 서비스 함수 추가

**5. 유틸리티**
formatters.ts: formatDateSimple 함수 추가 (yyyy.MM.dd 형식)

**6. 라우팅**
- 마이페이지 관련 모든 경로 추가
- MyPage에서 프로필, 계좌관리, 고객센터 메뉴 활성화

## 주요 특징
- 모바일 우선 반응형 디자인
- 입력 유효성 검사 및 에러 처리
- 페이징 처리 (계좌 목록은 페이지당 1개)
- 날짜 포맷팅 (yyyy.MM.dd)
- 백엔드 API와 연동 완료
- 프로필에서 '이메일' 필드 삭제

## 참고 사항 및 추가 구현 사항 ✨
- 피그마 와이어프레임 참고하여 디자인 구현
- 프로필 사진 업로드 기능 구현 필요 (AWS S3 연동)
- 프로필에서 핸드폰 번호 변경 시 번호인증 기능 구현 필요 (현재는 ui만 구현 된 상태)