### PR TITLE
Feature/mypage delivery

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -31,6 +31,7 @@ import MyQuotesPage from "pages/MyQuotesPage";
 import QuoteDetailPage from "pages/QuoteDetailPage";
 import BidDetailPage from "pages/BidDetailPage";
 import DeliveryAddressPage from "pages/DeliveryAddressPage";
+import DeliveryAddressListPage from "pages/DeliveryAddressListPage";
 import PurchaseCompletePage from "pages/PurchaseCompletePage";
 
 export const AppRouter: React.FC = () => {
@@ -54,6 +55,7 @@ export const AppRouter: React.FC = () => {
           element={<PurchaseDetailPage />}
         />
         <Route path="/mypage/accounts" element={<AccountManagementPage />} />
+        <Route path="/mypage/addresses" element={<DeliveryAddressListPage />} />
         <Route path="/mypage/quotes" element={<MyQuotesPage />} />
         <Route path="/mypage/quotes/:quoteId" element={<QuoteDetailPage />} />
         <Route path="/mypage/quotes/:quoteId/bids/:bidId" element={<BidDetailPage />} />

--- a/frontend/src/components/delivery/DeliveryAddressCard.tsx
+++ b/frontend/src/components/delivery/DeliveryAddressCard.tsx
@@ -1,0 +1,145 @@
+import type { DeliveryAddressResponseDto } from "types/MyPageTypes";
+
+interface DeliveryAddressCardProps {
+  address: DeliveryAddressResponseDto;
+  onSetDefault: (addressId: string) => void;
+  onDelete: (addressId: string) => void;
+}
+
+const DeliveryAddressCard = ({
+  address,
+  onSetDefault,
+  onDelete,
+}: DeliveryAddressCardProps) => {
+  const isDefault = address.isDefault;
+  const cardClassName = isDefault
+    ? "border-2 border-indigo-200 bg-indigo-50 rounded-lg p-5 space-y-4"
+    : "border border-gray-200 bg-white rounded-lg p-5 space-y-4";
+
+  return (
+    <div className={cardClassName}>
+      {/* 배송지명과 기본 배송지 뱃지 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <svg
+            className={`w-5 h-5 ${isDefault ? "text-indigo-600" : "text-gray-600"}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+            />
+          </svg>
+          <h3 className="text-base font-bold text-gray-900">{address.addressName}</h3>
+        </div>
+        {isDefault && (
+          <span className="px-2 py-1 text-xs font-semibold text-indigo-700 bg-indigo-200 rounded-full">
+            기본 배송지
+          </span>
+        )}
+      </div>
+
+      {/* 배송지 정보 */}
+      <div className={`space-y-3 pt-2 ${isDefault ? "border-t border-indigo-200" : "border-t border-gray-200"}`}>
+        <div className="flex items-start gap-3">
+          <svg
+            className="w-5 h-5 text-gray-400 mt-0.5 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+            />
+          </svg>
+          <div className="flex-1">
+            <p className="text-xs text-gray-500 mb-0.5">받는사람</p>
+            <p className="text-sm font-medium text-gray-900">{address.recipientName}</p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <svg
+            className="w-5 h-5 text-gray-400 mt-0.5 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+            />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+          </svg>
+          <div className="flex-1">
+            <p className="text-xs text-gray-500 mb-0.5">주소</p>
+            <p className="text-sm text-gray-900 leading-relaxed">
+              <span className="text-gray-600">({address.postalCode})</span> {address.address}
+              {address.detailAddress && (
+                <>
+                  <br />
+                  <span className="text-gray-600">{address.detailAddress}</span>
+                </>
+              )}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <svg
+            className="w-5 h-5 text-gray-400 mt-0.5 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+            />
+          </svg>
+          <div className="flex-1">
+            <p className="text-xs text-gray-500 mb-0.5">연락처</p>
+            <p className="text-sm font-medium text-gray-900">{address.phone}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* 액션 버튼 */}
+      <div className="flex items-center justify-end gap-2 pt-3 border-t border-gray-200">
+        {!isDefault && (
+          <button
+            onClick={() => onSetDefault(address.addressId)}
+            className="px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50 rounded-lg transition-colors"
+          >
+            기본 배송지로 설정
+          </button>
+        )}
+        <button
+          onClick={() => onDelete(address.addressId)}
+          className="px-3 py-1.5 text-sm font-medium text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
+        >
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DeliveryAddressCard;
+

--- a/frontend/src/components/delivery/DeliveryAddressCard.tsx
+++ b/frontend/src/components/delivery/DeliveryAddressCard.tsx
@@ -121,22 +121,22 @@ const DeliveryAddressCard = ({
       </div>
 
       {/* 액션 버튼 */}
-      <div className="flex items-center justify-end gap-2 pt-3 border-t border-gray-200">
-        {!isDefault && (
+      {!isDefault && (
+        <div className="flex items-center justify-end gap-2 pt-3 border-t border-gray-200">
           <button
             onClick={() => onSetDefault(address.addressId)}
             className="px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50 rounded-lg transition-colors"
           >
             기본 배송지로 설정
           </button>
-        )}
-        <button
-          onClick={() => onDelete(address.addressId)}
-          className="px-3 py-1.5 text-sm font-medium text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
-        >
-          삭제
-        </button>
-      </div>
+          <button
+            onClick={() => onDelete(address.addressId)}
+            className="px-3 py-1.5 text-sm font-medium text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
+          >
+            삭제
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/DeliveryAddressListPage.tsx
+++ b/frontend/src/pages/DeliveryAddressListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { mypageService } from "services/mypageService";
 import { toast } from "react-toastify";
@@ -61,11 +61,7 @@ const DeliveryAddressListPage = () => {
 
   const [errors, setErrors] = useState<DeliveryFormErrors>({});
 
-  useEffect(() => {
-    loadAddresses();
-  }, [currentPage]);
-
-  const loadAddresses = async () => {
+  const loadAddresses = useCallback(async () => {
     try {
       setIsLoadingAddresses(true);
       const data = await mypageService.getDeliveryAddresses(currentPage, 10);
@@ -75,7 +71,11 @@ const DeliveryAddressListPage = () => {
     } finally {
       setIsLoadingAddresses(false);
     }
-  };
+  }, [currentPage]);
+
+  useEffect(() => {
+    loadAddresses();
+  }, [loadAddresses]);
 
   const validateForm = (): boolean => {
     const newErrors: DeliveryFormErrors = {};

--- a/frontend/src/pages/DeliveryAddressListPage.tsx
+++ b/frontend/src/pages/DeliveryAddressListPage.tsx
@@ -1,0 +1,335 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { mypageService } from "services/mypageService";
+import { toast } from "react-toastify";
+import type {
+  DeliveryAddressCreateRequestDto,
+  DeliveryAddressResponseDto,
+  Page,
+} from "types/MyPageTypes";
+import type { DeliveryFormData, DeliveryFormErrors } from "components/delivery/DeliveryAddressForm";
+import { logError } from "utils/errorUtils";
+import DeliveryAddressCard from "components/delivery/DeliveryAddressCard";
+import DeliveryAddressForm from "components/delivery/DeliveryAddressForm";
+import EmptyDeliveryAddressCard from "components/delivery/EmptyDeliveryAddressCard";
+
+declare global {
+  interface Window {
+    daum: {
+      Postcode: new (options: {
+        oncomplete: (data: {
+          zonecode: string;
+          address: string;
+          addressEnglish: string;
+          addressType: string;
+          bname: string;
+          buildingName: string;
+        }) => void;
+        width?: string;
+        height?: string;
+      }) => {
+        open: () => void;
+      };
+    };
+  }
+}
+
+const DeliveryAddressListPage = () => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingAddresses, setIsLoadingAddresses] = useState(true);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [addressesPage, setAddressesPage] = useState<Page<DeliveryAddressResponseDto>>({
+    content: [],
+    totalElements: 0,
+    totalPages: 0,
+    size: 10,
+    number: 0,
+    first: true,
+    last: true,
+  });
+
+  const [formData, setFormData] = useState<DeliveryFormData>({
+    addressName: "",
+    recipientName: "",
+    postalCode: "",
+    address: "",
+    detailAddress: "",
+    phone: "",
+    saveAsDefault: false,
+  });
+
+  const [errors, setErrors] = useState<DeliveryFormErrors>({});
+
+  useEffect(() => {
+    loadAddresses();
+  }, [currentPage]);
+
+  const loadAddresses = async () => {
+    try {
+      setIsLoadingAddresses(true);
+      const data = await mypageService.getDeliveryAddresses(currentPage, 10);
+      setAddressesPage(data);
+    } catch (error: unknown) {
+      logError("배송지 목록 조회 실패:", error);
+    } finally {
+      setIsLoadingAddresses(false);
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: DeliveryFormErrors = {};
+
+    if (!formData.addressName.trim()) {
+      newErrors.addressName = "배송지명을 입력해주세요.";
+    }
+    if (!formData.recipientName.trim()) {
+      newErrors.recipientName = "받는사람을 입력해주세요.";
+    }
+    if (!formData.postalCode.trim()) {
+      newErrors.postalCode = "주소를 검색해주세요.";
+    }
+    if (!formData.address.trim()) {
+      newErrors.address = "주소를 검색해주세요.";
+    }
+    if (!formData.phone.trim()) {
+      newErrors.phone = "연락처를 입력해주세요.";
+    } else if (!/^[0-9-]+$/.test(formData.phone)) {
+      newErrors.phone = "연락처는 숫자와 하이픈(-)만 입력 가능합니다.";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleInputChange = (field: keyof DeliveryFormData, value: string | boolean) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: "" }));
+    }
+  };
+
+  const handleAddressSearch = () => {
+    if (!window.daum || !window.daum.Postcode) {
+      toast.error("주소 검색 서비스를 불러올 수 없습니다.");
+      return;
+    }
+
+    new window.daum.Postcode({
+      oncomplete: (data) => {
+        setFormData((prev) => ({
+          ...prev,
+          postalCode: data.zonecode,
+          address: data.address,
+        }));
+      },
+      width: "100%",
+      height: "100%",
+    }).open();
+  };
+
+  const handleSubmit = async () => {
+    if (!validateForm()) {
+      toast.error("입력 정보를 확인해주세요.");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const requestData: DeliveryAddressCreateRequestDto = {
+        addressName: formData.addressName.trim(),
+        recipientName: formData.recipientName.trim(),
+        phone: formData.phone.trim(),
+        postalCode: formData.postalCode.trim(),
+        address: formData.address.trim(),
+        detailAddress: formData.detailAddress.trim() || undefined,
+        saveAsDefault: formData.saveAsDefault,
+      };
+
+      await mypageService.createDeliveryAddress(requestData);
+      toast.success("배송지가 등록되었습니다.");
+      setFormData({
+        addressName: "",
+        recipientName: "",
+        postalCode: "",
+        address: "",
+        detailAddress: "",
+        phone: "",
+        saveAsDefault: false,
+      });
+      setErrors({});
+      loadAddresses();
+    } catch (error: unknown) {
+      logError("배송지 등록 실패:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSetDefault = async (addressId: string) => {
+    try {
+      await mypageService.setDefaultDeliveryAddress(addressId);
+      toast.success("기본 배송지로 설정되었습니다.");
+      loadAddresses();
+    } catch (error: unknown) {
+      logError("기본 배송지 설정 실패:", error);
+    }
+  };
+
+  const handleDelete = async (addressId: string) => {
+    if (!window.confirm("정말 이 배송지를 삭제하시겠습니까?")) {
+      return;
+    }
+
+    try {
+      await mypageService.deleteDeliveryAddress(addressId);
+      toast.success("배송지가 삭제되었습니다.");
+      loadAddresses();
+    } catch (error: unknown) {
+      logError("배송지 삭제 실패:", error);
+    }
+  };
+
+  const handleBack = () => {
+    navigate("/mypage");
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 0 && newPage < addressesPage.totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-md mx-auto bg-white min-h-screen">
+        {/* 헤더 */}
+        <div className="sticky top-0 bg-white border-b border-gray-200 z-10">
+          <div className="flex items-center px-4 py-3">
+            <button
+              onClick={handleBack}
+              className="mr-3 text-gray-600 hover:text-gray-900"
+            >
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 19l-7-7 7-7"
+                />
+              </svg>
+            </button>
+            <h1 className="text-lg font-bold text-gray-900 flex-1">배송주소록</h1>
+            <div className="w-9"></div>
+          </div>
+        </div>
+
+        <div className="px-4 py-4 space-y-6">
+          {/* 배송지 등록 폼 */}
+          <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">배송지 등록</h2>
+
+            <DeliveryAddressForm
+              formData={formData}
+              errors={errors}
+              onInputChange={handleInputChange}
+              onAddressSearch={handleAddressSearch}
+            />
+
+            {/* 배송지 등록 버튼 */}
+            <button
+              onClick={handleSubmit}
+              disabled={isLoading}
+              className="w-full mt-4 px-4 py-2 bg-indigo-500 text-white text-sm font-semibold rounded-lg hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isLoading ? "등록 중..." : "배송지 등록"}
+            </button>
+          </div>
+
+          {/* 등록된 배송지 목록 */}
+          <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">등록된 배송지</h2>
+
+            {isLoadingAddresses ? (
+              <div className="text-center py-8 text-gray-500">로딩 중...</div>
+            ) : addressesPage.content.length === 0 ? (
+              <EmptyDeliveryAddressCard />
+            ) : (
+              <>
+                {/* 배송지 목록 */}
+                <div className="space-y-4 mb-4">
+                  {addressesPage.content.map((address) => (
+                    <DeliveryAddressCard
+                      key={address.addressId}
+                      address={address}
+                      onSetDefault={handleSetDefault}
+                      onDelete={handleDelete}
+                    />
+                  ))}
+                </div>
+
+                {/* 페이징 컨트롤 */}
+                {addressesPage.totalPages > 1 && (
+                  <div className="flex items-center justify-center gap-2 pt-4 border-t border-gray-200">
+                    <button
+                      onClick={() => handlePageChange(currentPage - 1)}
+                      disabled={addressesPage.first}
+                      className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                      aria-label="이전 페이지"
+                    >
+                      <svg
+                        className="w-5 h-5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 19l-7-7 7-7"
+                        />
+                      </svg>
+                    </button>
+                    <span className="text-sm text-gray-700">
+                      {currentPage + 1}/{addressesPage.totalPages}
+                    </span>
+                    <button
+                      onClick={() => handlePageChange(currentPage + 1)}
+                      disabled={addressesPage.last}
+                      className="bg-gray-100 rounded-lg p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                      aria-label="다음 페이지"
+                    >
+                      <svg
+                        className="w-5 h-5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeliveryAddressListPage;
+

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -92,7 +92,7 @@ const MyPage = () => {
       id: "addresses",
       label: "배송주소록",
       path: "/mypage/addresses",
-      enabled: false,
+      enabled: true,
       icon: (
         <svg
           className="w-5 h-5"

--- a/frontend/src/services/mypageService.ts
+++ b/frontend/src/services/mypageService.ts
@@ -148,5 +148,48 @@ export const mypageService = {
       throw error;
     }
   },
+
+  getDeliveryAddresses: async (
+    page: number = 0,
+    size: number = 10
+  ): Promise<Page<DeliveryAddressResponseDto>> => {
+    try {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        size: size.toString(),
+      });
+      return await apiClient.get<Page<DeliveryAddressResponseDto>>(
+        `${ENDPOINTS.DELIVERY_ADDRESSES}?${params.toString()}`
+      );
+    } catch (error: unknown) {
+      logError("배송지 목록 조회 실패:", error);
+      toast.error("배송지 목록을 불러오는데 실패했습니다.");
+      throw error;
+    }
+  },
+
+  setDefaultDeliveryAddress: async (addressId: string): Promise<void> => {
+    try {
+      return await apiClient.put<void>(
+        `${ENDPOINTS.DELIVERY_ADDRESSES}/${addressId}/set-default`
+      );
+    } catch (error: unknown) {
+      logError("기본 배송지 설정 실패:", error);
+      toast.error("기본 배송지 설정에 실패했습니다.");
+      throw error;
+    }
+  },
+
+  deleteDeliveryAddress: async (addressId: string): Promise<void> => {
+    try {
+      return await apiClient.delete<void>(
+        `${ENDPOINTS.DELIVERY_ADDRESSES}/${addressId}`
+      );
+    } catch (error: unknown) {
+      logError("배송지 삭제 실패:", error);
+      toast.error("배송지 삭제에 실패했습니다.");
+      throw error;
+    }
+  },
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #81. 

## 📝작업 내용

> 마이페이지 '배송주소록' 기능 프론트엔드 구현, 기존 사용했던 배송지 도메인 관련 컴포넌트들을 재사용했습니다.

**1. mypageService 확장** (frontend/src/services/mypageService.ts)

- getDeliveryAddresses: 배송지 목록 조회 (페이징)
- setDefaultDeliveryAddress: 기본 배송지 설정
- deleteDeliveryAddress: 배송지 삭제

**2. DeliveryAddressCard 컴포넌트 생성** (frontend/src/components/delivery/DeliveryAddressCard.tsx)

- 배송지 정보 표시
- 기본 배송지 뱃지 표시
- 기본 배송지 설정 버튼 (기본 배송지가 아닌 경우)
- 삭제 버튼

**3. DeliveryAddressListPage 생성** (frontend/src/pages/DeliveryAddressListPage.tsx)

- 배송지 목록 조회 및 표시 (페이징)
- 배송지 추가 폼 (기존 DeliveryAddressForm 재사용)
- 기본 배송지 설정 기능
- 배송지 삭제 기능
- 카카오 주소 검색 API 연동

**4. 라우터 설정 (frontend/src/app/router.tsx) 및 마이페이지 메뉴 활성화** (frontend/src/pages/MyPage.tsx)

- /mypage/addresses 경로 추가
- 배송주소록 메뉴 항목 활성화