### PR TITLE
feat: Implement AWS S3 file upload functionality and improve image management functionality

### DIFF
--- a/backend/src/main/java/com/phonebid/app/chat/controller/ChatImageController.java
+++ b/backend/src/main/java/com/phonebid/app/chat/controller/ChatImageController.java
@@ -1,0 +1,41 @@
+package com.phonebid.app.chat.controller;
+
+import com.phonebid.app.chat.dto.response.ChatImageUploadResponseDto;
+import com.phonebid.app.chat.service.ChatImageService;
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat")
+public class ChatImageController {
+
+    private final ChatImageService chatImageService;
+
+    /**
+     * 채팅 이미지 업로드
+     * 채팅방에 이미지를 업로드하고 URL을 반환합니다.
+     * 업로드된 URL은 WebSocket을 통해 메시지로 전송할 수 있습니다.
+     */
+    @PostMapping("/rooms/{chatRoomId}/images/upload")
+    public ResponseEntity<ApiResponse<ChatImageUploadResponseDto>> uploadChatImage(
+            @PathVariable UUID chatRoomId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam("file") MultipartFile file) {
+        
+        ChatImageUploadResponseDto responseDto = chatImageService.uploadChatImage(
+                chatRoomId, userDetails.getUser(), file);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "채팅 이미지 업로드가 성공적으로 완료되었습니다.", responseDto));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/chat/dto/response/ChatImageUploadResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/chat/dto/response/ChatImageUploadResponseDto.java
@@ -1,0 +1,19 @@
+package com.phonebid.app.chat.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatImageUploadResponseDto {
+    private String imageUrl;
+
+    public ChatImageUploadResponseDto(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public static ChatImageUploadResponseDto from(String imageUrl) {
+        return new ChatImageUploadResponseDto(imageUrl);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/chat/service/ChatImageService.java
+++ b/backend/src/main/java/com/phonebid/app/chat/service/ChatImageService.java
@@ -1,0 +1,128 @@
+package com.phonebid.app.chat.service;
+
+import com.phonebid.app.chat.domain.ChatRoom;
+import com.phonebid.app.chat.dto.response.ChatImageUploadResponseDto;
+import com.phonebid.app.chat.errorcode.ChatErrorCode;
+import com.phonebid.app.chat.repository.ChatRoomRepository;
+import com.phonebid.app.common.errorcode.MemberErrorCode;
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatImageService {
+
+    private final S3Service s3Service;
+    private final ChatRoomRepository chatRoomRepository;
+
+    private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList(
+            "jpg", "jpeg", "png", "gif", "webp", "JPG", "JPEG", "PNG", "GIF", "WEBP"
+    );
+
+    private static final long MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+
+    /**
+     * 채팅 이미지 업로드
+     * 채팅방에 이미지를 업로드하고 URL을 반환합니다.
+     */
+    @Transactional(readOnly = true)
+    public ChatImageUploadResponseDto uploadChatImage(UUID chatRoomId, User user, MultipartFile file) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        validateParticipant(chatRoom, user.getId());
+        validateImageFile(file);
+
+        try {
+            String fileName = generateChatImageFileName(chatRoomId, file.getOriginalFilename());
+            String imageUrl = s3Service.uploadFile(fileName, file);
+            return ChatImageUploadResponseDto.from(imageUrl);
+        } catch (IOException e) {
+            log.error("채팅 이미지 업로드 실패: {}", e.getMessage(), e);
+            throw new CustomException(MemberErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    /**
+     * 채팅방 참여자 검증
+     */
+    private void validateParticipant(ChatRoom chatRoom, UUID userId) {
+        boolean isParticipant = chatRoom.getConsumer().getId().equals(userId)
+                || chatRoom.getSeller().getUser().getId().equals(userId);
+
+        if (!isParticipant) {
+            throw new CustomException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+    }
+
+    /**
+     * 이미지 파일 검증
+     */
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(MemberErrorCode.MISSING_FILE);
+        }
+
+        if (file.getSize() > MAX_IMAGE_SIZE) {
+            throw new CustomException(MemberErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.trim().isEmpty()) {
+            throw new CustomException(MemberErrorCode.INVALID_FILE_NAME);
+        }
+
+        String extension = getFileExtension(originalFilename);
+        if (!ALLOWED_IMAGE_EXTENSIONS.contains(extension)) {
+            throw new CustomException(MemberErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return "";
+        }
+        return fileName.substring(lastDotIndex + 1);
+    }
+
+    /**
+     * 채팅 이미지 파일명 생성
+     */
+    private String generateChatImageFileName(UUID chatRoomId, String originalFilename) {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        String sanitizedFilename = sanitizeFilename(originalFilename);
+        return String.format("chat/%s/%s_%s", chatRoomId, timestamp, sanitizedFilename);
+    }
+
+    /**
+     * 파일명 보안 정리
+     */
+    private String sanitizeFilename(String filename) {
+        if (filename == null || filename.trim().isEmpty()) {
+            return "unnamed.jpg";
+        }
+        return filename.trim()
+                .replaceAll("[^a-zA-Z0-9가-힣._-]", "_")
+                .replaceAll("_{2,}", "_")
+                .replaceAll("^_+|_+$", "");
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/common/errorcode/PhoneErrorCode.java
+++ b/backend/src/main/java/com/phonebid/app/common/errorcode/PhoneErrorCode.java
@@ -15,7 +15,11 @@ public enum PhoneErrorCode implements ErrorCode {
 
     // 휴대폰 옵션 관련 에러
     PHONE_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "휴대폰 옵션을 찾을 수 없습니다."),
-    PHONE_OPTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 휴대폰 옵션이 존재합니다.");
+    PHONE_OPTION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 휴대폰 옵션이 존재합니다."),
+
+    // 휴대폰 모델 이미지 관련 에러
+    PHONE_MODEL_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "휴대폰 모델 이미지를 찾을 수 없습니다."),
+    PHONE_MODEL_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "휴대폰 모델 이미지는 최대 10개까지 업로드할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/phonebid/app/member/domain/User.java
+++ b/backend/src/main/java/com/phonebid/app/member/domain/User.java
@@ -70,8 +70,12 @@ public class User extends BaseEntity {
     @Comment("소셜 로그인 고유 ID")
     private String providerId;
 
+    @Column(name = "profile_image_url", nullable = true)
+    @Comment("프로필 사진 URL")
+    private String profileImageUrl;
+
     @Builder
-    public User(String username, String password, String email, String name, String nickname, String phone, Role role, Provider provider, String providerId) {
+    public User(String username, String password, String email, String name, String nickname, String phone, Role role, Provider provider, String providerId, String profileImageUrl) {
         this.username = username;
         this.password = password;
         this.email = email;
@@ -81,6 +85,7 @@ public class User extends BaseEntity {
         this.role = role;
         this.provider = provider;
         this.providerId = providerId;
+        this.profileImageUrl = profileImageUrl;
     }
 
     // 비즈니스 메서드
@@ -126,6 +131,10 @@ public class User extends BaseEntity {
 
     public void updateProviderId(String providerId) {
         this.providerId = providerId;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 
     // 논리적 삭제

--- a/backend/src/main/java/com/phonebid/app/mypage/controller/MyPageController.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/controller/MyPageController.java
@@ -6,10 +6,12 @@ import com.phonebid.app.mypage.dto.request.DeliveryAddressCreateRequestDto;
 import com.phonebid.app.mypage.dto.request.ProfileUpdateRequestDto;
 import com.phonebid.app.mypage.dto.response.AccountResponseDto;
 import com.phonebid.app.mypage.dto.response.DeliveryAddressResponseDto;
+import com.phonebid.app.mypage.dto.response.ProfileImageUploadResponseDto;
 import com.phonebid.app.mypage.dto.response.ProfileResponseDto;
 import com.phonebid.app.mypage.dto.response.PurchaseDetailResponseDto;
 import com.phonebid.app.mypage.dto.response.PurchaseHistoryResponseDto;
 import com.phonebid.app.mypage.service.MyPageService;
+import org.springframework.web.multipart.MultipartFile;
 import com.phonebid.app.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -198,6 +200,33 @@ public class MyPageController {
         
         return ResponseEntity.ok()
                 .body(ApiResponse.success(HttpStatus.OK, "배송지 삭제가 성공적으로 완료되었습니다.", null));
+    }
+
+    /**
+     * 프로필 이미지 업로드
+     * 로그인한 사용자의 프로필 사진을 업로드합니다. 기존 프로필 사진이 있으면 자동으로 삭제됩니다.
+     */
+    @PostMapping("/profile/image")
+    public ResponseEntity<ApiResponse<ProfileImageUploadResponseDto>> uploadProfileImage(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam("file") MultipartFile file) {
+        
+        ProfileImageUploadResponseDto responseDto = myPageService.uploadProfileImage(userDetails.getUsername(), file);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "프로필 이미지 업로드가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    /**
+     * 프로필 이미지 삭제
+     * 로그인한 사용자의 프로필 사진을 삭제합니다.
+     */
+    @DeleteMapping("/profile/image")
+    public ResponseEntity<ApiResponse<Void>> deleteProfileImage(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        myPageService.deleteProfileImage(userDetails.getUsername());
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "프로필 이미지 삭제가 성공적으로 완료되었습니다.", null));
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/mypage/dto/response/ProfileImageUploadResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/dto/response/ProfileImageUploadResponseDto.java
@@ -1,0 +1,19 @@
+package com.phonebid.app.mypage.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProfileImageUploadResponseDto {
+    private String imageUrl;
+
+    public ProfileImageUploadResponseDto(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public static ProfileImageUploadResponseDto from(String imageUrl) {
+        return new ProfileImageUploadResponseDto(imageUrl);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/mypage/dto/response/ProfileResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/dto/response/ProfileResponseDto.java
@@ -12,6 +12,7 @@ public class ProfileResponseDto {
     private String nickname;
     private String phone;
     private String name;
+    private String profileImageUrl;
 
     public static ProfileResponseDto from(User user) {
         ProfileResponseDto dto = new ProfileResponseDto();
@@ -19,6 +20,7 @@ public class ProfileResponseDto {
         dto.nickname = user.getNickname();
         dto.phone = user.getPhone();
         dto.name = user.getName();
+        dto.profileImageUrl = user.getProfileImageUrl();
         return dto;
     }
 }

--- a/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
@@ -43,7 +43,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Slf4j
 @Service

--- a/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/phonebid/app/mypage/service/MyPageService.java
@@ -2,6 +2,7 @@ package com.phonebid.app.mypage.service;
 
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.common.errorcode.MemberErrorCode;
 import com.phonebid.app.member.domain.User;
 import com.phonebid.app.member.repository.UserRepository;
 import com.phonebid.app.mypage.domain.Account;
@@ -12,11 +13,21 @@ import com.phonebid.app.mypage.dto.request.DeliveryAddressCreateRequestDto;
 import com.phonebid.app.mypage.dto.request.ProfileUpdateRequestDto;
 import com.phonebid.app.mypage.dto.response.AccountResponseDto;
 import com.phonebid.app.mypage.dto.response.DeliveryAddressResponseDto;
+import com.phonebid.app.mypage.dto.response.ProfileImageUploadResponseDto;
 import com.phonebid.app.mypage.dto.response.ProfileResponseDto;
 import com.phonebid.app.mypage.dto.response.PurchaseDetailResponseDto;
 import com.phonebid.app.mypage.dto.response.PurchaseHistoryResponseDto;
 import com.phonebid.app.mypage.repository.AccountRepository;
 import com.phonebid.app.mypage.repository.UserDeliveryAddressRepository;
+import com.phonebid.app.s3.service.S3Service;
+import org.springframework.web.multipart.MultipartFile;
+import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 import com.phonebid.app.trade.domain.Contract;
 import com.phonebid.app.trade.domain.ContractStatus;
 import com.phonebid.app.trade.domain.Delivery;
@@ -34,6 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
@@ -44,6 +56,13 @@ public class MyPageService {
     private final DeliveryRepository deliveryRepository;
     private final AccountRepository accountRepository;
     private final UserDeliveryAddressRepository userDeliveryAddressRepository;
+    private final S3Service s3Service;
+
+    private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList(
+            "jpg", "jpeg", "png", "gif", "webp", "JPG", "JPEG", "PNG", "GIF", "WEBP"
+    );
+
+    private static final long MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
 
     /**
      * 프로필 조회
@@ -265,13 +284,141 @@ public class MyPageService {
     }
 
     /**
+     * 프로필 이미지 업로드
+     * 기존 프로필 이미지가 있으면 S3에서 삭제하고 새 이미지를 업로드합니다.
+     */
+    @Transactional
+    public ProfileImageUploadResponseDto uploadProfileImage(String username, MultipartFile file) {
+        User user = loadActiveUser(username);
+
+        validateImageFile(file);
+
+        String uploadedFileUrl = null;
+        try {
+            String previousImageUrl = user.getProfileImageUrl();
+
+            String fileName = generateProfileImageFileName(user.getId(), file.getOriginalFilename());
+            uploadedFileUrl = s3Service.uploadFile(fileName, file);
+
+            try {
+                user.updateProfileImageUrl(uploadedFileUrl);
+                userRepository.save(user);
+
+                if (previousImageUrl != null) {
+                    try {
+                        s3Service.deleteFileByUrl(previousImageUrl);
+                        log.info("기존 프로필 이미지 삭제 완료: {}", previousImageUrl);
+                    } catch (Exception e) {
+                        log.warn("기존 프로필 이미지 삭제 실패(무시): {}", previousImageUrl, e);
+                    }
+                }
+
+                return ProfileImageUploadResponseDto.from(uploadedFileUrl);
+            } catch (Exception dbException) {
+                log.error("DB 저장 실패로 업로드 파일 롤백 시작: {}", uploadedFileUrl, dbException);
+                try {
+                    s3Service.deleteFileByUrl(uploadedFileUrl);
+                    log.info("업로드 실패 파일 롤백 완료: {}", uploadedFileUrl);
+                } catch (CustomException ce) {
+                    log.warn("업로드 실패 파일 롤백 실패(무시): {}", uploadedFileUrl, ce);
+                }
+                throw new CustomException(MemberErrorCode.FILE_UPLOAD_FAILED);
+            }
+
+        } catch (IOException e) {
+            log.error("프로필 이미지 업로드 실패: {}", e.getMessage(), e);
+            throw new CustomException(MemberErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    /**
+     * 프로필 이미지 삭제
+     * S3에서 이미지를 삭제하고 User 엔티티의 profileImageUrl을 null로 설정합니다.
+     */
+    @Transactional
+    public void deleteProfileImage(String username) {
+        User user = loadActiveUser(username);
+
+        String imageUrl = user.getProfileImageUrl();
+        if (imageUrl == null || imageUrl.trim().isEmpty()) {
+            throw new CustomException(CommonErrorCode.RESOURCE_NOT_FOUND);
+        }
+
+        try {
+            s3Service.deleteFileByUrl(imageUrl);
+            user.updateProfileImageUrl(null);
+            userRepository.save(user);
+            log.info("프로필 이미지 삭제 완료: {}", imageUrl);
+        } catch (Exception e) {
+            log.error("프로필 이미지 삭제 실패: {}", imageUrl, e);
+            throw new CustomException(MemberErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
+    /**
+     * 이미지 파일 검증
+     */
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(MemberErrorCode.MISSING_FILE);
+        }
+
+        if (file.getSize() > MAX_IMAGE_SIZE) {
+            throw new CustomException(MemberErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.trim().isEmpty()) {
+            throw new CustomException(MemberErrorCode.INVALID_FILE_NAME);
+        }
+
+        String extension = getFileExtension(originalFilename);
+        if (!ALLOWED_IMAGE_EXTENSIONS.contains(extension)) {
+            throw new CustomException(MemberErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return "";
+        }
+        return fileName.substring(lastDotIndex + 1);
+    }
+
+    /**
+     * 프로필 이미지 파일명 생성
+     */
+    private String generateProfileImageFileName(UUID userId, String originalFilename) {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        String sanitizedFilename = sanitizeFilename(originalFilename);
+        return String.format("profiles/%s/%s_%s", userId, timestamp, sanitizedFilename);
+    }
+
+    /**
+     * 파일명 보안 정리
+     */
+    private String sanitizeFilename(String filename) {
+        if (filename == null || filename.trim().isEmpty()) {
+            return "unnamed.jpg";
+        }
+        return filename.trim()
+                .replaceAll("[^a-zA-Z0-9가-힣._-]", "_")
+                .replaceAll("_{2,}", "_")
+                .replaceAll("^_+|_+$", "");
+    }
+
+    /**
      * 활성 사용자 조회
      * 삭제되지 않은 활성 사용자만 조회하며, 사용자가 없거나 삭제된 경우 예외를 발생시킵니다.
      */
     private User loadActiveUser(String username) {
         return userRepository.findByUsername(username)
-            .filter(user -> !user.isDeleted())
-            .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+                .filter(user -> !user.isDeleted())
+                .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/phone/controller/PhoneModelController.java
+++ b/backend/src/main/java/com/phonebid/app/phone/controller/PhoneModelController.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.UUID;
 
 import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto;
-import com.phonebid.app.phone.dto.request.PhoneModelDeleteRequestDto;
 import com.phonebid.app.phone.dto.request.PhoneModelUpdateRequestDto;
 import com.phonebid.app.phone.dto.response.PhoneModelResponseDto;
 
@@ -54,17 +53,24 @@ public class PhoneModelController {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "휴대폰 모델 생성이 성공적으로 완료되었습니다.", phoneModelService.createPhoneModel(requestDto)));
     }
 
-    // 휴대폰 모델 수정
-    @PutMapping
-    public ResponseEntity<ApiResponse<PhoneModelResponseDto>> updatePhoneModel(@RequestBody @Valid PhoneModelUpdateRequestDto requestDto) {
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "휴대폰 모델 수정이 성공적으로 완료되었습니다.", phoneModelService.updatePhoneModel(requestDto)));
+    /**
+     * 휴대폰 모델 수정
+     * PUT /api/v1/phone/models/{id}
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<PhoneModelResponseDto>> updatePhoneModel(@PathVariable UUID id,
+                                                                               @RequestBody @Valid PhoneModelUpdateRequestDto requestDto) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "휴대폰 모델 수정이 성공적으로 완료되었습니다.", phoneModelService.updatePhoneModel(id, requestDto)));
     }
 
-    // 휴대폰 모델 삭제
-    @DeleteMapping
-    public ResponseEntity<ApiResponse<Void>> deletePhoneModel(@RequestBody @Valid PhoneModelDeleteRequestDto requestDto) {
-        phoneModelService.deletePhoneModel(requestDto);
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "휴대폰 모델 삭제이 성공적으로 완료되었습니다.", null));
+    /**
+     * 휴대폰 모델 삭제
+     * DELETE /api/v1/phone/models/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletePhoneModel(@PathVariable UUID id) {
+        phoneModelService.deletePhoneModel(id);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "휴대폰 모델 삭제가 성공적으로 완료되었습니다.", null));
     }
 
     // 휴대폰 모델 상세 조회

--- a/backend/src/main/java/com/phonebid/app/phone/controller/PhoneModelImageController.java
+++ b/backend/src/main/java/com/phonebid/app/phone/controller/PhoneModelImageController.java
@@ -1,0 +1,68 @@
+package com.phonebid.app.phone.controller;
+
+import com.phonebid.app.phone.dto.request.PhoneModelImageUploadRequestDto;
+import com.phonebid.app.phone.dto.response.PhoneModelImageResponseDto;
+import com.phonebid.app.phone.dto.response.PhoneModelImageUploadResponseDto;
+import com.phonebid.app.phone.service.PhoneModelImageService;
+import com.phonebid.app.common.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/phone/models/{phoneModelId}/images")
+public class PhoneModelImageController {
+
+    private final PhoneModelImageService phoneModelImageService;
+
+    /**
+     * 핸드폰 모델 이미지 업로드
+     * 여러 이미지를 업로드할 수 있으며, 최대 10개까지 허용됩니다.
+     * 관리자만 사용 가능합니다.
+     */
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<PhoneModelImageUploadResponseDto>> uploadPhoneModelImages(@PathVariable UUID phoneModelId,
+                                                                                                @Valid @ModelAttribute PhoneModelImageUploadRequestDto requestDto) {
+        
+        PhoneModelImageUploadResponseDto responseDto = phoneModelImageService.uploadPhoneModelImages(phoneModelId, requestDto);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "핸드폰 모델 이미지 업로드가 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    /**
+     * 핸드폰 모델 이미지 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PhoneModelImageResponseDto>>> getPhoneModelImages(@PathVariable UUID phoneModelId) {
+        
+        List<PhoneModelImageResponseDto> images = phoneModelImageService.getPhoneModelImages(phoneModelId);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "핸드폰 모델 이미지 목록 조회가 성공적으로 완료되었습니다.", images));
+    }
+
+    /**
+     * 핸드폰 모델 이미지 삭제
+     * 관리자만 사용 가능합니다.
+     */
+    @DeleteMapping("/{imageId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> deletePhoneModelImage(@PathVariable UUID phoneModelId,
+                                                                   @PathVariable UUID imageId) {
+        
+        phoneModelImageService.deletePhoneModelImage(phoneModelId, imageId);
+        
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "핸드폰 모델 이미지 삭제가 성공적으로 완료되었습니다.", null));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/phone/controller/PhoneModelImageController.java
+++ b/backend/src/main/java/com/phonebid/app/phone/controller/PhoneModelImageController.java
@@ -1,16 +1,17 @@
 package com.phonebid.app.phone.controller;
 
-import com.phonebid.app.phone.dto.request.PhoneModelImageUploadRequestDto;
 import com.phonebid.app.phone.dto.response.PhoneModelImageResponseDto;
 import com.phonebid.app.phone.dto.response.PhoneModelImageUploadResponseDto;
 import com.phonebid.app.phone.service.PhoneModelImageService;
 import com.phonebid.app.common.dto.ApiResponse;
-import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.UUID;
@@ -29,10 +30,12 @@ public class PhoneModelImageController {
      */
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<ApiResponse<PhoneModelImageUploadResponseDto>> uploadPhoneModelImages(@PathVariable UUID phoneModelId,
-                                                                                                @Valid @ModelAttribute PhoneModelImageUploadRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<PhoneModelImageUploadResponseDto>> uploadPhoneModelImages(
+            @PathVariable UUID phoneModelId,
+            @RequestParam("files") @NotNull(message = "이미지 파일은 필수입니다.") 
+            @NotEmpty(message = "최소 1개 이상의 이미지 파일이 필요합니다.") List<MultipartFile> files) {
         
-        PhoneModelImageUploadResponseDto responseDto = phoneModelImageService.uploadPhoneModelImages(phoneModelId, requestDto);
+        PhoneModelImageUploadResponseDto responseDto = phoneModelImageService.uploadPhoneModelImages(phoneModelId, files);
         
         return ResponseEntity.ok()
                 .body(ApiResponse.success(HttpStatus.OK, "핸드폰 모델 이미지 업로드가 성공적으로 완료되었습니다.", responseDto));

--- a/backend/src/main/java/com/phonebid/app/phone/domain/PhoneModelImage.java
+++ b/backend/src/main/java/com/phonebid/app/phone/domain/PhoneModelImage.java
@@ -1,0 +1,47 @@
+package com.phonebid.app.phone.domain;
+
+import com.phonebid.app.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "phone_model_images", indexes = {
+    @Index(name = "idx_phone_model_images_model_id", columnList = "model_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhoneModelImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    @Comment("핸드폰 모델 이미지 고유 ID (UUID)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "model_id", nullable = false)
+    @Comment("핸드폰 모델 ID")
+    private PhoneModel phoneModel;
+
+    @Column(name = "image_url", nullable = false, columnDefinition = "TEXT")
+    @Comment("이미지 URL")
+    private String imageUrl;
+
+    @Column(name = "display_order", nullable = false)
+    @Comment("이미지 표시 순서")
+    private Integer displayOrder;
+
+    @Builder
+    public PhoneModelImage(PhoneModel phoneModel, String imageUrl, Integer displayOrder) {
+        this.phoneModel = phoneModel;
+        this.imageUrl = imageUrl;
+        this.displayOrder = displayOrder;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/phone/dto/request/PhoneModelImageUploadRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/phone/dto/request/PhoneModelImageUploadRequestDto.java
@@ -1,0 +1,18 @@
+package com.phonebid.app.phone.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PhoneModelImageUploadRequestDto {
+    @NotNull(message = "이미지 파일은 필수입니다.")
+    @NotEmpty(message = "최소 1개 이상의 이미지 파일이 필요합니다.")
+    private List<MultipartFile> files;
+}
+

--- a/backend/src/main/java/com/phonebid/app/phone/dto/request/PhoneModelUpdateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/phone/dto/request/PhoneModelUpdateRequestDto.java
@@ -2,25 +2,21 @@ package com.phonebid.app.phone.dto.request;
 
 import com.phonebid.app.phone.domain.Brand;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
 /**
  * 휴대폰 모델 수정 요청 DTO
+ * ID는 path variable로 전달되므로 DTO에서 제외
  */
 @Getter
 @Setter
 @NoArgsConstructor
 public class PhoneModelUpdateRequestDto {
-
-    @NotNull(message = "모델 ID는 필수입니다.")
-    private UUID id;
 
     private Brand brand;
 
@@ -33,9 +29,8 @@ public class PhoneModelUpdateRequestDto {
 
     private LocalDate releasedAt;
 
-    public PhoneModelUpdateRequestDto(UUID id, Brand brand, String model, String modelNumber, 
+    public PhoneModelUpdateRequestDto(Brand brand, String model, String modelNumber, 
                                     Integer releasedPrice, LocalDate releasedAt) {
-        this.id = id;
         this.brand = brand;
         this.model = model;
         this.modelNumber = modelNumber;

--- a/backend/src/main/java/com/phonebid/app/phone/dto/response/PhoneModelImageResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/phone/dto/response/PhoneModelImageResponseDto.java
@@ -1,0 +1,30 @@
+package com.phonebid.app.phone.dto.response;
+
+import com.phonebid.app.phone.domain.PhoneModelImage;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class PhoneModelImageResponseDto {
+    private UUID id;
+    private String imageUrl;
+    private Integer displayOrder;
+
+    public PhoneModelImageResponseDto(UUID id, String imageUrl, Integer displayOrder) {
+        this.id = id;
+        this.imageUrl = imageUrl;
+        this.displayOrder = displayOrder;
+    }
+
+    public static PhoneModelImageResponseDto from(PhoneModelImage phoneModelImage) {
+        return new PhoneModelImageResponseDto(
+            phoneModelImage.getId(),
+            phoneModelImage.getImageUrl(),
+            phoneModelImage.getDisplayOrder()
+        );
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/phone/dto/response/PhoneModelImageUploadResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/phone/dto/response/PhoneModelImageUploadResponseDto.java
@@ -1,0 +1,21 @@
+package com.phonebid.app.phone.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PhoneModelImageUploadResponseDto {
+    private List<PhoneModelImageResponseDto> images;
+
+    public PhoneModelImageUploadResponseDto(List<PhoneModelImageResponseDto> images) {
+        this.images = images;
+    }
+
+    public static PhoneModelImageUploadResponseDto from(List<PhoneModelImageResponseDto> images) {
+        return new PhoneModelImageUploadResponseDto(images);
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/phone/repository/PhoneModelImageRepository.java
+++ b/backend/src/main/java/com/phonebid/app/phone/repository/PhoneModelImageRepository.java
@@ -1,0 +1,15 @@
+package com.phonebid.app.phone.repository;
+
+import com.phonebid.app.phone.domain.PhoneModelImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface PhoneModelImageRepository extends JpaRepository<PhoneModelImage, UUID> {
+    List<PhoneModelImage> findByPhoneModelIdOrderByDisplayOrder(UUID phoneModelId);
+    void deleteByPhoneModelId(UUID phoneModelId);
+}
+

--- a/backend/src/main/java/com/phonebid/app/phone/repository/PhoneModelImageRepository.java
+++ b/backend/src/main/java/com/phonebid/app/phone/repository/PhoneModelImageRepository.java
@@ -2,6 +2,9 @@ package com.phonebid.app.phone.repository;
 
 import com.phonebid.app.phone.domain.PhoneModelImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,6 +13,9 @@ import java.util.UUID;
 @Repository
 public interface PhoneModelImageRepository extends JpaRepository<PhoneModelImage, UUID> {
     List<PhoneModelImage> findByPhoneModelIdOrderByDisplayOrder(UUID phoneModelId);
-    void deleteByPhoneModelId(UUID phoneModelId);
+    
+    @Modifying
+    @Query("UPDATE PhoneModelImage p SET p.isDelete = true, p.deletedAt = CURRENT_TIMESTAMP WHERE p.phoneModel.id = :phoneModelId")
+    void deleteByPhoneModelId(@Param("phoneModelId") UUID phoneModelId);
 }
 

--- a/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelImageService.java
+++ b/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelImageService.java
@@ -2,7 +2,6 @@ package com.phonebid.app.phone.service;
 
 import com.phonebid.app.phone.domain.PhoneModel;
 import com.phonebid.app.phone.domain.PhoneModelImage;
-import com.phonebid.app.phone.dto.request.PhoneModelImageUploadRequestDto;
 import com.phonebid.app.phone.dto.response.PhoneModelImageResponseDto;
 import com.phonebid.app.phone.dto.response.PhoneModelImageUploadResponseDto;
 import com.phonebid.app.phone.repository.PhoneModelImageRepository;
@@ -48,11 +47,10 @@ public class PhoneModelImageService {
      * 관리자만 사용 가능합니다.
      */
     @Transactional
-    public PhoneModelImageUploadResponseDto uploadPhoneModelImages(UUID phoneModelId, PhoneModelImageUploadRequestDto requestDto) {
+    public PhoneModelImageUploadResponseDto uploadPhoneModelImages(UUID phoneModelId, List<MultipartFile> files) {
         PhoneModel phoneModel = phoneModelRepository.findById(phoneModelId)
                 .orElseThrow(() -> new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND));
 
-        List<MultipartFile> files = requestDto.getFiles();
         if (files == null || files.isEmpty()) {
             throw new CustomException(MemberErrorCode.MISSING_FILE);
         }

--- a/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelImageService.java
+++ b/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelImageService.java
@@ -125,8 +125,11 @@ public class PhoneModelImageService {
         String imageUrl = phoneModelImage.getImageUrl();
 
         try {
-            phoneModelImageRepository.delete(phoneModelImage);
+            // S3에서 파일 삭제를 먼저 수행 (외부 서비스)
             s3Service.deleteFileByUrl(imageUrl);
+            
+            // S3 삭제 성공 후 DB에서 레코드 삭제
+            phoneModelImageRepository.delete(phoneModelImage);
             log.info("핸드폰 모델 이미지 삭제 완료: phoneModelId={}, imageId={}", phoneModelId, imageId);
         } catch (Exception e) {
             log.error("핸드폰 모델 이미지 삭제 실패: {}", imageUrl, e);

--- a/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelImageService.java
+++ b/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelImageService.java
@@ -1,0 +1,206 @@
+package com.phonebid.app.phone.service;
+
+import com.phonebid.app.phone.domain.PhoneModel;
+import com.phonebid.app.phone.domain.PhoneModelImage;
+import com.phonebid.app.phone.dto.request.PhoneModelImageUploadRequestDto;
+import com.phonebid.app.phone.dto.response.PhoneModelImageResponseDto;
+import com.phonebid.app.phone.dto.response.PhoneModelImageUploadResponseDto;
+import com.phonebid.app.phone.repository.PhoneModelImageRepository;
+import com.phonebid.app.phone.repository.PhoneModelRepository;
+import com.phonebid.app.common.errorcode.MemberErrorCode;
+import com.phonebid.app.common.errorcode.PhoneErrorCode;
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhoneModelImageService {
+
+    private final PhoneModelImageRepository phoneModelImageRepository;
+    private final PhoneModelRepository phoneModelRepository;
+    private final S3Service s3Service;
+
+    private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList(
+            "jpg", "jpeg", "png", "gif", "webp", "JPG", "JPEG", "PNG", "GIF", "WEBP"
+    );
+
+    private static final long MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final int MAX_IMAGES_PER_MODEL = 10;
+
+    /**
+     * 핸드폰 모델 이미지 업로드
+     * 여러 이미지를 업로드할 수 있으며, 최대 10개까지 허용됩니다.
+     * 관리자만 사용 가능합니다.
+     */
+    @Transactional
+    public PhoneModelImageUploadResponseDto uploadPhoneModelImages(UUID phoneModelId, PhoneModelImageUploadRequestDto requestDto) {
+        PhoneModel phoneModel = phoneModelRepository.findById(phoneModelId)
+                .orElseThrow(() -> new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND));
+
+        List<MultipartFile> files = requestDto.getFiles();
+        if (files == null || files.isEmpty()) {
+            throw new CustomException(MemberErrorCode.MISSING_FILE);
+        }
+
+        List<PhoneModelImage> existingImages = phoneModelImageRepository.findByPhoneModelIdOrderByDisplayOrder(phoneModelId);
+        int currentImageCount = existingImages.size();
+        int newImageCount = files.size();
+
+        if (currentImageCount + newImageCount > MAX_IMAGES_PER_MODEL) {
+            throw new CustomException(PhoneErrorCode.PHONE_MODEL_IMAGE_LIMIT_EXCEEDED);
+        }
+
+        List<String> uploadedUrls = new ArrayList<>();
+        List<PhoneModelImage> savedImages = new ArrayList<>();
+
+        try {
+            int startOrder = currentImageCount + 1;
+
+            for (int i = 0; i < files.size(); i++) {
+                MultipartFile file = files.get(i);
+                validateImageFile(file);
+
+                String fileName = generatePhoneModelImageFileName(phoneModelId, file.getOriginalFilename(), i);
+                String imageUrl = s3Service.uploadFile(fileName, file);
+                uploadedUrls.add(imageUrl);
+
+                PhoneModelImage phoneModelImage = PhoneModelImage.builder()
+                        .phoneModel(phoneModel)
+                        .imageUrl(imageUrl)
+                        .displayOrder(startOrder + i)
+                        .build();
+
+                PhoneModelImage saved = phoneModelImageRepository.save(phoneModelImage);
+                savedImages.add(saved);
+            }
+
+            List<PhoneModelImageResponseDto> responseDtos = savedImages.stream()
+                    .map(PhoneModelImageResponseDto::from)
+                    .collect(Collectors.toList());
+
+            return PhoneModelImageUploadResponseDto.from(responseDtos);
+
+        } catch (IOException e) {
+            log.error("핸드폰 모델 이미지 업로드 실패: {}", e.getMessage(), e);
+            for (String url : uploadedUrls) {
+                try {
+                    s3Service.deleteFileByUrl(url);
+                } catch (Exception ignore) {
+                    log.error("업로드 실패 파일 롤백 실패: {}", url, ignore);
+                }
+            }
+            throw new CustomException(MemberErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    /**
+     * 핸드폰 모델 이미지 삭제
+     * 관리자만 사용 가능합니다.
+     */
+    @Transactional
+    public void deletePhoneModelImage(UUID phoneModelId, UUID imageId) {
+        phoneModelRepository.findById(phoneModelId)
+                .orElseThrow(() -> new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND));
+
+        PhoneModelImage phoneModelImage = phoneModelImageRepository.findById(imageId)
+                .orElseThrow(() -> new CustomException(PhoneErrorCode.PHONE_MODEL_IMAGE_NOT_FOUND));
+
+        if (!phoneModelImage.getPhoneModel().getId().equals(phoneModelId)) {
+            throw new CustomException(PhoneErrorCode.PHONE_MODEL_IMAGE_NOT_FOUND);
+        }
+
+        String imageUrl = phoneModelImage.getImageUrl();
+
+        try {
+            phoneModelImageRepository.delete(phoneModelImage);
+            s3Service.deleteFileByUrl(imageUrl);
+            log.info("핸드폰 모델 이미지 삭제 완료: phoneModelId={}, imageId={}", phoneModelId, imageId);
+        } catch (Exception e) {
+            log.error("핸드폰 모델 이미지 삭제 실패: {}", imageUrl, e);
+            throw new CustomException(MemberErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
+    /**
+     * 핸드폰 모델의 모든 이미지 조회
+     */
+    @Transactional(readOnly = true)
+    public List<PhoneModelImageResponseDto> getPhoneModelImages(UUID phoneModelId) {
+        List<PhoneModelImage> images = phoneModelImageRepository.findByPhoneModelIdOrderByDisplayOrder(phoneModelId);
+        return images.stream()
+                .map(PhoneModelImageResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 이미지 파일 검증
+     */
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(MemberErrorCode.MISSING_FILE);
+        }
+
+        if (file.getSize() > MAX_IMAGE_SIZE) {
+            throw new CustomException(MemberErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.trim().isEmpty()) {
+            throw new CustomException(MemberErrorCode.INVALID_FILE_NAME);
+        }
+
+        String extension = getFileExtension(originalFilename);
+        if (!ALLOWED_IMAGE_EXTENSIONS.contains(extension)) {
+            throw new CustomException(MemberErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return "";
+        }
+        return fileName.substring(lastDotIndex + 1);
+    }
+
+    /**
+     * 핸드폰 모델 이미지 파일명 생성
+     */
+    private String generatePhoneModelImageFileName(UUID phoneModelId, String originalFilename, int index) {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        String sanitizedFilename = sanitizeFilename(originalFilename);
+        return String.format("phone-models/%s/%s_%d_%s", phoneModelId, timestamp, index, sanitizedFilename);
+    }
+
+    /**
+     * 파일명 보안 정리
+     */
+    private String sanitizeFilename(String filename) {
+        if (filename == null || filename.trim().isEmpty()) {
+            return "unnamed.jpg";
+        }
+        return filename.trim()
+                .replaceAll("[^a-zA-Z0-9가-힣._-]", "_")
+                .replaceAll("_{2,}", "_")
+                .replaceAll("^_+|_+$", "");
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelService.java
+++ b/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelService.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import com.phonebid.app.phone.repository.PhoneModelRepository;
 import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto;
 import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto.OptionItem;
-import com.phonebid.app.phone.dto.request.PhoneModelDeleteRequestDto;
 import com.phonebid.app.phone.dto.request.PhoneModelUpdateRequestDto;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.PhoneErrorCode;
@@ -58,8 +57,9 @@ public class PhoneModelService {
         return PhoneModelResponseDto.from(savedModel);
     }
     
-    public PhoneModelResponseDto updatePhoneModel(PhoneModelUpdateRequestDto requestDto) {
-        PhoneModel existingModel = phoneModelRepository.findById(requestDto.getId())
+    @Transactional
+    public PhoneModelResponseDto updatePhoneModel(UUID id, PhoneModelUpdateRequestDto requestDto) {
+        PhoneModel existingModel = phoneModelRepository.findById(id)
             .orElseThrow(() -> new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND));
         
         // 브랜드와 모델명 조합의 중복 확인 (둘 다 업데이트되는 경우)
@@ -118,11 +118,11 @@ public class PhoneModelService {
     }
 
     
-    public void deletePhoneModel(PhoneModelDeleteRequestDto requestDto) {
-        if (phoneModelRepository.findById(requestDto.getId()).isEmpty()) {
-            throw new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND);
-        }
-        phoneModelRepository.deleteById(requestDto.getId());
+    @Transactional
+    public void deletePhoneModel(UUID id) {
+        PhoneModel model = phoneModelRepository.findById(id)
+            .orElseThrow(() -> new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND));
+        phoneModelRepository.delete(model);
     }
     
     public PhoneModelResponseDto getPhoneModel(UUID id) {

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -74,7 +74,7 @@ export function MessageBubble({
                   <img
                     src={message.content}
                     alt="전송된 이미지"
-                    className={`max-w-xs rounded-lg cursor-pointer ${
+                    className={`rounded-lg cursor-pointer ${
                       isImageExpanded ? "max-w-2xl" : "max-w-xs"
                     }`}
                     onClick={() => setIsImageExpanded(!isImageExpanded)}

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,5 +1,7 @@
 import type { ChatMessage } from "types/ChatTypes";
+import { MessageType } from "types/ChatTypes";
 import { ChatAvatar } from "components/chat/ChatAvatar";
+import { useState } from "react";
 
 interface MessageBubbleProps {
   message: ChatMessage;
@@ -21,6 +23,9 @@ export function MessageBubble({
   senderName,
   senderAvatar,
 }: MessageBubbleProps) {
+  const [imageError, setImageError] = useState(false);
+  const [isImageExpanded, setIsImageExpanded] = useState(false);
+
   const formatTime = (dateString: string): string => {
     const date = new Date(dateString);
     return date.toLocaleTimeString("ko-KR", {
@@ -29,6 +34,8 @@ export function MessageBubble({
       hour12: true,
     });
   };
+
+  const isImageMessage = message.messageType === MessageType.IMAGE;
 
   // 상대방 메시지: 왼쪽 정렬, 흰색 말풍선
   // 내 메시지: 오른쪽 정렬, 회색 말풍선
@@ -57,18 +64,49 @@ export function MessageBubble({
                 : "bg-white text-gray-900 rounded-bl-sm border-gray-200 shadow-sm"
             }`}
           >
-            <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
-              {message.content}
-            </p>
-            <div className="flex items-center justify-end gap-1.5 mt-1.5">
-              <p
-                className={`text-xs ${
-                  isCurrentUser ? "text-gray-500" : "text-gray-400"
-                }`}
-              >
-                {formatTime(message.createdAt)}
-              </p>
-            </div>
+            {isImageMessage ? (
+              <div className="space-y-2">
+                {imageError ? (
+                  <div className="flex items-center justify-center w-64 h-48 bg-gray-100 rounded-lg">
+                    <p className="text-sm text-gray-500">이미지를 불러올 수 없습니다.</p>
+                  </div>
+                ) : (
+                  <img
+                    src={message.content}
+                    alt="전송된 이미지"
+                    className={`max-w-xs rounded-lg cursor-pointer ${
+                      isImageExpanded ? "max-w-2xl" : "max-w-xs"
+                    }`}
+                    onClick={() => setIsImageExpanded(!isImageExpanded)}
+                    onError={() => setImageError(true)}
+                  />
+                )}
+                <div className="flex items-center justify-end gap-1.5">
+                  <p
+                    className={`text-xs ${
+                      isCurrentUser ? "text-gray-500" : "text-gray-400"
+                    }`}
+                  >
+                    {formatTime(message.createdAt)}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <>
+                <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+                  {message.content}
+                </p>
+                <div className="flex items-center justify-end gap-1.5 mt-1.5">
+                  <p
+                    className={`text-xs ${
+                      isCurrentUser ? "text-gray-500" : "text-gray-400"
+                    }`}
+                  >
+                    {formatTime(message.createdAt)}
+                  </p>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -1,10 +1,14 @@
 import { useState, useCallback, KeyboardEvent, useEffect, useRef } from "react";
 import type { WebSocketConnectionStatus } from "types/ChatTypes";
+import { uploadChatImage } from "services/chatService";
+import { toast } from "react-toastify";
 
 interface MessageInputProps {
   onSendMessage: (message: string) => void;
+  onSendImage?: (imageUrl: string) => void;
   onTyping?: (isTyping: boolean) => void;
   connectionStatus: WebSocketConnectionStatus;
+  chatRoomId?: string;
   disabled?: boolean;
   placeholder?: string;
 }
@@ -14,14 +18,18 @@ interface MessageInputProps {
  */
 export function MessageInput({
   onSendMessage,
+  onSendImage,
   onTyping,
   connectionStatus,
+  chatRoomId,
   disabled = false,
   placeholder = "메시지를 입력하세요.",
 }: MessageInputProps) {
   const [inputMessage, setInputMessage] = useState("");
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isTypingRef = useRef(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // 타이핑 이벤트 전송 (디바운싱)
   const handleTyping = useCallback(() => {
@@ -90,11 +98,117 @@ export function MessageInput({
     [handleSend]
   );
 
-  const isDisabled = disabled || connectionStatus !== "CONNECTED";
+  const handleImageUploadClick = useCallback(() => {
+    if (!chatRoomId) {
+      toast.error("채팅방 정보가 없습니다.");
+      return;
+    }
+    fileInputRef.current?.click();
+  }, [chatRoomId]);
+
+  const handleImageFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file || !chatRoomId) return;
+
+      // 파일 유효성 검사
+      const allowedTypes = [
+        "image/jpeg",
+        "image/jpg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+      ];
+      if (!allowedTypes.includes(file.type)) {
+        toast.error(
+          "지원하지 않는 파일 형식입니다. (jpg, jpeg, png, gif, webp만 가능)"
+        );
+        return;
+      }
+
+      const maxSize = 5 * 1024 * 1024; // 5MB
+      if (file.size > maxSize) {
+        toast.error("파일 크기는 5MB 이하여야 합니다.");
+        return;
+      }
+
+      try {
+        setIsUploadingImage(true);
+        const response = await uploadChatImage(chatRoomId, file);
+        if (onSendImage) {
+          onSendImage(response.imageUrl);
+        } else {
+          // onSendImage가 없으면 onSendMessage로 이미지 URL 전송
+          onSendMessage(response.imageUrl);
+        }
+      } catch (error) {
+        console.error("Failed to upload image", error);
+      } finally {
+        setIsUploadingImage(false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+      }
+    },
+    [chatRoomId, onSendImage, onSendMessage]
+  );
+
+  const isDisabled = disabled || connectionStatus !== "CONNECTED" || isUploadingImage;
 
   return (
     <div className="border-t bg-white p-4">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
+        className="hidden"
+        onChange={handleImageFileChange}
+        disabled={isDisabled}
+      />
       <div className="flex items-end gap-2">
+        <button
+          onClick={handleImageUploadClick}
+          disabled={isDisabled}
+          className="bg-gray-100 text-gray-600 rounded-full w-10 h-10 flex items-center justify-center hover:bg-gray-200 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors flex-shrink-0"
+          aria-label="이미지 업로드"
+          title="이미지 업로드"
+        >
+          {isUploadingImage ? (
+            <svg
+              className="w-5 h-5 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+          ) : (
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          )}
+        </button>
         <textarea
           value={inputMessage}
           onChange={(e) => {

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -143,6 +143,7 @@ export function MessageInput({
         }
       } catch (error) {
         console.error("Failed to upload image", error);
+        toast.error("이미지 업로드에 실패했습니다.");
       } finally {
         setIsUploadingImage(false);
         if (fileInputRef.current) {

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -9,7 +9,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     // 높이 100vh 설정
     <div className="min-h-screen h-screen flex flex-col overflow-hidden">
       <Header />
-      <main className="flex-1 overflow-hidden min-h-0">{children}</main>
+      <main className="flex-1 overflow-y-auto min-h-0">{children}</main>
     </div>
   );
 };

--- a/frontend/src/pages/ChatRoomPage.tsx
+++ b/frontend/src/pages/ChatRoomPage.tsx
@@ -555,6 +555,46 @@ const ChatRoomPage: React.FC = () => {
     [chatRoomId, user, chatRoom, sendWebSocketMessage]
   );
 
+  const handleSendImage = useCallback(
+    (imageUrl: string) => {
+      if (!chatRoomId || !user || !chatRoom) {
+        return;
+      }
+
+      // 현재 사용자 ID 확인 (채팅방 정보 사용)
+      const currentUserId = user.role === "CONSUMER" 
+        ? chatRoom.consumerId 
+        : chatRoom.sellerId;
+
+      // 임시 메시지 ID 생성 (서버 응답 전까지 사용)
+      const tempId = `temp-${Date.now()}-${Math.random()}`;
+      
+      // 즉시 로컬 상태에 추가 (isRead: false로 설정하여 "1" 표시)
+      const tempMessage: ChatMessage = {
+        id: tempId,
+        chatRoomId,
+        senderId: currentUserId,
+        messageType: MessageType.IMAGE,
+        content: imageUrl,
+        isRead: false,
+        createdAt: new Date().toISOString(),
+      };
+
+      // 임시 메시지를 먼저 추가
+      setMessages((prev) => [...prev, tempMessage]);
+
+      const messageRequest = {
+        chatRoomId,
+        senderId: user.username,
+        messageType: MessageType.IMAGE,
+        content: imageUrl,
+      };
+
+      sendWebSocketMessage(messageRequest);
+    },
+    [chatRoomId, user, chatRoom, sendWebSocketMessage]
+  );
+
   // 타이핑 이벤트 전송 핸들러
   const handleTyping = useCallback(
     (isTyping: boolean) => {
@@ -764,8 +804,10 @@ const ChatRoomPage: React.FC = () => {
       <div className="flex-shrink-0 sticky bottom-0 bg-white">
         <MessageInput
           onSendMessage={handleSendMessage}
+          onSendImage={handleSendImage}
           onTyping={handleTyping}
           connectionStatus={connectionStatus}
+          chatRoomId={chatRoomId || undefined}
         />
       </div>
     </div>

--- a/frontend/src/pages/DeliveryAddressListPage.tsx
+++ b/frontend/src/pages/DeliveryAddressListPage.tsx
@@ -105,8 +105,9 @@ const DeliveryAddressListPage = () => {
   const handleInputChange = (field: keyof DeliveryFormData, value: string | boolean) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
 
-    if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: "" }));
+    const errorField = field as keyof DeliveryFormErrors;
+    if (errorField in errors && errors[errorField]) {
+      setErrors((prev) => ({ ...prev, [errorField]: "" }));
     }
   };
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { mypageService } from "services/mypageService";
 import { toast } from "react-toastify";
@@ -9,6 +9,9 @@ const ProfilePage = () => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingProfile, setIsLoadingProfile] = useState(true);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [formData, setFormData] = useState({
     username: "",
@@ -40,6 +43,7 @@ const ProfilePage = () => {
         nickname: data.nickname || "",
         phone: data.phone || "",
       });
+      setProfileImageUrl(data.profileImageUrl || null);
     } catch (error: unknown) {
       logError("프로필 조회 실패:", error);
     } finally {
@@ -150,6 +154,66 @@ const ProfilePage = () => {
     navigate("/mypage");
   };
 
+  const handleImageUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImageFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // 파일 유효성 검사
+    const allowedTypes = ["image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      toast.error("지원하지 않는 파일 형식입니다. (jpg, jpeg, png, gif, webp만 가능)");
+      return;
+    }
+
+    const maxSize = 5 * 1024 * 1024; // 5MB
+    if (file.size > maxSize) {
+      toast.error("파일 크기는 5MB 이하여야 합니다.");
+      return;
+    }
+
+    try {
+      setIsUploadingImage(true);
+      const response = await mypageService.uploadProfileImage(file);
+      setProfileImageUrl(response.profileImageUrl);
+      toast.success("프로필 이미지가 업로드되었습니다.");
+      // 프로필 정보 갱신
+      await loadProfile();
+    } catch (error: unknown) {
+      logError("프로필 이미지 업로드 실패:", error);
+    } finally {
+      setIsUploadingImage(false);
+      // 파일 input 초기화
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleImageDelete = async () => {
+    if (!profileImageUrl) return;
+
+    if (!window.confirm("프로필 이미지를 삭제하시겠습니까?")) {
+      return;
+    }
+
+    try {
+      setIsUploadingImage(true);
+      await mypageService.deleteProfileImage();
+      setProfileImageUrl(null);
+      toast.success("프로필 이미지가 삭제되었습니다.");
+      // 프로필 정보 갱신
+      await loadProfile();
+    } catch (error: unknown) {
+      logError("프로필 이미지 삭제 실패:", error);
+    } finally {
+      setIsUploadingImage(false);
+    }
+  };
+
   if (isLoadingProfile) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-purple-200 via-purple-100 to-blue-200 flex items-center justify-center">
@@ -190,45 +254,107 @@ const ProfilePage = () => {
         {/* 프로필 사진 영역 */}
         <div className="flex justify-center mb-10">
           <div className="relative">
-            <div className="w-32 h-32 bg-white rounded-full flex items-center justify-center shadow-lg">
-              <svg
-                className="w-20 h-20 text-gray-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+            <div className="w-32 h-32 bg-white rounded-full flex items-center justify-center shadow-lg overflow-hidden">
+              {profileImageUrl ? (
+                <img
+                  src={profileImageUrl}
+                  alt="프로필 이미지"
+                  className="w-full h-full object-cover"
                 />
-              </svg>
+              ) : (
+                <svg
+                  className="w-20 h-20 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              )}
             </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
+              className="hidden"
+              onChange={handleImageFileChange}
+              disabled={isUploadingImage}
+            />
             <button
-              className="absolute bottom-0 right-0 w-10 h-10 bg-indigo-500 rounded-full flex items-center justify-center shadow-lg hover:bg-indigo-600 transition-colors"
-              onClick={() => toast.info("프로필 사진 변경 기능은 준비 중입니다.")}
+              className="absolute bottom-0 right-0 w-10 h-10 bg-indigo-500 rounded-full flex items-center justify-center shadow-lg hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={handleImageUploadClick}
+              disabled={isUploadingImage}
+              aria-label="프로필 이미지 업로드"
             >
-              <svg
-                className="w-5 h-5 text-white"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
+              {isUploadingImage ? (
+                <svg
+                  className="w-5 h-5 text-white animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  className="w-5 h-5 text-white"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                </svg>
+              )}
             </button>
+            {profileImageUrl && (
+              <button
+                className="absolute top-0 right-0 w-8 h-8 bg-red-500 rounded-full flex items-center justify-center shadow-lg hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={handleImageDelete}
+                disabled={isUploadingImage}
+                aria-label="프로필 이미지 삭제"
+              >
+                <svg
+                  className="w-4 h-4 text-white"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            )}
           </div>
         </div>
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { mypageService } from "services/mypageService";
 import { toast } from "react-toastify";
 import type { ProfileUpdateRequestDto } from "types/MyPageTypes";
 import { logError } from "utils/errorUtils";
+import { Trash2 } from "lucide-react";
 
 const ProfilePage = () => {
   const navigate = useNavigate();
@@ -253,7 +254,7 @@ const ProfilePage = () => {
 
         {/* 프로필 사진 영역 */}
         <div className="flex justify-center mb-10">
-          <div className="relative">
+          <div className="relative group">
             <div className="w-32 h-32 bg-white rounded-full flex items-center justify-center shadow-lg overflow-hidden">
               {profileImageUrl ? (
                 <img
@@ -286,14 +287,14 @@ const ProfilePage = () => {
               disabled={isUploadingImage}
             />
             <button
-              className="absolute bottom-0 right-0 w-10 h-10 bg-indigo-500 rounded-full flex items-center justify-center shadow-lg hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="absolute bottom-0 right-0 w-7 h-7 bg-indigo-500 rounded-full flex items-center justify-center shadow-lg hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               onClick={handleImageUploadClick}
               disabled={isUploadingImage}
               aria-label="프로필 이미지 업로드"
             >
               {isUploadingImage ? (
                 <svg
-                  className="w-5 h-5 text-white animate-spin"
+                  className="w-4 h-4 text-white animate-spin"
                   fill="none"
                   viewBox="0 0 24 24"
                 >
@@ -313,7 +314,7 @@ const ProfilePage = () => {
                 </svg>
               ) : (
                 <svg
-                  className="w-5 h-5 text-white"
+                  className="w-4 h-4 text-white"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -335,24 +336,12 @@ const ProfilePage = () => {
             </button>
             {profileImageUrl && (
               <button
-                className="absolute top-0 right-0 w-8 h-8 bg-red-500 rounded-full flex items-center justify-center shadow-lg hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="absolute top-0 right-0 w-7 h-7 bg-gray-700/80 backdrop-blur-sm rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-gray-800/90 disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={handleImageDelete}
                 disabled={isUploadingImage}
                 aria-label="프로필 이미지 삭제"
               >
-                <svg
-                  className="w-4 h-4 text-white"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
+                <Trash2 className="w-3.5 h-3.5 text-white" />
               </button>
             )}
           </div>

--- a/frontend/src/pages/admin/PhoneModelManagePage.tsx
+++ b/frontend/src/pages/admin/PhoneModelManagePage.tsx
@@ -218,6 +218,7 @@ const PhoneModelManagePage = () => {
   const [editingModel, setEditingModel] = useState<PhoneModelResponse | null>(null);
   const [editForm, setEditForm] = useState<FormState>(DEFAULT_FORM);
   const [isUpdating, setIsUpdating] = useState(false);
+  const modalCardRef = useRef<HTMLDivElement>(null);
 
   const {
     data: models,
@@ -448,6 +449,28 @@ const PhoneModelManagePage = () => {
       imagePreviews.forEach((preview) => URL.revokeObjectURL(preview));
     };
   }, [imagePreviews]);
+
+  // 모달 외부 클릭 시 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        editingModel &&
+        modalCardRef.current &&
+        !modalCardRef.current.contains(event.target as Node)
+      ) {
+        setEditingModel(null);
+        setEditForm(DEFAULT_FORM);
+      }
+    };
+
+    if (editingModel) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [editingModel]);
 
   const handleSelectModel = async (modelId: string) => {
     setSelectedModelId(modelId);
@@ -896,7 +919,8 @@ const PhoneModelManagePage = () => {
       {/* 수정 모달 */}
       {editingModel && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <Card className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+          <div ref={modalCardRef}>
+            <Card className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
             <CardHeader>
               <CardTitle>모델 수정</CardTitle>
               <CardDescription>
@@ -973,6 +997,7 @@ const PhoneModelManagePage = () => {
               </div>
             </CardContent>
           </Card>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/pages/admin/PhoneModelManagePage.tsx
+++ b/frontend/src/pages/admin/PhoneModelManagePage.tsx
@@ -214,7 +214,9 @@ const PhoneModelManagePage = () => {
   const [isUploadingImages, setIsUploadingImages] = useState(false);
   const [isLoadingImages, setIsLoadingImages] = useState(false);
   const [imagePreviews, setImagePreviews] = useState<string[]>([]);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const imagePreviewsRef = useRef<string[]>([]);
+  const createFormFileInputRef = useRef<HTMLInputElement>(null);
+  const modelImageFileInputRef = useRef<HTMLInputElement>(null);
   const [editingModel, setEditingModel] = useState<PhoneModelResponse | null>(null);
   const [editForm, setEditForm] = useState<FormState>(DEFAULT_FORM);
   const [isUpdating, setIsUpdating] = useState(false);
@@ -336,8 +338,8 @@ const PhoneModelManagePage = () => {
         toast.success("휴대폰 모델이 생성되었습니다.");
       }
 
-      setSelectedModelId(createdModel.id);
       resetForm();
+      setSelectedModelId(createdModel.id);
       await mutate("/phone/models");
       // 생성된 모델의 이미지 로드
       await loadModelImages(createdModel.id);
@@ -360,8 +362,12 @@ const PhoneModelManagePage = () => {
     }
   };
 
-  const handleImageUploadClick = () => {
-    fileInputRef.current?.click();
+  const handleCreateFormImageUploadClick = () => {
+    createFormFileInputRef.current?.click();
+  };
+
+  const handleModelImageUploadClick = () => {
+    modelImageFileInputRef.current?.click();
   };
 
   const handleImageFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -408,8 +414,61 @@ const PhoneModelManagePage = () => {
     setImagePreviews((prev) => [...prev, ...newPreviews]);
 
     // 파일 input 초기화
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
+    if (createFormFileInputRef.current) {
+      createFormFileInputRef.current.value = "";
+    }
+  };
+
+  const handleModelImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (!files.length) return;
+
+    if (!selectedModelId) {
+      toast.error("모델을 선택해주세요.");
+      return;
+    }
+
+    // 파일 유효성 검사
+    const allowedTypes = [
+      "image/jpeg",
+      "image/jpg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+    ];
+    const invalidFiles = files.filter((file) => !allowedTypes.includes(file.type));
+    if (invalidFiles.length > 0) {
+      toast.error(
+        "지원하지 않는 파일 형식이 있습니다. (jpg, jpeg, png, gif, webp만 가능)"
+      );
+      return;
+    }
+
+    const maxSize = 5 * 1024 * 1024; // 5MB
+    const oversizedFiles = files.filter((file) => file.size > maxSize);
+    if (oversizedFiles.length > 0) {
+      toast.error("파일 크기는 5MB 이하여야 합니다.");
+      return;
+    }
+
+    const currentImageCount = modelImages.length;
+    if (currentImageCount + files.length > 10) {
+      toast.error("이미지는 최대 10개까지 업로드할 수 있습니다.");
+      return;
+    }
+
+    try {
+      setIsUploadingImages(true);
+      await uploadPhoneModelImages(selectedModelId, files);
+      toast.success("이미지가 업로드되었습니다.");
+      await loadModelImages(selectedModelId);
+    } catch (error) {
+      toast.error("이미지 업로드에 실패했습니다.");
+    } finally {
+      setIsUploadingImages(false);
+      if (modelImageFileInputRef.current) {
+        modelImageFileInputRef.current.value = "";
+      }
     }
   };
 
@@ -443,12 +502,17 @@ const PhoneModelManagePage = () => {
     }
   };
 
+  // imagePreviews 변경 시 ref 업데이트
+  useEffect(() => {
+    imagePreviewsRef.current = imagePreviews;
+  }, [imagePreviews]);
+
   // 컴포넌트 언마운트 시 미리보기 URL 정리
   useEffect(() => {
     return () => {
-      imagePreviews.forEach((preview) => URL.revokeObjectURL(preview));
+      imagePreviewsRef.current.forEach((preview) => URL.revokeObjectURL(preview));
     };
-  }, [imagePreviews]);
+  }, []);
 
   // 모달 외부 클릭 시 닫기
   useEffect(() => {
@@ -729,14 +793,14 @@ const PhoneModelManagePage = () => {
               <Button
                 type="button"
                 variant="secondary"
-                onClick={handleImageUploadClick}
+                onClick={handleCreateFormImageUploadClick}
                 disabled={form.selectedImages.length >= 10}
               >
                 이미지 추가
               </Button>
             </div>
             <input
-              ref={fileInputRef}
+              ref={createFormFileInputRef}
               type="file"
               accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
               multiple
@@ -812,12 +876,12 @@ const PhoneModelManagePage = () => {
           </CardHeader>
           <CardContent className="space-y-4">
             <input
-              ref={fileInputRef}
+              ref={modelImageFileInputRef}
               type="file"
               accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
               multiple
               className="hidden"
-              onChange={handleImageFileChange}
+              onChange={handleModelImageUpload}
               disabled={isUploadingImages}
             />
             <div className="flex items-center justify-between">
@@ -827,7 +891,7 @@ const PhoneModelManagePage = () => {
               <Button
                 type="button"
                 variant="secondary"
-                onClick={handleImageUploadClick}
+                onClick={handleModelImageUploadClick}
                 disabled={isUploadingImages || modelImages.length >= 10}
               >
                 {isUploadingImages ? "업로드 중..." : "이미지 추가"}

--- a/frontend/src/pages/admin/PhoneModelManagePage.tsx
+++ b/frontend/src/pages/admin/PhoneModelManagePage.tsx
@@ -3,6 +3,8 @@ import useSWR, { mutate } from "swr";
 import { defaultSWRConfig } from "services/swrConfig";
 import {
   createPhoneModel,
+  updatePhoneModel,
+  deletePhoneModel,
   uploadPhoneModelImages,
   getPhoneModelImages,
   deletePhoneModelImage,
@@ -10,6 +12,7 @@ import {
 import type {
   Brand,
   PhoneModelCreateRequest,
+  PhoneModelUpdateRequest,
   PhoneModelOptionRequest,
   PhoneModelResponse,
   PhoneOptionType,
@@ -25,6 +28,7 @@ import {
 } from "@/components/ui/card";
 import Input from "@/components/common/Input";
 import { toast } from "react-toastify";
+import { Pencil, Trash2 } from "lucide-react";
 
 interface FormState {
   brand: Brand | "";
@@ -68,10 +72,14 @@ const ModelListItem = ({
   model,
   selectedModelId,
   onSelect,
+  onEdit,
+  onDelete,
 }: {
   model: PhoneModelResponse;
   selectedModelId: string | null;
   onSelect: () => void;
+  onEdit: (model: PhoneModelResponse) => void;
+  onDelete: (modelId: string) => void;
 }) => {
   const { data: images } = useSWR<PhoneModelImageResponse[]>(
     `/phone/models/${model.id}/images`,
@@ -80,18 +88,29 @@ const ModelListItem = ({
 
   const firstImage = images && images.length > 0 ? images[0] : null;
 
+  const handleEditClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onEdit(model);
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (window.confirm(`"${model.brand} ${model.model}" 모델을 삭제하시겠습니까?`)) {
+      onDelete(model.id);
+    }
+  };
+
   return (
     <div
-      className={`rounded-lg border p-4 cursor-pointer transition-colors ${
+      className={`rounded-lg border p-4 transition-colors ${
         selectedModelId === model.id
           ? "border-indigo-500 bg-indigo-50"
           : "hover:bg-gray-50"
       }`}
-      onClick={onSelect}
     >
       <div className="flex flex-col gap-4 md:flex-row md:items-start">
         {/* 이미지 영역 */}
-        <div className="flex-shrink-0">
+        <div className="flex-shrink-0 cursor-pointer" onClick={onSelect}>
           {firstImage ? (
             <img
               src={firstImage.imageUrl}
@@ -119,7 +138,7 @@ const ModelListItem = ({
 
         {/* 모델 정보 영역 */}
         <div className="flex-1 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <div>
+          <div className="flex-1 cursor-pointer" onClick={onSelect}>
             <p className="text-sm font-medium text-muted-foreground">
               {model.brand}
             </p>
@@ -130,18 +149,38 @@ const ModelListItem = ({
               </p>
             )}
           </div>
-          <div className="text-sm text-muted-foreground">
-            {model.releasedPrice ? (
-              <p>출시가: {model.releasedPrice.toLocaleString()}원</p>
-            ) : (
-              <p>출시가 정보 없음</p>
-            )}
-            <p>
-              출시일:{" "}
-              {model.releasedAt
-                ? new Date(model.releasedAt).toLocaleDateString()
-                : "미입력"}
-            </p>
+          <div className="flex items-center gap-4">
+            <div className="text-sm text-muted-foreground">
+              {model.releasedPrice ? (
+                <p>출시가: {model.releasedPrice.toLocaleString()}원</p>
+              ) : (
+                <p>출시가 정보 없음</p>
+              )}
+              <p>
+                출시일:{" "}
+                {model.releasedAt
+                  ? new Date(model.releasedAt).toLocaleDateString()
+                  : "미입력"}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleEditClick}
+                className="p-2 text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+                aria-label="수정"
+              >
+                <Pencil className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={handleDeleteClick}
+                className="p-2 text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+                aria-label="삭제"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -176,6 +215,9 @@ const PhoneModelManagePage = () => {
   const [isLoadingImages, setIsLoadingImages] = useState(false);
   const [imagePreviews, setImagePreviews] = useState<string[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [editingModel, setEditingModel] = useState<PhoneModelResponse | null>(null);
+  const [editForm, setEditForm] = useState<FormState>(DEFAULT_FORM);
+  const [isUpdating, setIsUpdating] = useState(false);
 
   const {
     data: models,
@@ -411,6 +453,91 @@ const PhoneModelManagePage = () => {
   const handleSelectModel = async (modelId: string) => {
     setSelectedModelId(modelId);
     await loadModelImages(modelId);
+  };
+
+  const handleEditModel = (model: PhoneModelResponse) => {
+    setEditingModel(model);
+    let releasedAtValue: string = "";
+    if (model.releasedAt) {
+      try {
+        const dateStr = new Date(model.releasedAt).toISOString().split("T")[0];
+        releasedAtValue = dateStr || "";
+      } catch {
+        releasedAtValue = "";
+      }
+    }
+    setEditForm({
+      brand: model.brand,
+      model: model.model,
+      modelNumber: model.modelNumber ?? "",
+      releasedPrice: model.releasedPrice?.toString() ?? "",
+      releasedAt: releasedAtValue,
+      options: model.options
+        ? model.options.map((opt): FormOption => ({
+            id: opt.id,
+            type: opt.optionType,
+            value: opt.optionValue,
+            displayLabel: opt.displayLabel ?? "",
+          }))
+        : [],
+      selectedImages: [],
+    });
+  };
+
+  const handleUpdateModel = async () => {
+    if (!editingModel) return;
+
+    if (!editForm.brand || !editForm.model.trim()) {
+      toast.error("브랜드와 모델명은 필수입니다.");
+      return;
+    }
+
+    try {
+      setIsUpdating(true);
+      const payload: PhoneModelUpdateRequest = {
+        brand: editForm.brand as Brand,
+        model: editForm.model.trim(),
+        modelNumber: editForm.modelNumber.trim() || undefined,
+        releasedPrice: editForm.releasedPrice
+          ? Number.parseInt(editForm.releasedPrice, 10)
+          : undefined,
+        releasedAt: editForm.releasedAt || undefined,
+      };
+
+      await updatePhoneModel(editingModel.id, payload);
+      toast.success("모델이 수정되었습니다.");
+      setEditingModel(null);
+      setEditForm(DEFAULT_FORM);
+      await mutate("/phone/models");
+    } catch (error) {
+      console.error("Failed to update phone model", error);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleDeleteModel = async (modelId: string) => {
+    try {
+      await deletePhoneModel(modelId);
+      toast.success("모델이 삭제되었습니다.");
+      if (selectedModelId === modelId) {
+        setSelectedModelId(null);
+        setModelImages([]);
+      }
+      await mutate("/phone/models");
+    } catch (error) {
+      console.error("Failed to delete phone model", error);
+    }
+  };
+
+  const handleEditFormChange = <K extends keyof FormState>(
+    key: K,
+    value: FormState[K]
+  ) => {
+    setEditForm((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
   };
 
   const renderOptions = () => {
@@ -753,6 +880,8 @@ const PhoneModelManagePage = () => {
                     model={model}
                     selectedModelId={selectedModelId}
                     onSelect={() => handleSelectModel(model.id)}
+                    onEdit={handleEditModel}
+                    onDelete={handleDeleteModel}
                   />
                 ))
               ) : (
@@ -764,6 +893,89 @@ const PhoneModelManagePage = () => {
           )}
         </CardContent>
       </Card>
+
+      {/* 수정 모달 */}
+      {editingModel && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <Card className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+            <CardHeader>
+              <CardTitle>모델 수정</CardTitle>
+              <CardDescription>
+                모델 정보를 수정할 수 있습니다.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-sm font-medium">브랜드</label>
+                  <select
+                    className="w-full rounded-md border px-3 py-2"
+                    value={editForm.brand}
+                    onChange={(event) =>
+                      handleEditFormChange("brand", event.target.value as Brand | "")
+                    }
+                  >
+                    <option value="">브랜드 선택</option>
+                    {BRAND_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <Input
+                  label="모델명"
+                  required
+                  value={editForm.model}
+                  onChange={(value) => handleEditFormChange("model", value)}
+                />
+                <Input
+                  label="모델 번호"
+                  value={editForm.modelNumber}
+                  onChange={(value) => handleEditFormChange("modelNumber", value)}
+                />
+                <Input
+                  label="출시가"
+                  type="number"
+                  value={editForm.releasedPrice}
+                  onChange={(value) => handleEditFormChange("releasedPrice", value)}
+                />
+                <div>
+                  <label className="mb-1 block text-sm font-medium">출시일</label>
+                  <input
+                    type="date"
+                    className="w-full rounded-md border px-3 py-2"
+                    value={editForm.releasedAt || ""}
+                    onChange={(event) =>
+                      handleEditFormChange("releasedAt", event.target.value)
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-3">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    setEditingModel(null);
+                    setEditForm(DEFAULT_FORM);
+                  }}
+                >
+                  취소
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleUpdateModel}
+                  disabled={isUpdating || !editForm.brand || !editForm.model.trim()}
+                >
+                  {isUpdating ? "수정 중..." : "수정 완료"}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/admin/PhoneModelManagePage.tsx
+++ b/frontend/src/pages/admin/PhoneModelManagePage.tsx
@@ -63,6 +63,110 @@ const OPTION_TYPE_OPTIONS: { label: string; value: PhoneOptionType }[] = [
   { label: "저장용량", value: "STORAGE" },
 ];
 
+// 모델 목록 아이템 컴포넌트
+const ModelListItem = ({
+  model,
+  selectedModelId,
+  onSelect,
+}: {
+  model: PhoneModelResponse;
+  selectedModelId: string | null;
+  onSelect: () => void;
+}) => {
+  const { data: images } = useSWR<PhoneModelImageResponse[]>(
+    `/phone/models/${model.id}/images`,
+    defaultSWRConfig
+  );
+
+  const firstImage = images && images.length > 0 ? images[0] : null;
+
+  return (
+    <div
+      className={`rounded-lg border p-4 cursor-pointer transition-colors ${
+        selectedModelId === model.id
+          ? "border-indigo-500 bg-indigo-50"
+          : "hover:bg-gray-50"
+      }`}
+      onClick={onSelect}
+    >
+      <div className="flex flex-col gap-4 md:flex-row md:items-start">
+        {/* 이미지 영역 */}
+        <div className="flex-shrink-0">
+          {firstImage ? (
+            <img
+              src={firstImage.imageUrl}
+              alt={model.model}
+              className="w-24 h-24 object-cover rounded-lg border"
+            />
+          ) : (
+            <div className="w-24 h-24 rounded-lg border bg-muted flex items-center justify-center">
+              <svg
+                className="w-12 h-12 text-muted-foreground"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+          )}
+        </div>
+
+        {/* 모델 정보 영역 */}
+        <div className="flex-1 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">
+              {model.brand}
+            </p>
+            <h3 className="text-lg font-semibold">{model.model}</h3>
+            {model.modelNumber && (
+              <p className="text-sm text-muted-foreground">
+                모델 번호: {model.modelNumber}
+              </p>
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {model.releasedPrice ? (
+              <p>출시가: {model.releasedPrice.toLocaleString()}원</p>
+            ) : (
+              <p>출시가 정보 없음</p>
+            )}
+            <p>
+              출시일:{" "}
+              {model.releasedAt
+                ? new Date(model.releasedAt).toLocaleDateString()
+                : "미입력"}
+            </p>
+          </div>
+        </div>
+      </div>
+      {model.options && model.options.length > 0 && (
+        <div className="mt-4 space-y-2">
+          <h4 className="text-sm font-semibold">옵션</h4>
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+            {model.options.map((option) => (
+              <div
+                key={option.id}
+                className="flex items-center justify-between rounded-md bg-muted px-3 py-2 text-sm"
+              >
+                <span className="font-medium">{option.optionType}</span>
+                <span>
+                  {option.displayLabel || option.optionValue}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
 const PhoneModelManagePage = () => {
   const [form, setForm] = useState<FormState>(DEFAULT_FORM);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -644,64 +748,12 @@ const PhoneModelManagePage = () => {
             <div className="space-y-6">
               {models && models.length > 0 ? (
                 models.map((model) => (
-                  <div
+                  <ModelListItem
                     key={model.id}
-                    className={`rounded-lg border p-4 cursor-pointer transition-colors ${
-                      selectedModelId === model.id
-                        ? "border-indigo-500 bg-indigo-50"
-                        : "hover:bg-gray-50"
-                    }`}
-                    onClick={() => handleSelectModel(model.id)}
-                  >
-                    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                      <div>
-                        <p className="text-sm font-medium text-muted-foreground">
-                          {model.brand}
-                        </p>
-                        <h3 className="text-lg font-semibold">{model.model}</h3>
-                        {model.modelNumber && (
-                          <p className="text-sm text-muted-foreground">
-                            모델 번호: {model.modelNumber}
-                          </p>
-                        )}
-                      </div>
-                      <div className="text-sm text-muted-foreground">
-                        {model.releasedPrice ? (
-                          <p>
-                            출시가: {model.releasedPrice.toLocaleString()}원
-                          </p>
-                        ) : (
-                          <p>출시가 정보 없음</p>
-                        )}
-                        <p>
-                          출시일:{" "}
-                          {model.releasedAt
-                            ? new Date(model.releasedAt).toLocaleDateString()
-                            : "미입력"}
-                        </p>
-                      </div>
-                    </div>
-                    {model.options && model.options.length > 0 && (
-                      <div className="mt-4 space-y-2">
-                        <h4 className="text-sm font-semibold">옵션</h4>
-                        <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-                          {model.options.map((option) => (
-                            <div
-                              key={option.id}
-                              className="flex items-center justify-between rounded-md bg-muted px-3 py-2 text-sm"
-                            >
-                              <span className="font-medium">
-                                {option.optionType}
-                              </span>
-                              <span>
-                                {option.displayLabel || option.optionValue}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
+                    model={model}
+                    selectedModelId={selectedModelId}
+                    onSelect={() => handleSelectModel(model.id)}
+                  />
                 ))
               ) : (
                 <p className="text-sm text-muted-foreground">

--- a/frontend/src/pages/admin/PhoneModelManagePage.tsx
+++ b/frontend/src/pages/admin/PhoneModelManagePage.tsx
@@ -1,13 +1,19 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, useRef, useEffect } from "react";
 import useSWR, { mutate } from "swr";
 import { defaultSWRConfig } from "services/swrConfig";
-import { createPhoneModel } from "services/phoneModelService";
+import {
+  createPhoneModel,
+  uploadPhoneModelImages,
+  getPhoneModelImages,
+  deletePhoneModelImage,
+} from "services/phoneModelService";
 import type {
   Brand,
   PhoneModelCreateRequest,
   PhoneModelOptionRequest,
   PhoneModelResponse,
   PhoneOptionType,
+  PhoneModelImageResponse,
 } from "types/PhoneModelTypes";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,6 +33,7 @@ interface FormState {
   releasedPrice: string;
   releasedAt: string;
   options: FormOption[];
+  selectedImages: File[];
 }
 
 interface FormOption {
@@ -43,6 +50,7 @@ const DEFAULT_FORM: FormState = {
   releasedPrice: "",
   releasedAt: "",
   options: [],
+  selectedImages: [],
 };
 
 const BRAND_OPTIONS: { label: string; value: Brand }[] = [
@@ -58,6 +66,12 @@ const OPTION_TYPE_OPTIONS: { label: string; value: PhoneOptionType }[] = [
 const PhoneModelManagePage = () => {
   const [form, setForm] = useState<FormState>(DEFAULT_FORM);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
+  const [modelImages, setModelImages] = useState<PhoneModelImageResponse[]>([]);
+  const [isUploadingImages, setIsUploadingImages] = useState(false);
+  const [isLoadingImages, setIsLoadingImages] = useState(false);
+  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const {
     data: models,
@@ -68,6 +82,9 @@ const PhoneModelManagePage = () => {
   // const { data: brands } = useSWR("/phone/brands");
   const resetForm = useCallback(() => {
     setForm(DEFAULT_FORM);
+    setImagePreviews([]);
+    setSelectedModelId(null);
+    setModelImages([]);
   }, []);
 
   const canSubmit = useMemo(() => {
@@ -155,16 +172,141 @@ const PhoneModelManagePage = () => {
           })),
       };
 
-      await createPhoneModel(payload);
+      const createdModel = await createPhoneModel(payload);
 
-      toast.success("휴대폰 모델이 생성되었습니다.");
+      // 모델 생성 후 선택된 이미지들 업로드
+      if (form.selectedImages.length > 0) {
+        try {
+          setIsUploadingImages(true);
+          await uploadPhoneModelImages(createdModel.id, form.selectedImages);
+          toast.success("휴대폰 모델과 이미지가 생성되었습니다.");
+        } catch (imageError) {
+          console.error("Failed to upload images", imageError);
+          toast.error("모델은 생성되었지만 이미지 업로드에 실패했습니다.");
+        } finally {
+          setIsUploadingImages(false);
+        }
+      } else {
+        toast.success("휴대폰 모델이 생성되었습니다.");
+      }
+
+      setSelectedModelId(createdModel.id);
       resetForm();
       await mutate("/phone/models");
+      // 생성된 모델의 이미지 로드
+      await loadModelImages(createdModel.id);
     } catch (submitError) {
       console.error("Failed to create phone model", submitError);
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const loadModelImages = async (modelId: string) => {
+    try {
+      setIsLoadingImages(true);
+      const images = await getPhoneModelImages(modelId);
+      setModelImages(images);
+    } catch (error) {
+      console.error("Failed to load model images", error);
+    } finally {
+      setIsLoadingImages(false);
+    }
+  };
+
+  const handleImageUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImageFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (!files.length) return;
+
+    // 파일 유효성 검사
+    const allowedTypes = [
+      "image/jpeg",
+      "image/jpg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+    ];
+    const invalidFiles = files.filter((file) => !allowedTypes.includes(file.type));
+    if (invalidFiles.length > 0) {
+      toast.error(
+        "지원하지 않는 파일 형식이 있습니다. (jpg, jpeg, png, gif, webp만 가능)"
+      );
+      return;
+    }
+
+    const maxSize = 5 * 1024 * 1024; // 5MB
+    const oversizedFiles = files.filter((file) => file.size > maxSize);
+    if (oversizedFiles.length > 0) {
+      toast.error("파일 크기는 5MB 이하여야 합니다.");
+      return;
+    }
+
+    const currentImageCount = form.selectedImages.length;
+    if (currentImageCount + files.length > 10) {
+      toast.error("이미지는 최대 10개까지 선택할 수 있습니다.");
+      return;
+    }
+
+    // 이미지 파일 추가
+    setForm((prev) => ({
+      ...prev,
+      selectedImages: [...prev.selectedImages, ...files],
+    }));
+
+    // 미리보기 생성
+    const newPreviews = files.map((file) => URL.createObjectURL(file));
+    setImagePreviews((prev) => [...prev, ...newPreviews]);
+
+    // 파일 input 초기화
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleRemoveSelectedImage = (index: number) => {
+    setForm((prev) => ({
+      ...prev,
+      selectedImages: prev.selectedImages.filter((_, i) => i !== index),
+    }));
+    setImagePreviews((prev) => {
+      const removedPreview = prev[index];
+      if (removedPreview) {
+        URL.revokeObjectURL(removedPreview);
+      }
+      return prev.filter((_, i) => i !== index);
+    });
+  };
+
+  const handleImageDelete = async (imageId: string) => {
+    if (!selectedModelId) return;
+
+    if (!window.confirm("이미지를 삭제하시겠습니까?")) {
+      return;
+    }
+
+    try {
+      await deletePhoneModelImage(selectedModelId, imageId);
+      setModelImages((prev) => prev.filter((img) => img.id !== imageId));
+      toast.success("이미지가 삭제되었습니다.");
+    } catch (error) {
+      console.error("Failed to delete image", error);
+    }
+  };
+
+  // 컴포넌트 언마운트 시 미리보기 URL 정리
+  useEffect(() => {
+    return () => {
+      imagePreviews.forEach((preview) => URL.revokeObjectURL(preview));
+    };
+  }, [imagePreviews]);
+
+  const handleSelectModel = async (modelId: string) => {
+    setSelectedModelId(modelId);
+    await loadModelImages(modelId);
   };
 
   const renderOptions = () => {
@@ -323,6 +465,75 @@ const PhoneModelManagePage = () => {
             {renderOptions()}
           </div>
 
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-lg font-semibold">모델 이미지</h3>
+                <p className="text-sm text-muted-foreground">
+                  모델 이미지를 업로드할 수 있습니다. (최대 10개, 선택사항)
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleImageUploadClick}
+                disabled={form.selectedImages.length >= 10}
+              >
+                이미지 추가
+              </Button>
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
+              multiple
+              className="hidden"
+              onChange={handleImageFileChange}
+            />
+            {form.selectedImages.length > 0 ? (
+              <div className="grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-5">
+                {form.selectedImages.map((_, index) => (
+                  <div key={index} className="relative group">
+                    <img
+                      src={imagePreviews[index]}
+                      alt={`미리보기 ${index + 1}`}
+                      className="w-full h-32 object-cover rounded-lg border"
+                    />
+                    <button
+                      className="absolute top-1 right-1 w-6 h-6 bg-red-500 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={() => handleRemoveSelectedImage(index)}
+                      type="button"
+                      aria-label="이미지 제거"
+                    >
+                      <svg
+                        className="w-4 h-4 text-white"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                선택된 이미지가 없습니다. 이미지를 추가하려면 위 버튼을 클릭하세요.
+              </p>
+            )}
+            {form.selectedImages.length > 0 && (
+              <p className="text-sm text-muted-foreground">
+                선택된 이미지: {form.selectedImages.length} / 10
+              </p>
+            )}
+          </div>
+
           <div className="flex justify-end gap-3">
             <Button type="button" variant="ghost" onClick={resetForm}>
               초기화
@@ -337,6 +548,81 @@ const PhoneModelManagePage = () => {
           </div>
         </CardContent>
       </Card>
+
+      {selectedModelId && (
+        <Card>
+          <CardHeader>
+            <CardTitle>모델 이미지 관리</CardTitle>
+            <CardDescription>
+              생성된 모델의 이미지를 업로드할 수 있습니다. (최대 10개)
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
+              multiple
+              className="hidden"
+              onChange={handleImageFileChange}
+              disabled={isUploadingImages}
+            />
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                업로드된 이미지: {modelImages.length} / 10
+              </p>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleImageUploadClick}
+                disabled={isUploadingImages || modelImages.length >= 10}
+              >
+                {isUploadingImages ? "업로드 중..." : "이미지 추가"}
+              </Button>
+            </div>
+            {isLoadingImages ? (
+              <p className="text-sm text-muted-foreground">
+                이미지를 불러오는 중...
+              </p>
+            ) : modelImages.length > 0 ? (
+              <div className="grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-5">
+                {modelImages.map((image) => (
+                  <div key={image.id} className="relative group">
+                    <img
+                      src={image.imageUrl}
+                      alt={`모델 이미지 ${image.displayOrder}`}
+                      className="w-full h-32 object-cover rounded-lg border"
+                    />
+                    <button
+                      className="absolute top-1 right-1 w-6 h-6 bg-red-500 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={() => handleImageDelete(image.id)}
+                      aria-label="이미지 삭제"
+                    >
+                      <svg
+                        className="w-4 h-4 text-white"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                업로드된 이미지가 없습니다.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       <Card>
         <CardHeader>
@@ -358,7 +644,15 @@ const PhoneModelManagePage = () => {
             <div className="space-y-6">
               {models && models.length > 0 ? (
                 models.map((model) => (
-                  <div key={model.id} className="rounded-lg border p-4">
+                  <div
+                    key={model.id}
+                    className={`rounded-lg border p-4 cursor-pointer transition-colors ${
+                      selectedModelId === model.id
+                        ? "border-indigo-500 bg-indigo-50"
+                        : "hover:bg-gray-50"
+                    }`}
+                    onClick={() => handleSelectModel(model.id)}
+                  >
                     <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                       <div>
                         <p className="text-sm font-medium text-muted-foreground">

--- a/frontend/src/pages/admin/PhoneModelManagePage.tsx
+++ b/frontend/src/pages/admin/PhoneModelManagePage.tsx
@@ -327,7 +327,6 @@ const PhoneModelManagePage = () => {
           await uploadPhoneModelImages(createdModel.id, form.selectedImages);
           toast.success("휴대폰 모델과 이미지가 생성되었습니다.");
         } catch (imageError) {
-          console.error("Failed to upload images", imageError);
           toast.error("모델은 생성되었지만 이미지 업로드에 실패했습니다.");
         } finally {
           setIsUploadingImages(false);
@@ -342,7 +341,7 @@ const PhoneModelManagePage = () => {
       // 생성된 모델의 이미지 로드
       await loadModelImages(createdModel.id);
     } catch (submitError) {
-      console.error("Failed to create phone model", submitError);
+      toast.error("휴대폰 모델 생성에 실패했습니다.");
     } finally {
       setIsSubmitting(false);
     }
@@ -354,7 +353,7 @@ const PhoneModelManagePage = () => {
       const images = await getPhoneModelImages(modelId);
       setModelImages(images);
     } catch (error) {
-      console.error("Failed to load model images", error);
+      toast.error("모델 이미지를 불러오는데 실패했습니다.");
     } finally {
       setIsLoadingImages(false);
     }
@@ -439,7 +438,7 @@ const PhoneModelManagePage = () => {
       setModelImages((prev) => prev.filter((img) => img.id !== imageId));
       toast.success("이미지가 삭제되었습니다.");
     } catch (error) {
-      console.error("Failed to delete image", error);
+      toast.error("이미지 삭제에 실패했습니다.");
     }
   };
 
@@ -510,7 +509,7 @@ const PhoneModelManagePage = () => {
       setEditForm(DEFAULT_FORM);
       await mutate("/phone/models");
     } catch (error) {
-      console.error("Failed to update phone model", error);
+      toast.error("모델 수정에 실패했습니다.");
     } finally {
       setIsUpdating(false);
     }
@@ -526,7 +525,7 @@ const PhoneModelManagePage = () => {
       }
       await mutate("/phone/models");
     } catch (error) {
-      console.error("Failed to delete phone model", error);
+      toast.error("모델 삭제에 실패했습니다.");
     }
   };
 

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -31,6 +31,10 @@ class ApiClient {
         if (token) {
           config.headers.Authorization = "Bearer " + token;
         }
+        // FormData인 경우 Content-Type 헤더를 삭제하여 브라우저가 자동으로 boundary를 포함한 올바른 Content-Type을 설정하도록 함
+        if (config.data instanceof FormData) {
+          delete config.headers["Content-Type"];
+        }
         return config;
       },
       (error) => Promise.reject(error)

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -103,3 +103,19 @@ export const leaveChatRoom = async (chatRoomId: string): Promise<void> => {
   return await apiClient.delete<void>(`${BASE_URL}/${chatRoomId}`);
 };
 
+/**
+ * 채팅 이미지 업로드
+ */
+export const uploadChatImage = async (
+  chatRoomId: string,
+  file: File
+): Promise<{ imageUrl: string }> => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  return await apiClient.post<{ imageUrl: string }>(
+    `${BASE_URL}/${chatRoomId}/images/upload`,
+    formData
+  );
+};
+

--- a/frontend/src/services/mypageService.ts
+++ b/frontend/src/services/mypageService.ts
@@ -191,5 +191,31 @@ export const mypageService = {
       throw error;
     }
   },
+
+  uploadProfileImage: async (file: File): Promise<{ profileImageUrl: string }> => {
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      
+      return await apiClient.post<{ profileImageUrl: string }>(
+        `${ENDPOINTS.PROFILE}/image`,
+        formData
+      );
+    } catch (error: unknown) {
+      logError("프로필 이미지 업로드 실패:", error);
+      toast.error("프로필 이미지 업로드에 실패했습니다.");
+      throw error;
+    }
+  },
+
+  deleteProfileImage: async (): Promise<void> => {
+    try {
+      return await apiClient.delete<void>(`${ENDPOINTS.PROFILE}/image`);
+    } catch (error: unknown) {
+      logError("프로필 이미지 삭제 실패:", error);
+      toast.error("프로필 이미지 삭제에 실패했습니다.");
+      throw error;
+    }
+  },
 };
 

--- a/frontend/src/services/phoneModelService.ts
+++ b/frontend/src/services/phoneModelService.ts
@@ -4,6 +4,8 @@ import type {
   PhoneModelCreateRequest,
   PhoneModelResponse,
   PhoneModelUpdateRequest,
+  PhoneModelImageResponse,
+  PhoneModelImageUploadResponse,
 } from "types/PhoneModelTypes";
 
 const BASE_URL = "/phone/models";
@@ -52,6 +54,56 @@ export const deletePhoneModel = async (id: string): Promise<void> => {
   } catch (err) {
     console.error(err);
     toast.error("휴대폰 모델 삭제에 실패했습니다.");
+    throw err;
+  }
+};
+
+export const uploadPhoneModelImages = async (
+  phoneModelId: string,
+  files: File[]
+): Promise<PhoneModelImageUploadResponse> => {
+  try {
+    const formData = new FormData();
+    files.forEach((file) => {
+      formData.append("files", file);
+    });
+
+    return await apiClient.post<PhoneModelImageUploadResponse>(
+      `${BASE_URL}/${phoneModelId}/images`,
+      formData
+    );
+  } catch (err) {
+    console.error(err);
+    toast.error("핸드폰 모델 이미지 업로드에 실패했습니다.");
+    throw err;
+  }
+};
+
+export const getPhoneModelImages = async (
+  phoneModelId: string
+): Promise<PhoneModelImageResponse[]> => {
+  try {
+    return await apiClient.get<PhoneModelImageResponse[]>(
+      `${BASE_URL}/${phoneModelId}/images`
+    );
+  } catch (err) {
+    console.error(err);
+    toast.error("핸드폰 모델 이미지 조회에 실패했습니다.");
+    throw err;
+  }
+};
+
+export const deletePhoneModelImage = async (
+  phoneModelId: string,
+  imageId: string
+): Promise<void> => {
+  try {
+    return await apiClient.delete<void>(
+      `${BASE_URL}/${phoneModelId}/images/${imageId}`
+    );
+  } catch (err) {
+    console.error(err);
+    toast.error("핸드폰 모델 이미지 삭제에 실패했습니다.");
     throw err;
   }
 };

--- a/frontend/src/types/MyPageTypes.ts
+++ b/frontend/src/types/MyPageTypes.ts
@@ -3,6 +3,7 @@ export interface ProfileResponseDto {
   nickname: string;
   phone: string | null;
   name: string;
+  profileImageUrl?: string | null;
 }
 
 export interface ProfileUpdateRequestDto {

--- a/frontend/src/types/PhoneModelTypes.ts
+++ b/frontend/src/types/PhoneModelTypes.ts
@@ -47,3 +47,13 @@ export interface PhoneModelUpdateRequest {
   releasedAt?: string;
   options?: PhoneModelOptionRequest[];
 }
+
+export interface PhoneModelImageResponse {
+  id: string;
+  imageUrl: string;
+  displayOrder: number;
+}
+
+export interface PhoneModelImageUploadResponse {
+  images: PhoneModelImageResponse[];
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #79.

## 📝작업 내용

> 백엔드와 프론트엔드 전반적으로 수정 및 구현 진행했습니다.

### 1. AWS S3 파일 업로드 인프라 구축
- **S3Service 구현**: AWS S3를 통한 파일 업로드/삭제 서비스 구현
  - 파일 업로드: `uploadFile()` - S3에 파일 저장 후 URL 반환
  - 파일 삭제: `deleteFile()`, `deleteFileByUrl()` - 파일명 또는 URL로 삭제
  - URL 파싱 및 검증 로직 포함
- **S3Config 설정**: AWS SDK를 활용한 S3 클라이언트 빈 등록
- **파일명 생성 규칙**: 각 도메인별로 구조화된 경로 및 파일명 생성
  - 프로필 이미지: `profile-images/{userId}/{timestamp}_{filename}`
  - 핸드폰 모델 이미지: `phone-models/{phoneModelId}/{timestamp}_{index}_{filename}`
  - 판매자 문서: `seller-documents/{sellerId}/{documentType}/{uuid}-{filename}`
  - 채팅 이미지: `chat-images/{chatRoomId}/{uuid}-{filename}`

### 2. 이미지 업로드 기능 구현
- **프로필 이미지 업로드/삭제**
  - 기존 이미지 자동 삭제 후 새 이미지 업로드
  - 업로드 실패 시 롤백 처리
- **핸드폰 모델 이미지 업로드** (관리자 전용)
  - 다중 이미지 업로드 지원 (최대 10개)
  - 이미지별 displayOrder 관리
  - 업로드 실패 시 부분 업로드된 파일 롤백
- **채팅 이미지 업로드**

### 3. 백엔드 API 개선
- **RESTful API 설계로 리팩토링**
  - `PUT /api/v1/phone/models/{id}` - 모델 수정 (path variable 사용)
  - `DELETE /api/v1/phone/models/{id}` - 모델 삭제 (path variable 사용)
  - 기존 body에 id를 포함하던 방식에서 path variable 방식으로 변경
- **DTO 구조 개선**
  - `PhoneModelUpdateRequestDto`에서 id 필드 제거
  - `PhoneModelDeleteRequestDto` 사용 중단

### 4. 프론트엔드 기능 추가 및 개선
- **핸드폰 모델 관리 페이지**
  - 모델 수정/삭제 기능 추가
  - 모델 목록에 각 모델의 첫 번째 이미지 표시
  - 수정 모달 구현
- **프로필 페이지 UI 개선**
  - 프로필 사진 삭제 버튼을 호버 시에만 표시되도록 변경
  - 삭제 버튼 스타일 개선 (반투명 회색 배경, 쓰레기통 아이콘)

### 5. 버그 수정
- **FormData 전송 시 Content-Type 헤더 문제 해결**
  - `apiClient.ts`에서 FormData 전송 시 Content-Type 헤더를 삭제하도록 수정
  - 브라우저가 자동으로 `multipart/form-data; boundary=...` 형식 설정하도록 변경

### 6. 파일 검증 및 보안
- 이미지 파일 타입 검증 (jpg, jpeg, png, gif, webp)
- 파일 크기 제한 (5MB)
- 파일명 sanitization (특수문자 제거, 한글 지원)
- S3 버킷 검증 (다른 버킷의 파일 삭제 방지)

## 🔧기술 스택
- **백엔드**: Spring Cloud AWS (S3 SDK)
- **프론트엔드**: FormData, axios
- **인프라**: AWS S3
