### PR TITLE
Refactoring the parts to be fixed in the cell phone quote and chat domains

### DIFF
--- a/backend/src/main/java/com/phonebid/app/chat/dto/response/ChatRoomResponse.java
+++ b/backend/src/main/java/com/phonebid/app/chat/dto/response/ChatRoomResponse.java
@@ -21,13 +21,16 @@ public class ChatRoomResponse {
     
     private String sellerName;
     private String consumerName;
+    private String sellerProfileImageUrl;
+    private String consumerProfileImageUrl;
     private String lastMessage;
     private Integer totalPrice;
     private Long unreadCount;
 
     private ChatRoomResponse(UUID id, UUID quoteId, UUID consumerId, UUID sellerId,
                              ChatRoomStatus status, LocalDateTime createdAt, LocalDateTime updatedAt,
-                             String sellerName, String consumerName, String lastMessage, Integer totalPrice, Long unreadCount) {
+                             String sellerName, String consumerName, String sellerProfileImageUrl, String consumerProfileImageUrl,
+                             String lastMessage, Integer totalPrice, Long unreadCount) {
         this.id = id;
         this.quoteId = quoteId;
         this.consumerId = consumerId;
@@ -37,6 +40,8 @@ public class ChatRoomResponse {
         this.updatedAt = updatedAt;
         this.sellerName = sellerName;
         this.consumerName = consumerName;
+        this.sellerProfileImageUrl = sellerProfileImageUrl;
+        this.consumerProfileImageUrl = consumerProfileImageUrl;
         this.lastMessage = lastMessage;
         this.totalPrice = totalPrice;
         this.unreadCount = unreadCount;
@@ -53,13 +58,15 @@ public class ChatRoomResponse {
                 chatRoom.getUpdatedAt(),
                 null, // sellerName은 서비스에서 설정
                 null, // consumerName은 서비스에서 설정
+                null, // sellerProfileImageUrl은 서비스에서 설정
+                null, // consumerProfileImageUrl은 서비스에서 설정
                 null, // lastMessage는 서비스에서 설정
                 null, // totalPrice는 서비스에서 설정
                 null  // unreadCount는 서비스에서 설정
         );
     }
     
-    public static ChatRoomResponse from(ChatRoom chatRoom, String sellerName, String consumerName, String lastMessage, Integer totalPrice, Long unreadCount) {
+    public static ChatRoomResponse from(ChatRoom chatRoom, String sellerName, String consumerName, String sellerProfileImageUrl, String consumerProfileImageUrl, String lastMessage, Integer totalPrice, Long unreadCount) {
         return new ChatRoomResponse(
                 chatRoom.getId(),
                 chatRoom.getQuote().getId(),
@@ -70,6 +77,8 @@ public class ChatRoomResponse {
                 chatRoom.getUpdatedAt(),
                 sellerName,
                 consumerName,
+                sellerProfileImageUrl,
+                consumerProfileImageUrl,
                 lastMessage,
                 totalPrice,
                 unreadCount

--- a/backend/src/main/java/com/phonebid/app/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/phonebid/app/chat/service/ChatRoomService.java
@@ -107,16 +107,25 @@ public class ChatRoomService {
         validateParticipantByUserChatRoom(chatRoomId, requesterId);
         
         // 판매자 가게 이름
-        String sellerName = chatRoom.getSeller().getStoreName();
+        String sellerName = Optional.ofNullable(chatRoom.getSeller())
+                .map(Seller::getStoreName)
+                .orElse("");
         
         // 구매자 이름 (닉네임 사용)
-        String consumerName = chatRoom.getConsumer().getNickname();
+        String consumerName = Optional.ofNullable(chatRoom.getConsumer())
+                .map(User::getNickname)
+                .orElse("");
         
         // 판매자 프로필 이미지 URL
-        String sellerProfileImageUrl = chatRoom.getSeller().getUser().getProfileImageUrl();
+        String sellerProfileImageUrl = Optional.ofNullable(chatRoom.getSeller())
+                .map(Seller::getUser)
+                .map(User::getProfileImageUrl)
+                .orElse("");
         
         // 구매자 프로필 이미지 URL
-        String consumerProfileImageUrl = chatRoom.getConsumer().getProfileImageUrl();
+        String consumerProfileImageUrl = Optional.ofNullable(chatRoom.getConsumer())
+                .map(User::getProfileImageUrl)
+                .orElse("");
         
         // 읽지 않은 메시지 수
         long unreadCount = chatMessageRepository.countUnreadMessagesByChatRoomIdAndUserId(
@@ -235,16 +244,25 @@ public class ChatRoomService {
             ChatRoom chatRoom = userChatRoom.getChatRoom();
             
             // 판매자 가게 이름
-            String sellerName = chatRoom.getSeller().getStoreName();
+            String sellerName = Optional.ofNullable(chatRoom.getSeller())
+                    .map(Seller::getStoreName)
+                    .orElse("");
             
             // 구매자 이름 (닉네임 사용)
-            String consumerName = chatRoom.getConsumer().getNickname();
+            String consumerName = Optional.ofNullable(chatRoom.getConsumer())
+                    .map(User::getNickname)
+                    .orElse("");
             
             // 판매자 프로필 이미지 URL
-            String sellerProfileImageUrl = chatRoom.getSeller().getUser().getProfileImageUrl();
+            String sellerProfileImageUrl = Optional.ofNullable(chatRoom.getSeller())
+                    .map(Seller::getUser)
+                    .map(User::getProfileImageUrl)
+                    .orElse("");
             
             // 구매자 프로필 이미지 URL
-            String consumerProfileImageUrl = chatRoom.getConsumer().getProfileImageUrl();
+            String consumerProfileImageUrl = Optional.ofNullable(chatRoom.getConsumer())
+                    .map(User::getProfileImageUrl)
+                    .orElse("");
             
             // 마지막 메시지
             Optional<ChatMessage> lastMessageOpt = chatMessageRepository

--- a/backend/src/main/java/com/phonebid/app/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/phonebid/app/chat/service/ChatRoomService.java
@@ -112,11 +112,17 @@ public class ChatRoomService {
         // 구매자 이름 (닉네임 사용)
         String consumerName = chatRoom.getConsumer().getNickname();
         
+        // 판매자 프로필 이미지 URL
+        String sellerProfileImageUrl = chatRoom.getSeller().getUser().getProfileImageUrl();
+        
+        // 구매자 프로필 이미지 URL
+        String consumerProfileImageUrl = chatRoom.getConsumer().getProfileImageUrl();
+        
         // 읽지 않은 메시지 수
         long unreadCount = chatMessageRepository.countUnreadMessagesByChatRoomIdAndUserId(
                 chatRoomId, requesterId);
         
-        return ChatRoomResponse.from(chatRoom, sellerName, consumerName, null, null, unreadCount);
+        return ChatRoomResponse.from(chatRoom, sellerName, consumerName, sellerProfileImageUrl, consumerProfileImageUrl, null, null, unreadCount);
     }
 
     /**
@@ -234,6 +240,12 @@ public class ChatRoomService {
             // 구매자 이름 (닉네임 사용)
             String consumerName = chatRoom.getConsumer().getNickname();
             
+            // 판매자 프로필 이미지 URL
+            String sellerProfileImageUrl = chatRoom.getSeller().getUser().getProfileImageUrl();
+            
+            // 구매자 프로필 이미지 URL
+            String consumerProfileImageUrl = chatRoom.getConsumer().getProfileImageUrl();
+            
             // 마지막 메시지
             Optional<ChatMessage> lastMessageOpt = chatMessageRepository
                     .findFirstByChatRoomIdOrderByCreatedAtDesc(chatRoom.getId());
@@ -255,7 +267,7 @@ public class ChatRoomService {
             // 읽지 않은 메시지 수 (상대방이 보낸 메시지 중 읽지 않은 메시지)
             long unreadCount = chatMessageRepository.countUnreadMessagesByChatRoomIdAndUserId(chatRoom.getId(), userId);
             
-            return ChatRoomResponse.from(chatRoom, sellerName, consumerName, lastMessage, totalPrice, unreadCount);
+            return ChatRoomResponse.from(chatRoom, sellerName, consumerName, sellerProfileImageUrl, consumerProfileImageUrl, lastMessage, totalPrice, unreadCount);
         });
     }
 

--- a/backend/src/main/java/com/phonebid/app/common/errorcode/PhoneErrorCode.java
+++ b/backend/src/main/java/com/phonebid/app/common/errorcode/PhoneErrorCode.java
@@ -19,7 +19,8 @@ public enum PhoneErrorCode implements ErrorCode {
 
     // 휴대폰 모델 이미지 관련 에러
     PHONE_MODEL_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "휴대폰 모델 이미지를 찾을 수 없습니다."),
-    PHONE_MODEL_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "휴대폰 모델 이미지는 최대 10개까지 업로드할 수 있습니다.");
+    PHONE_MODEL_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "휴대폰 모델 이미지는 최대 10개까지 업로드할 수 있습니다."),
+    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 파일 삭제에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/phonebid/app/phone/controller/PhoneModelController.java
+++ b/backend/src/main/java/com/phonebid/app/phone/controller/PhoneModelController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import com.phonebid.app.phone.service.PhoneModelService;
 
@@ -47,8 +48,10 @@ public class PhoneModelController {
 
     /**
      * 휴대폰 모델 생성
+     * 관리자만 사용 가능합니다.
      */
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<PhoneModelResponseDto>> createPhoneModel(@RequestBody @Valid PhoneModelCreateRequestDto requestDto) {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "휴대폰 모델 생성이 성공적으로 완료되었습니다.", phoneModelService.createPhoneModel(requestDto)));
     }
@@ -56,8 +59,10 @@ public class PhoneModelController {
     /**
      * 휴대폰 모델 수정
      * PUT /api/v1/phone/models/{id}
+     * 관리자만 사용 가능합니다.
      */
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<PhoneModelResponseDto>> updatePhoneModel(@PathVariable UUID id,
                                                                                @RequestBody @Valid PhoneModelUpdateRequestDto requestDto) {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "휴대폰 모델 수정이 성공적으로 완료되었습니다.", phoneModelService.updatePhoneModel(id, requestDto)));
@@ -66,8 +71,10 @@ public class PhoneModelController {
     /**
      * 휴대폰 모델 삭제
      * DELETE /api/v1/phone/models/{id}
+     * 관리자만 사용 가능합니다.
      */
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<Void>> deletePhoneModel(@PathVariable UUID id) {
         phoneModelService.deletePhoneModel(id);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "휴대폰 모델 삭제가 성공적으로 완료되었습니다.", null));

--- a/backend/src/main/java/com/phonebid/app/phone/dto/response/PhoneModelResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/phone/dto/response/PhoneModelResponseDto.java
@@ -26,13 +26,14 @@ public class PhoneModelResponseDto {
     private Integer releasedPrice;
     private LocalDate releasedAt;
     private List<PhoneOptionResponseDto> options;
+    private String thumbnailImageUrl;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     // 옵션 정보는 별도 API로 조회하거나 PhoneModelWithOptionsResponseDto 사용
 
     public PhoneModelResponseDto(UUID id, Brand brand, String model, String modelNumber, 
                                Integer releasedPrice, LocalDate releasedAt, List<PhoneOptionResponseDto> options,
-                               LocalDateTime createdAt, LocalDateTime updatedAt) {
+                               String thumbnailImageUrl, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.brand = brand;
         this.model = model;
@@ -40,6 +41,7 @@ public class PhoneModelResponseDto {
         this.releasedPrice = releasedPrice;
         this.releasedAt = releasedAt;
         this.options = options;
+        this.thumbnailImageUrl = thumbnailImageUrl;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -64,6 +66,7 @@ public class PhoneModelResponseDto {
             phoneModel.getReleasedPrice(),
             phoneModel.getReleasedAt(),
             optionDtos,
+            null, // thumbnailImageUrl은 별도로 설정
             phoneModel.getCreatedAt(),
             phoneModel.getUpdatedAt()
         );
@@ -82,6 +85,32 @@ public class PhoneModelResponseDto {
             phoneModel.getReleasedPrice(),
             phoneModel.getReleasedAt(),
             null, // options는 null로 설정하여 순환 참조 방지
+            null, // thumbnailImageUrl은 별도로 설정
+            phoneModel.getCreatedAt(),
+            phoneModel.getUpdatedAt()
+        );
+    }
+
+    /**
+     * Entity를 DTO로 변환하는 정적 메서드 (썸네일 이미지 URL 포함)
+     */
+    public static PhoneModelResponseDto from(PhoneModel phoneModel, String thumbnailImageUrl) {
+        List<PhoneOptionResponseDto> optionDtos = null;
+        if (phoneModel.getOptions() != null) {
+            optionDtos = phoneModel.getOptions().stream()
+                .map(PhoneOptionResponseDto::from)
+                .collect(Collectors.toList());
+        }
+        
+        return new PhoneModelResponseDto(
+            phoneModel.getId(),
+            phoneModel.getBrand(),
+            phoneModel.getModel(),
+            phoneModel.getModelNumber(),
+            phoneModel.getReleasedPrice(),
+            phoneModel.getReleasedAt(),
+            optionDtos,
+            thumbnailImageUrl,
             phoneModel.getCreatedAt(),
             phoneModel.getUpdatedAt()
         );

--- a/backend/src/main/java/com/phonebid/app/phone/repository/PhoneModelImageRepository.java
+++ b/backend/src/main/java/com/phonebid/app/phone/repository/PhoneModelImageRepository.java
@@ -14,6 +14,14 @@ import java.util.UUID;
 public interface PhoneModelImageRepository extends JpaRepository<PhoneModelImage, UUID> {
     List<PhoneModelImage> findByPhoneModelIdOrderByDisplayOrder(UUID phoneModelId);
     
+    /**
+     * 여러 모델 ID에 해당하는 이미지들을 한 번에 조회
+     * 모델 ID와 displayOrder 순서로 정렬하여 반환
+     * 성능 최적화를 위해 N+1 쿼리 문제를 방지하기 위해 사용
+     */
+    @Query("SELECT pmi FROM PhoneModelImage pmi WHERE pmi.phoneModel.id IN :phoneModelIds ORDER BY pmi.phoneModel.id, pmi.displayOrder")
+    List<PhoneModelImage> findByPhoneModelIdInOrderByDisplayOrder(@Param("phoneModelIds") List<UUID> phoneModelIds);
+    
     @Modifying
     @Query("UPDATE PhoneModelImage p SET p.isDelete = true, p.deletedAt = CURRENT_TIMESTAMP WHERE p.phoneModel.id = :phoneModelId")
     void deleteByPhoneModelId(@Param("phoneModelId") UUID phoneModelId);

--- a/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelService.java
+++ b/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelService.java
@@ -18,15 +18,19 @@ import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto.OptionItem;
 import com.phonebid.app.phone.dto.request.PhoneModelUpdateRequestDto;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.PhoneErrorCode;
+import com.phonebid.app.common.errorcode.MemberErrorCode;
 import com.phonebid.app.phone.dto.response.PhoneModelResponseDto;
 import com.phonebid.app.phone.domain.PhoneModel;
 import com.phonebid.app.phone.domain.Brand;
 import com.phonebid.app.phone.domain.PhoneOption;
 import com.phonebid.app.phone.domain.PhoneModelImage;
 import com.phonebid.app.phone.repository.PhoneOptionRepository;
+import com.phonebid.app.s3.service.S3Service;
+import lombok.extern.slf4j.Slf4j;
 import java.util.stream.Collectors;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PhoneModelService {
@@ -34,6 +38,7 @@ public class PhoneModelService {
     private final PhoneModelRepository phoneModelRepository;
     private final PhoneOptionRepository phoneOptionRepository;
     private final PhoneModelImageRepository phoneModelImageRepository;
+    private final S3Service s3Service;
 
     /**
      * 휴대폰 모델 목록 조회
@@ -148,11 +153,40 @@ public class PhoneModelService {
     }
 
     
+    /**
+     * 휴대폰 모델 삭제
+     * 해당 모델의 모든 이미지를 S3에서 삭제한 후 DB에서도 삭제합니다.
+     */
     @Transactional
     public void deletePhoneModel(UUID id) {
         PhoneModel model = phoneModelRepository.findById(id)
             .orElseThrow(() -> new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND));
+        
+        // 해당 모델의 모든 이미지 조회
+        List<PhoneModelImage> images = phoneModelImageRepository.findByPhoneModelIdOrderByDisplayOrder(id);
+        
+        // S3에서 이미지 파일 삭제
+        for (PhoneModelImage image : images) {
+            try {
+                String imageUrl = image.getImageUrl();
+                if (imageUrl != null && !imageUrl.trim().isEmpty()) {
+                    s3Service.deleteFileByUrl(imageUrl);
+                    log.info("휴대폰 모델 이미지 S3 삭제 완료: modelId={}, imageUrl={}", id, imageUrl);
+                }
+            } catch (Exception e) {
+                log.error("휴대폰 모델 이미지 S3 삭제 실패: modelId={}, imageUrl={}", id, image.getImageUrl(), e);
+                throw new CustomException(MemberErrorCode.FILE_DELETE_FAILED);
+            }
+        }
+        
+        // DB에서 이미지 삭제
+        if (!images.isEmpty()) {
+            phoneModelImageRepository.deleteAll(images);
+        }
+        
+        // DB에서 모델 삭제
         phoneModelRepository.delete(model);
+        log.info("휴대폰 모델 삭제 완료: modelId={}, modelName={}", id, model.getFullModelName());
     }
     
     public PhoneModelResponseDto getPhoneModel(UUID id) {

--- a/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelService.java
+++ b/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.phonebid.app.phone.repository.PhoneModelRepository;
+import com.phonebid.app.phone.repository.PhoneModelImageRepository;
 import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto;
 import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto.OptionItem;
 import com.phonebid.app.phone.dto.request.PhoneModelUpdateRequestDto;
@@ -21,8 +22,10 @@ import com.phonebid.app.phone.dto.response.PhoneModelResponseDto;
 import com.phonebid.app.phone.domain.PhoneModel;
 import com.phonebid.app.phone.domain.Brand;
 import com.phonebid.app.phone.domain.PhoneOption;
+import com.phonebid.app.phone.domain.PhoneModelImage;
 import com.phonebid.app.phone.repository.PhoneOptionRepository;
 import java.util.stream.Collectors;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -30,14 +33,41 @@ public class PhoneModelService {
     
     private final PhoneModelRepository phoneModelRepository;
     private final PhoneOptionRepository phoneOptionRepository;
+    private final PhoneModelImageRepository phoneModelImageRepository;
 
+    /**
+     * 휴대폰 모델 목록 조회
+     * 각 모델의 썸네일 이미지 URL을 함께 조회하여 반환
+     * 성능 최적화: N+1 쿼리 문제를 방지하기 위해 모든 모델의 이미지를 한 번에 조회
+     */
     public List<PhoneModelResponseDto> getPhoneModels() {
         List<PhoneModel> models = phoneModelRepository.findAll();
         if (models.isEmpty()) {
             throw new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND);
         }
 
-        return models.stream().map(PhoneModelResponseDto::from).collect(Collectors.toList());
+        // 모든 모델 ID 수집
+        List<UUID> modelIds = models.stream()
+            .map(PhoneModel::getId)
+            .collect(Collectors.toList());
+
+        // 각 모델의 첫 번째 이미지 URL을 한 번에 조회 (N+1 쿼리 방지)
+        Map<UUID, String> thumbnailImageMap = phoneModelImageRepository
+            .findByPhoneModelIdInOrderByDisplayOrder(modelIds)
+            .stream()
+            .collect(Collectors.toMap(
+                image -> image.getPhoneModel().getId(),
+                PhoneModelImage::getImageUrl,
+                (existing, replacement) -> existing // 첫 번째 이미지만 유지
+            ));
+
+        // 각 모델에 썸네일 이미지 URL 포함하여 DTO 생성
+        return models.stream()
+            .map(model -> {
+                String thumbnailUrl = thumbnailImageMap.get(model.getId());
+                return PhoneModelResponseDto.from(model, thumbnailUrl);
+            })
+            .collect(Collectors.toList());
     }
     
     @Transactional
@@ -128,6 +158,11 @@ public class PhoneModelService {
     public PhoneModelResponseDto getPhoneModel(UUID id) {
         PhoneModel model = phoneModelRepository.findById(id)
             .orElseThrow(() -> new CustomException(PhoneErrorCode.PHONE_MODEL_NOT_FOUND));
-        return PhoneModelResponseDto.from(model);
+        
+        // 첫 번째 이미지 URL 조회
+        List<PhoneModelImage> images = phoneModelImageRepository.findByPhoneModelIdOrderByDisplayOrder(id);
+        String thumbnailUrl = images.isEmpty() ? null : images.get(0).getImageUrl();
+        
+        return PhoneModelResponseDto.from(model, thumbnailUrl);
     }
 }

--- a/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelService.java
+++ b/backend/src/main/java/com/phonebid/app/phone/service/PhoneModelService.java
@@ -18,7 +18,6 @@ import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto.OptionItem;
 import com.phonebid.app.phone.dto.request.PhoneModelUpdateRequestDto;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.PhoneErrorCode;
-import com.phonebid.app.common.errorcode.MemberErrorCode;
 import com.phonebid.app.phone.dto.response.PhoneModelResponseDto;
 import com.phonebid.app.phone.domain.PhoneModel;
 import com.phonebid.app.phone.domain.Brand;
@@ -173,9 +172,16 @@ public class PhoneModelService {
                     s3Service.deleteFileByUrl(imageUrl);
                     log.info("휴대폰 모델 이미지 S3 삭제 완료: modelId={}, imageUrl={}", id, imageUrl);
                 }
-            } catch (Exception e) {
-                log.error("휴대폰 모델 이미지 S3 삭제 실패: modelId={}, imageUrl={}", id, image.getImageUrl(), e);
-                throw new CustomException(MemberErrorCode.FILE_DELETE_FAILED);
+            } catch (CustomException e) {
+                // S3Service에서 발생한 CustomException의 원인 예외를 로그에 기록
+                Throwable cause = e.getCause();
+                if (cause != null) {
+                    log.error("휴대폰 모델 이미지 S3 삭제 실패: modelId={}, imageUrl={}", id, image.getImageUrl(), cause);
+                } else {
+                    log.error("휴대폰 모델 이미지 S3 삭제 실패: modelId={}, imageUrl={}, errorCode={}, message={}", 
+                            id, image.getImageUrl(), e.getErrorCode(), e.getMessage(), e);
+                }
+                throw new CustomException(PhoneErrorCode.IMAGE_DELETE_FAILED);
             }
         }
         

--- a/backend/src/test/java/com/phonebid/app/phone/service/PhoneModelServiceTest.java
+++ b/backend/src/test/java/com/phonebid/app/phone/service/PhoneModelServiceTest.java
@@ -1,8 +1,10 @@
 package com.phonebid.app.phone.service;
 
 import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.PhoneErrorCode;
 import com.phonebid.app.phone.domain.Brand;
 import com.phonebid.app.phone.domain.PhoneModel;
+import com.phonebid.app.phone.domain.PhoneModelImage;
 import com.phonebid.app.phone.domain.PhoneOption.OptionType;
 import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto;
 import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto.OptionItem;
@@ -243,5 +245,122 @@ class PhoneModelServiceTest {
         // when & then
         assertThatThrownBy(() -> phoneModelService.updatePhoneModel(modelId, validUpdateRequest))
             .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("모델 삭제 - 이미지가 있는 경우 성공")
+    void deletePhoneModel_WithImages_Success() {
+        // given
+        String imageUrl1 = "https://s3.amazonaws.com/bucket/image1.jpg";
+        String imageUrl2 = "https://s3.amazonaws.com/bucket/image2.jpg";
+        
+        PhoneModelImage image1 = PhoneModelImage.builder()
+            .phoneModel(savedModel)
+            .imageUrl(imageUrl1)
+            .displayOrder(1)
+            .build();
+        
+        PhoneModelImage image2 = PhoneModelImage.builder()
+            .phoneModel(savedModel)
+            .imageUrl(imageUrl2)
+            .displayOrder(2)
+            .build();
+        
+        List<PhoneModelImage> images = Arrays.asList(image1, image2);
+        
+        when(phoneModelRepository.findById(modelId))
+            .thenReturn(Optional.of(savedModel));
+        when(phoneModelImageRepository.findByPhoneModelIdOrderByDisplayOrder(modelId))
+            .thenReturn(images);
+        doNothing().when(s3Service).deleteFileByUrl(anyString());
+
+        // when
+        phoneModelService.deletePhoneModel(modelId);
+
+        // then
+        verify(phoneModelRepository, times(1)).findById(modelId);
+        verify(phoneModelImageRepository, times(1)).findByPhoneModelIdOrderByDisplayOrder(modelId);
+        verify(s3Service, times(1)).deleteFileByUrl(imageUrl1);
+        verify(s3Service, times(1)).deleteFileByUrl(imageUrl2);
+        verify(phoneModelImageRepository, times(1)).deleteAll(images);
+        verify(phoneModelRepository, times(1)).delete(savedModel);
+    }
+
+    @Test
+    @DisplayName("모델 삭제 - 이미지가 없는 경우 성공")
+    void deletePhoneModel_NoImages_Success() {
+        // given
+        when(phoneModelRepository.findById(modelId))
+            .thenReturn(Optional.of(savedModel));
+        when(phoneModelImageRepository.findByPhoneModelIdOrderByDisplayOrder(modelId))
+            .thenReturn(Collections.emptyList());
+
+        // when
+        phoneModelService.deletePhoneModel(modelId);
+
+        // then
+        verify(phoneModelRepository, times(1)).findById(modelId);
+        verify(phoneModelImageRepository, times(1)).findByPhoneModelIdOrderByDisplayOrder(modelId);
+        verify(s3Service, never()).deleteFileByUrl(anyString());
+        verify(phoneModelImageRepository, never()).deleteAll(anyList());
+        verify(phoneModelRepository, times(1)).delete(savedModel);
+    }
+
+    @Test
+    @DisplayName("모델 삭제 - 모델을 찾을 수 없음 실패")
+    void deletePhoneModel_NotFoundFail() {
+        // given
+        when(phoneModelRepository.findById(modelId))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> phoneModelService.deletePhoneModel(modelId))
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> {
+                CustomException customException = (CustomException) exception;
+                assertThat(customException.getErrorCode()).isEqualTo(PhoneErrorCode.PHONE_MODEL_NOT_FOUND);
+            });
+        
+        verify(phoneModelRepository, times(1)).findById(modelId);
+        verify(phoneModelImageRepository, never()).findByPhoneModelIdOrderByDisplayOrder(any(UUID.class));
+        verify(s3Service, never()).deleteFileByUrl(anyString());
+        verify(phoneModelImageRepository, never()).deleteAll(anyList());
+        verify(phoneModelRepository, never()).delete(any(PhoneModel.class));
+    }
+
+    @Test
+    @DisplayName("모델 삭제 - S3 삭제 실패")
+    void deletePhoneModel_S3DeleteFail() {
+        // given
+        String imageUrl = "https://s3.amazonaws.com/bucket/image1.jpg";
+        
+        PhoneModelImage image = PhoneModelImage.builder()
+            .phoneModel(savedModel)
+            .imageUrl(imageUrl)
+            .displayOrder(1)
+            .build();
+        
+        List<PhoneModelImage> images = Arrays.asList(image);
+        
+        when(phoneModelRepository.findById(modelId))
+            .thenReturn(Optional.of(savedModel));
+        when(phoneModelImageRepository.findByPhoneModelIdOrderByDisplayOrder(modelId))
+            .thenReturn(images);
+        doThrow(new CustomException(PhoneErrorCode.IMAGE_DELETE_FAILED))
+            .when(s3Service).deleteFileByUrl(imageUrl);
+
+        // when & then
+        assertThatThrownBy(() -> phoneModelService.deletePhoneModel(modelId))
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> {
+                CustomException customException = (CustomException) exception;
+                assertThat(customException.getErrorCode()).isEqualTo(PhoneErrorCode.IMAGE_DELETE_FAILED);
+            });
+        
+        verify(phoneModelRepository, times(1)).findById(modelId);
+        verify(phoneModelImageRepository, times(1)).findByPhoneModelIdOrderByDisplayOrder(modelId);
+        verify(s3Service, times(1)).deleteFileByUrl(imageUrl);
+        verify(phoneModelImageRepository, never()).deleteAll(anyList());
+        verify(phoneModelRepository, never()).delete(any(PhoneModel.class));
     }
 }

--- a/backend/src/test/java/com/phonebid/app/phone/service/PhoneModelServiceTest.java
+++ b/backend/src/test/java/com/phonebid/app/phone/service/PhoneModelServiceTest.java
@@ -1,7 +1,6 @@
 package com.phonebid.app.phone.service;
 
 import com.phonebid.app.common.exception.CustomException;
-import com.phonebid.app.common.errorcode.PhoneErrorCode;
 import com.phonebid.app.phone.domain.Brand;
 import com.phonebid.app.phone.domain.PhoneModel;
 import com.phonebid.app.phone.domain.PhoneOption.OptionType;
@@ -10,7 +9,9 @@ import com.phonebid.app.phone.dto.request.PhoneModelCreateRequestDto.OptionItem;
 import com.phonebid.app.phone.dto.request.PhoneModelUpdateRequestDto;
 import com.phonebid.app.phone.dto.response.PhoneModelResponseDto;
 import com.phonebid.app.phone.repository.PhoneModelRepository;
+import com.phonebid.app.phone.repository.PhoneModelImageRepository;
 import com.phonebid.app.phone.repository.PhoneOptionRepository;
+import com.phonebid.app.s3.service.S3Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,12 @@ class PhoneModelServiceTest {
 
     @Mock
     private PhoneOptionRepository phoneOptionRepository;
+
+    @Mock
+    private PhoneModelImageRepository phoneModelImageRepository;
+
+    @Mock
+    private S3Service s3Service;
 
     @InjectMocks
     private PhoneModelService phoneModelService;
@@ -70,7 +77,6 @@ class PhoneModelServiceTest {
 
         // 업데이트 요청
         validUpdateRequest = new PhoneModelUpdateRequestDto(
-            modelId,
             Brand.SAMSUNG,
             "Galaxy S24",
             "SM-S921",
@@ -153,6 +159,8 @@ class PhoneModelServiceTest {
         // given
         List<PhoneModel> models = Arrays.asList(savedModel);
         when(phoneModelRepository.findAll()).thenReturn(models);
+        when(phoneModelImageRepository.findByPhoneModelIdInOrderByDisplayOrder(anyList()))
+            .thenReturn(Collections.emptyList());
 
         // when
         List<PhoneModelResponseDto> result = phoneModelService.getPhoneModels();
@@ -161,6 +169,7 @@ class PhoneModelServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getModel()).isEqualTo("iPhone 16");
         verify(phoneModelRepository, times(1)).findAll();
+        verify(phoneModelImageRepository, times(1)).findByPhoneModelIdInOrderByDisplayOrder(anyList());
     }
 
     @Test
@@ -180,6 +189,8 @@ class PhoneModelServiceTest {
         // given
         when(phoneModelRepository.findById(modelId))
             .thenReturn(Optional.of(savedModel));
+        when(phoneModelImageRepository.findByPhoneModelIdOrderByDisplayOrder(modelId))
+            .thenReturn(Collections.emptyList());
 
         // when
         PhoneModelResponseDto result = phoneModelService.getPhoneModel(modelId);
@@ -188,6 +199,7 @@ class PhoneModelServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getModel()).isEqualTo("iPhone 16");
         verify(phoneModelRepository, times(1)).findById(modelId);
+        verify(phoneModelImageRepository, times(1)).findByPhoneModelIdOrderByDisplayOrder(modelId);
     }
 
     @Test
@@ -214,7 +226,7 @@ class PhoneModelServiceTest {
             .thenReturn(savedModel);
 
         // when
-        PhoneModelResponseDto result = phoneModelService.updatePhoneModel(validUpdateRequest);
+        PhoneModelResponseDto result = phoneModelService.updatePhoneModel(modelId, validUpdateRequest);
 
         // then
         assertThat(result).isNotNull();
@@ -229,7 +241,7 @@ class PhoneModelServiceTest {
             .thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> phoneModelService.updatePhoneModel(validUpdateRequest))
+        assertThatThrownBy(() -> phoneModelService.updatePhoneModel(modelId, validUpdateRequest))
             .isInstanceOf(CustomException.class);
     }
 }

--- a/frontend/src/components/chat/ChatAvatar.tsx
+++ b/frontend/src/components/chat/ChatAvatar.tsx
@@ -27,13 +27,22 @@ export function ChatAvatar({
     lg: "w-8 h-8",
   };
 
+  const pixelSizes = {
+    sm: 32,
+    md: 40,
+    lg: 48,
+  };
+
   return (
     <div className={`flex-shrink-0 ${sizeClasses[size]}`}>
       {avatar ? (
         <img
           src={avatar}
           alt={alt || name || "사용자"}
+          width={pixelSizes[size]}
+          height={pixelSizes[size]}
           className={`${sizeClasses[size]} rounded-full object-cover`}
+          fetchPriority="high"
         />
       ) : (
         <div

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -50,7 +50,7 @@ export function MessageBubble({
         <ChatAvatar avatar={senderAvatar} name={senderName} alt={senderName || "상대방"} />
       )}
 
-      <div className={`flex flex-col max-w-[70%] ${isCurrentUser ? "items-end" : "items-start"} relative`}>
+      <div className={`flex flex-col ${isImageMessage ? "max-w-[85%]" : "max-w-[70%]"} ${isCurrentUser ? "items-end" : "items-start"} relative`}>
         <div className="flex items-end gap-2">
           {/* 읽음 표시 (내 메시지이고 읽지 않았을 때만, 말풍선 밖 왼쪽 하단) */}
           {isCurrentUser && !message.isRead && (
@@ -58,7 +58,7 @@ export function MessageBubble({
           )}
 
           <div
-            className={`px-4 py-2.5 rounded-2xl border ${
+            className={`${isImageMessage ? "p-1" : "px-4 py-2.5"} rounded-2xl border ${
               isCurrentUser
                 ? "bg-[#E0E7FF] text-gray-900 rounded-br-sm border-indigo-200"
                 : "bg-white text-gray-900 rounded-bl-sm border-gray-200 shadow-sm"
@@ -74,8 +74,10 @@ export function MessageBubble({
                   <img
                     src={message.content}
                     alt="전송된 이미지"
-                    className={`rounded-lg cursor-pointer ${
-                      isImageExpanded ? "max-w-2xl" : "max-w-xs"
+                    className={`rounded-lg cursor-pointer w-full h-auto object-contain ${
+                      isImageExpanded 
+                        ? "max-w-2xl max-h-[80vh]" 
+                        : "max-w-[280px] sm:max-w-[320px] max-h-[60vh]"
                     }`}
                     onClick={() => setIsImageExpanded(!isImageExpanded)}
                     onError={() => setImageError(true)}

--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -5,9 +5,11 @@ import { getChatRooms } from "services/chatService";
 import { realtimeDataConfig } from "services/swrConfig";
 import type { PaginatedChatRooms } from "types/ChatTypes";
 import { ChatRoomCard } from "components/chat/ChatRoomCard";
+import { useAuthStore } from "store/authStore";
 
 const ChatListPage: React.FC = () => {
   const navigate = useNavigate();
+  const { user } = useAuthStore();
 
   useEffect(() => {
     document.title = "채팅 목록 | PhoneBid";
@@ -170,13 +172,21 @@ const ChatListPage: React.FC = () => {
           </div>
         ) : (
           <div className="divide-y divide-gray-100 bg-white">
-            {chatRooms.map((room) => (
-              <ChatRoomCard
-                key={room.id}
-                room={room}
-                unreadCount={unreadCounts[room.id] || 0}
-              />
-            ))}
+            {chatRooms.map((room) => {
+              // 현재 사용자 역할에 따라 상대방 프로필 이미지 선택
+              const otherUserProfileImageUrl = user?.role === "CONSUMER"
+                ? room.sellerProfileImageUrl
+                : room.consumerProfileImageUrl;
+              
+              return (
+                <ChatRoomCard
+                  key={room.id}
+                  room={room}
+                  unreadCount={unreadCounts[room.id] || 0}
+                  sellerAvatar={otherUserProfileImageUrl}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/frontend/src/pages/ChatRoomPage.tsx
+++ b/frontend/src/pages/ChatRoomPage.tsx
@@ -724,6 +724,7 @@ const ChatRoomPage: React.FC = () => {
                 quote={quote}
                 bidPrice={chatRoom.totalPrice}
                 sellerName={chatRoom.sellerName}
+                sellerAvatar={chatRoom.sellerProfileImageUrl}
               />
             )}
             <div className="text-center text-gray-500 py-12">
@@ -764,6 +765,7 @@ const ChatRoomPage: React.FC = () => {
                     quote={quote}
                     bidPrice={chatRoom.totalPrice}
                     sellerName={chatRoom.sellerName}
+                    sellerAvatar={chatRoom.sellerProfileImageUrl}
                   />
                 )}
 
@@ -776,6 +778,13 @@ const ChatRoomPage: React.FC = () => {
                       ? (user?.role === "CONSUMER"
                           ? chatRoom.sellerName
                           : chatRoom.consumerName)
+                      : undefined
+                  }
+                  senderAvatar={
+                    !isCurrentUserMessage
+                      ? (user?.role === "CONSUMER"
+                          ? chatRoom.sellerProfileImageUrl
+                          : chatRoom.consumerProfileImageUrl)
                       : undefined
                   }
                 />
@@ -793,7 +802,11 @@ const ChatRoomPage: React.FC = () => {
                 ? chatRoom.sellerName
                 : chatRoom.consumerName
             }
-            senderAvatar={undefined}
+            senderAvatar={
+              user?.role === "CONSUMER"
+                ? chatRoom.sellerProfileImageUrl
+                : chatRoom.consumerProfileImageUrl
+            }
           />
         )}
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -165,6 +165,7 @@ const LoginPage = () => {
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
+                    aria-hidden="true"
                   >
                     <path
                       strokeLinecap="round"
@@ -200,6 +201,7 @@ const LoginPage = () => {
                     <button
                       onClick={() => setShowOAuthError(false)}
                       className="text-xs text-yellow-600 hover:text-yellow-800 mt-2 underline"
+                      aria-label="소셜 로그인 안내 닫기"
                     >
                       닫기
                     </button>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuthStore } from "store/authStore";
 import SocialLoginButton from "components/auth/SocialLoginButton";
 import Input from "components/common/Input";
@@ -11,6 +11,7 @@ import type { LoginResponse, User } from "@/types/UserTypes";
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { isAuthenticated, login } = useAuthStore();
 
   // 일반 로그인 상태
@@ -23,6 +24,7 @@ const LoginPage = () => {
     password: "",
   });
   const [isLoading, setIsLoading] = useState(false);
+  const [showOAuthError, setShowOAuthError] = useState(false);
 
   // 이미 로그인된 사용자는 홈으로 리다이렉트
   useEffect(() => {
@@ -30,6 +32,17 @@ const LoginPage = () => {
       navigate("/", { replace: true });
     }
   }, [isAuthenticated, navigate]);
+
+  // URL 파라미터에서 OAuth 에러 확인
+  useEffect(() => {
+    const error = searchParams.get("error");
+    if (error === "social_login_failed") {
+      setShowOAuthError(true);
+      toast.error("소셜 로그인에 실패했습니다. 아래 안내를 확인해주세요.");
+      // URL에서 에러 파라미터 제거
+      navigate("/login", { replace: true });
+    }
+  }, [searchParams, navigate]);
 
   // 일반 로그인 처리
   const handleLogin = async () => {
@@ -144,9 +157,61 @@ const LoginPage = () => {
 
           {/* 소셜 로그인 버튼들 */}
           <div className="space-y-4 w-full">
+            {showOAuthError && (
+              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4">
+                <div className="flex items-start">
+                  <svg
+                    className="w-5 h-5 text-yellow-600 mt-0.5 mr-2 flex-shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                  </svg>
+                  <div className="flex-1">
+                    <h3 className="text-sm font-semibold text-yellow-800 mb-1">
+                      소셜 로그인이 되지 않나요? 다음 사항을 확인해주세요.
+                    </h3>
+                    <ul className="text-xs text-yellow-700 space-y-1 list-disc list-inside">
+                      <li>
+                        브라우저의 <strong>광고 차단 확장 프로그램</strong>을
+                        비활성화해보세요
+                      </li>
+                      <li>
+                        팝업 차단이 해제되어 있는지 확인해주세요
+                      </li>
+                      <li>
+                        시크릿 모드(프라이빗 모드)에서 다시 시도해보세요
+                      </li>
+                      <li>
+                        다른 브라우저(Chrome, Edge, Safari 등)에서
+                        시도해보세요
+                      </li>
+                      <li>
+                        문제가 계속되면 네이버 로그인을 이용하시거나 고객센터로
+                        문의해주세요
+                      </li>
+                    </ul>
+                    <button
+                      onClick={() => setShowOAuthError(false)}
+                      className="text-xs text-yellow-600 hover:text-yellow-800 mt-2 underline"
+                    >
+                      닫기
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
             <SocialLoginButton provider="kakao" onClick={handleKakaoLogin} />
 
             <SocialLoginButton provider="naver" onClick={handleNaverLogin} />
+
           </div>
 
           <div className="text-muted-foreground flex justify-center gap-1 text-sm mt-4">

--- a/frontend/src/pages/QuoteCreateWizardPage.tsx
+++ b/frontend/src/pages/QuoteCreateWizardPage.tsx
@@ -307,34 +307,12 @@ const QuoteCreateWizardPage: React.FC = () => {
             {phoneModels.map((model) => {
               const selected = draft.model === model.id;
               return (
-                <SelectionCard
+                <PhoneModelCard
                   key={model.id}
+                  model={model}
                   selected={selected}
-                  onClick={() => handleSelectPhone(model)}
-                  className="py-3"
-                  showCheckIcon
-                >
-                  <CardContent className="flex w-full items-center gap-4 py-2">
-                    <div className="flex h-16 w-16 items-center justify-center rounded-xl bg-gradient-to-br from-primary/10 via-primary/20 to-primary/10 text-xs font-medium text-primary">
-                      {model.brand}
-                    </div>
-                    <div className="flex flex-1 flex-col gap-1">
-                      <CardTitle className="text-base font-semibold">
-                        {model.model}
-                      </CardTitle>
-                      {model.modelNumber ? (
-                        <span className="text-xs text-muted-foreground">
-                          모델 번호 {model.modelNumber}
-                        </span>
-                      ) : null}
-                      {model.releasedPrice ? (
-                        <span className="text-sm font-medium text-primary">
-                          출시가 {model.releasedPrice.toLocaleString()}원
-                        </span>
-                      ) : null}
-                    </div>
-                  </CardContent>
-                </SelectionCard>
+                  onSelect={() => handleSelectPhone(model)}
+                />
               );
             })}
           </div>
@@ -683,6 +661,57 @@ const getPurchasePlanLabel = (value?: PurchaseMethod) => {
     return "상관 없음";
   }
   return "선택되지 않음";
+};
+
+const PhoneModelCard = ({
+  model,
+  selected,
+  onSelect,
+}: {
+  model: PhoneModelResponse;
+  selected: boolean;
+  onSelect: () => void;
+}) => {
+  return (
+    <SelectionCard
+      selected={selected}
+      onClick={onSelect}
+      className="py-3"
+      showCheckIcon
+    >
+      <CardContent className="flex w-full items-center gap-4 py-2">
+        <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br from-primary/10 via-primary/20 to-primary/10">
+          {model.thumbnailImageUrl ? (
+            <img
+              src={model.thumbnailImageUrl}
+              alt={model.model}
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <span className="text-xs font-medium text-primary">
+              {model.brand}
+            </span>
+          )}
+        </div>
+        <div className="flex flex-1 flex-col gap-1">
+          <CardTitle className="text-base font-semibold">
+            {model.model}
+          </CardTitle>
+          {model.modelNumber ? (
+            <span className="text-xs text-muted-foreground">
+              모델 번호 {model.modelNumber}
+            </span>
+          ) : null}
+          {model.releasedPrice ? (
+            <span className="text-sm font-medium text-primary">
+              출시가 {model.releasedPrice.toLocaleString()}원
+            </span>
+          ) : null}
+        </div>
+      </CardContent>
+    </SelectionCard>
+  );
 };
 
 const ArrowLeftIcon = () => (

--- a/frontend/src/types/ChatTypes.ts
+++ b/frontend/src/types/ChatTypes.ts
@@ -34,6 +34,8 @@ export interface ChatRoom {
   updatedAt: string;
   sellerName?: string;
   consumerName?: string;
+  sellerProfileImageUrl?: string;
+  consumerProfileImageUrl?: string;
   lastMessage?: string;
   totalPrice?: number;
   unreadCount?: number; // 읽지 않은 메시지 수

--- a/frontend/src/types/PhoneModelTypes.ts
+++ b/frontend/src/types/PhoneModelTypes.ts
@@ -20,6 +20,7 @@ export interface PhoneModelResponse {
   releasedPrice?: number | null;
   releasedAt?: string | null;
   options?: PhoneOptionResponse[];
+  thumbnailImageUrl?: string | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #84 .

## 📝작업 내용

> 각종 bug를 fix하고 부족한 부분들을 리팩토링 했습니다.

1. **kakao oauth 로그인 안되는 현상**의 원인을 파악했습니다. 필자의 크롬에 깔려있던 광고차단기 익스텐션이 문제였습니다. 해당 문제를 겪을 사용자들을 위해 만약 소셜 로그인이 실패할 시의 해결 방안을 login page에 업데이트했습니다.
2. **견적 생성 시 상품(핸드폰) 이미지가 안보이는 현상**을 수정했습니다. 그 과정에서 이미지를 불러올 때 N+1 현상이 발생하는 것을 수정하여 **API 호출 횟수 90% 이상 감소**시키고 **로딩 시간을 86% 단축** 시켰습니다.
3. 휴대폰 모델 관리 관련 api들은 오직 관리자만 접근 가능하도록 권한을 주었습니다. (@PreAuthorize)
4. 채팅 목록 페이지와 채팅방 페이지에서 프로필 사진이 보이도록 수정했습니다. 이미지가 더 신속하게 로딩되도록 로직을 수정했습니다 (이미지 지연 로딩 등).
5.  **핸드폰 모델을 삭제하면 관련된 이미지 파일도 s3에서 함께 삭제**되도록 구현했습니다. 해당 메서드의 유닛 테스트 또한 함께 수정 후 재 테스트하여 통과됨을 확인하였습니다.

## ✏️ 향후 추가 고려 사항

> 핸드폰 기종이 더욱 많아지고 유저 및 트래픽이 늘어난다면 고려해보아야 합니다.
- 이미지 CDN 사용
- 이미지 압축 및 WebP 포맷 사용
- 썸네일 이미지 크기 최적화
- 캐싱 전략 강화

