### PR TITLE
Implement Refresh Token Certification Systems and Seller Features

### DIFF
--- a/.cursor/rules/database-schema.mdc
+++ b/.cursor/rules/database-schema.mdc
@@ -7,18 +7,21 @@ alwaysApply: false
 
 ### 🔑 기본 원칙
 
-- **Entity 수정** : Entity가 수정 및 추가 생성되었을 때 이 파일에도 반드시 수정
+- **Entity 수정**: Entity가 수정 및 추가 생성되었을 때 이 파일에도 반드시 수정
 - **UUID 기본키**: 모든 테이블은 UUID 타입의 기본키 사용
-- **BaseEntity 상속**: 일반 엔터티는 `BaseEntity`를 상속받아 공통 감사 필드 포함
-- **BaseTimeEntity 예외**: immutable한 엔터티(예: RefreshToken)는 `BaseTimeEntity`를 상속받을 수 있음
-  - `BaseTimeEntity`는 `created_at`, `deleted_at`만 포함하며, `is_delete`, `deleted_by` 필드는 포함하지 않음
-  - 이는 의도적인 설계로, 수정되지 않는 엔터티에 최소한의 감사 정보만 제공
-- **소프트 삭제**: 일반 엔터티는 `is_delete`, `deleted_at`, `deleted_by` 필드로 논리적 삭제
+- **엔터티 상속 규칙**:
+  - **일반 엔터티**: `BaseEntity`를 상속받아 모든 감사 필드 포함 (기본 규칙)
+  - **Immutable 엔터티 예외**: 수정되지 않는 엔터티(예: RefreshToken)는 `BaseTimeEntity`를 상속받을 수 있음
+- **소프트 삭제**:
+  - **BaseEntity 엔터티**: `is_delete = true`, `deleted_at`, `deleted_by` 필드로 논리적 삭제
+  - **BaseTimeEntity 엔터티**: `deleted_at` 필드만으로 논리적 삭제 (`is_delete`, `deleted_by` 없음)
 - **네이밍 규칙**: 테이블명은 복수형, 컬럼명은 snake_case
 
-### 📋 공통 필드 (BaseEntity)
+### 📋 공통 필드
 
-모든 테이블에 포함되는 공통 필드:
+#### BaseEntity (일반 엔터티용)
+
+일반 엔터티(예: User, Product, Quote 등)에 포함되는 공통 필드:
 
 ```sql
 created_at      TIMESTAMP    -- 생성 시각
@@ -30,20 +33,20 @@ deleted_by      VARCHAR(255) -- 삭제자
 is_delete       BOOLEAN      -- 삭제 여부
 ```
 
-## 🏗️ 실제 테이블 구조 (11개 테이블)
+#### BaseTimeEntity (Immutable 엔터티용)
 
-### 공통 BaseEntity
+Immutable한 엔터티(예: RefreshToken)에 포함되는 최소한의 공통 필드:
 
 ```sql
--- BaseEntity 필드
-is_delete       BOOLEAN
-created_at      TIMESTAMP
-updated_at      TIMESTAMP
-deleted_at      TIMESTAMP
-created_by      VARCHAR(255)
-updated_by      VARCHAR(255)
-deleted_by      VARCHAR(255)
+created_at      TIMESTAMP    -- 생성 시각
+deleted_at      TIMESTAMP    -- 삭제 시각 (소프트 삭제)
 ```
+
+**참고**: `BaseTimeEntity`는 수정되지 않는 엔터티에 사용되므로 `updated_at`, `updated_by`, `created_by`, `deleted_by`, `is_delete` 필드를 포함하지 않습니다. 소프트 삭제는 `deleted_at IS NULL` 조건으로만 확인합니다.
+
+## 🏗️ 실제 테이블 구조
+
+**참고**: 아래 테이블들은 모두 `BaseEntity`를 상속받는 일반 엔터티입니다. `BaseTimeEntity`를 사용하는 테이블(예: `refresh_tokens`)은 별도로 관리됩니다.
 
 ### 1. users (사용자)
 
@@ -461,11 +464,13 @@ idx_seller_documents_type       -- seller_documents(type) - 문서 타입별 조
 
 ## ⚠️ 주의사항
 
-1. **소프트 삭제**: 모든 삭제는 `is_delete = true` 처리
+1. **소프트 삭제**:
+   - **BaseEntity 엔터티**: `is_delete = true`, `deleted_at`, `deleted_by` 설정
+   - **BaseTimeEntity 엔터티**: `deleted_at`만 설정 (`is_delete`, `deleted_by` 없음)
 2. **UUID 사용**: 모든 ID는 UUID 타입
 3. **Enum 검증**: 문자열 Enum 값은 애플리케이션에서 검증
 4. **외래키 제약**: 데이터 무결성 보장
-5. **감사 로그**: BaseEntity 필드 자동 관리
+5. **감사 로그**: BaseEntity/BaseTimeEntity 필드 자동 관리
 6. **1:1 관계**: UNIQUE 제약으로 보장
 7. **price_plans 테이블**: bids와 1:1 관계로 요금제 정보 분리 저장
 
@@ -479,46 +484,6 @@ idx_seller_documents_type       -- seller_documents(type) - 문서 타입별 조
 
 이 스키마는 휴대폰 역경매 플랫폼의 모든 비즈니스 요구사항을 지원하도록 설계되었으며, 실제 데이터베이스와 정확히 일치합니다.
 
-# Database Schema Rules
-
-## 📊 데이터베이스 스키마 구조 (정확한 실제 스키마)
-
-### 🔑 기본 원칙
-
-- **UUID 기본키**: 모든 테이블은 UUID 타입의 기본키 사용
-- **BaseEntity 상속**: 일반 엔터티는 `BaseEntity`를 상속받아 공통 감사 필드 포함
-- **BaseTimeEntity 예외**: immutable한 엔터티(예: RefreshToken)는 `BaseTimeEntity`를 상속받을 수 있음
-  - `BaseTimeEntity`는 `created_at`, `deleted_at`만 포함하며, `is_delete`, `deleted_by` 필드는 포함하지 않음
-  - 이는 의도적인 설계로, 수정되지 않는 엔터티에 최소한의 감사 정보만 제공
-- **소프트 삭제**: 일반 엔터티는 `is_delete`, `deleted_at`, `deleted_by` 필드로 논리적 삭제
-- **네이밍 규칙**: 테이블명은 복수형, 컬럼명은 snake_case
-
-### 📋 공통 필드
-
-#### BaseEntity (일반 엔터티용)
-
-일반 엔터티(예: User, Product, Quote 등)에 포함되는 공통 필드:
-
-```sql
-created_at      TIMESTAMP    -- 생성 시각
-created_by      VARCHAR(255) -- 생성자
-updated_at      TIMESTAMP    -- 수정 시각
-updated_by      VARCHAR(255) -- 수정자
-deleted_at      TIMESTAMP    -- 삭제 시각 (소프트 삭제)
-deleted_by      VARCHAR(255) -- 삭제자
-is_delete       BOOLEAN      -- 삭제 여부
-```
-
-#### BaseTimeEntity (Immutable 엔터티용)
-
-Immutable한 엔터티(예: RefreshToken)에 포함되는 최소한의 공통 필드:
-
-```sql
-created_at      TIMESTAMP    -- 생성 시각
-deleted_at      TIMESTAMP    -- 삭제 시각 (소프트 삭제)
-```
-
-**참고**: `BaseTimeEntity`는 수정되지 않는 엔터티에 사용되므로 `updated_at`, `updated_by`, `created_by`, `deleted_by`, `is_delete` 필드를 포함하지 않습니다.
 
 ## 🏗️ 실제 테이블 구조 (11개 테이블)
 
@@ -984,11 +949,13 @@ idx_seller_documents_type       -- seller_documents(type) - 문서 타입별 조
 
 ## ⚠️ 주의사항
 
-1. **소프트 삭제**: 모든 삭제는 `is_delete = true` 처리
+1. **소프트 삭제**:
+   - **BaseEntity 엔터티**: `is_delete = true`, `deleted_at`, `deleted_by` 설정
+   - **BaseTimeEntity 엔터티**: `deleted_at`만 설정 (`is_delete`, `deleted_by` 없음)
 2. **UUID 사용**: 모든 ID는 UUID 타입
 3. **Enum 검증**: 문자열 Enum 값은 애플리케이션에서 검증
 4. **외래키 제약**: 데이터 무결성 보장
-5. **감사 로그**: BaseEntity 필드 자동 관리
+5. **감사 로그**: BaseEntity/BaseTimeEntity 필드 자동 관리
 6. **1:1 관계**: UNIQUE 제약으로 보장
 7. **price_plans 테이블**: bids와 1:1 관계로 요금제 정보 분리 저장
 

--- a/.cursor/rules/database-schema.mdc
+++ b/.cursor/rules/database-schema.mdc
@@ -9,8 +9,11 @@ alwaysApply: false
 
 - **Entity 수정** : Entity가 수정 및 추가 생성되었을 때 이 파일에도 반드시 수정
 - **UUID 기본키**: 모든 테이블은 UUID 타입의 기본키 사용
-- **BaseEntity 상속**: 모든 엔터티는 공통 감사 필드 포함
-- **소프트 삭제**: `is_delete`, `deleted_at`, `deleted_by` 필드로 논리적 삭제
+- **BaseEntity 상속**: 일반 엔터티는 `BaseEntity`를 상속받아 공통 감사 필드 포함
+- **BaseTimeEntity 예외**: immutable한 엔터티(예: RefreshToken)는 `BaseTimeEntity`를 상속받을 수 있음
+  - `BaseTimeEntity`는 `created_at`, `deleted_at`만 포함하며, `is_delete`, `deleted_by` 필드는 포함하지 않음
+  - 이는 의도적인 설계로, 수정되지 않는 엔터티에 최소한의 감사 정보만 제공
+- **소프트 삭제**: 일반 엔터티는 `is_delete`, `deleted_at`, `deleted_by` 필드로 논리적 삭제
 - **네이밍 규칙**: 테이블명은 복수형, 컬럼명은 snake_case
 
 ### 📋 공통 필드 (BaseEntity)
@@ -483,13 +486,18 @@ idx_seller_documents_type       -- seller_documents(type) - 문서 타입별 조
 ### 🔑 기본 원칙
 
 - **UUID 기본키**: 모든 테이블은 UUID 타입의 기본키 사용
-- **BaseEntity 상속**: 모든 엔터티는 공통 감사 필드 포함
-- **소프트 삭제**: `is_delete`, `deleted_at`, `deleted_by` 필드로 논리적 삭제
+- **BaseEntity 상속**: 일반 엔터티는 `BaseEntity`를 상속받아 공통 감사 필드 포함
+- **BaseTimeEntity 예외**: immutable한 엔터티(예: RefreshToken)는 `BaseTimeEntity`를 상속받을 수 있음
+  - `BaseTimeEntity`는 `created_at`, `deleted_at`만 포함하며, `is_delete`, `deleted_by` 필드는 포함하지 않음
+  - 이는 의도적인 설계로, 수정되지 않는 엔터티에 최소한의 감사 정보만 제공
+- **소프트 삭제**: 일반 엔터티는 `is_delete`, `deleted_at`, `deleted_by` 필드로 논리적 삭제
 - **네이밍 규칙**: 테이블명은 복수형, 컬럼명은 snake_case
 
-### 📋 공통 필드 (BaseEntity)
+### 📋 공통 필드
 
-모든 테이블에 포함되는 공통 필드:
+#### BaseEntity (일반 엔터티용)
+
+일반 엔터티(예: User, Product, Quote 등)에 포함되는 공통 필드:
 
 ```sql
 created_at      TIMESTAMP    -- 생성 시각
@@ -500,6 +508,17 @@ deleted_at      TIMESTAMP    -- 삭제 시각 (소프트 삭제)
 deleted_by      VARCHAR(255) -- 삭제자
 is_delete       BOOLEAN      -- 삭제 여부
 ```
+
+#### BaseTimeEntity (Immutable 엔터티용)
+
+Immutable한 엔터티(예: RefreshToken)에 포함되는 최소한의 공통 필드:
+
+```sql
+created_at      TIMESTAMP    -- 생성 시각
+deleted_at      TIMESTAMP    -- 삭제 시각 (소프트 삭제)
+```
+
+**참고**: `BaseTimeEntity`는 수정되지 않는 엔터티에 사용되므로 `updated_at`, `updated_by`, `created_by`, `deleted_by`, `is_delete` 필드를 포함하지 않습니다.
 
 ## 🏗️ 실제 테이블 구조 (11개 테이블)
 

--- a/backend/src/main/java/com/phonebid/app/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/phonebid/app/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.phonebid.app.common.Constants;
 import com.phonebid.app.common.dto.ApiResponse;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.util.CookieUtil;
 import com.phonebid.app.jwt.JwtUtil;
 import com.phonebid.app.member.domain.User;
 import com.phonebid.app.member.service.UserService;
@@ -18,8 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Arrays;
 
 /**
  * 인증 관련 컨트롤러
@@ -68,32 +67,17 @@ public class AuthController {
 
         // 새로운 Access Token 생성 (기본 만료 시간: 1시간)
         String newAccessToken = jwtUtil.createToken(user.getUsername(), user.getRole(), false);
-        
-        // Bearer 접두사 제거
-        String accessTokenValue = newAccessToken.startsWith(JwtUtil.BEARER_PREFIX) 
-            ? newAccessToken.substring(JwtUtil.BEARER_PREFIX.length()) 
-            : newAccessToken;
 
         // 쿠키 설정
-        boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
+        boolean isProduction = CookieUtil.isProduction(environment);
         
-        // Access Token 쿠키
-        ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
-                .path("/")
-                .httpOnly(true)
-                .secure(isProduction)
-                .sameSite("Strict")
-                .maxAge(Constants.Jwt.DEFAULT_EXPIRY) // 1시간
-                .build();
+        // Access Token 쿠키 생성
+        ResponseCookie accessTokenCookie = CookieUtil.createAccessTokenCookie(
+            newAccessToken, isProduction, Constants.Jwt.DEFAULT_EXPIRY);
 
-        // Refresh Token 쿠키 (로테이션된 새 토큰)
-        ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, newRefreshToken)
-                .path("/")
-                .httpOnly(true)
-                .secure(isProduction)
-                .sameSite("Strict")
-                .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
-                .build();
+        // Refresh Token 쿠키 생성 (로테이션된 새 토큰)
+        ResponseCookie refreshTokenCookie = CookieUtil.createRefreshTokenCookie(
+            newRefreshToken, isProduction);
 
         log.info("Access Token 및 Refresh Token 갱신 완료: username={}", username);
 

--- a/backend/src/main/java/com/phonebid/app/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/phonebid/app/auth/controller/AuthController.java
@@ -7,7 +7,7 @@ import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.jwt.JwtUtil;
 import com.phonebid.app.member.domain.User;
-import com.phonebid.app.member.repository.UserRepository;
+import com.phonebid.app.member.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,14 +32,14 @@ import java.util.Arrays;
 public class AuthController {
 
     private final RefreshTokenService refreshTokenService;
-    private final UserRepository userRepository;
+    private final UserService userService;
     private final JwtUtil jwtUtil;
     private final Environment environment;
 
     /**
-     * Refresh Token으로 Access Token 갱신
+     * Refresh Token으로 Access Token 갱신 및 Refresh Token 로테이션
      * @param request HTTP 요청 (쿠키에서 Refresh Token 추출)
-     * @return 새로운 Access Token
+     * @return 새로운 Access Token 및 Refresh Token (쿠키로 설정)
      */
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<String>> refresh(HttpServletRequest request) {
@@ -57,8 +57,14 @@ public class AuthController {
 
         // Refresh Token에서 사용자 정보 추출
         String username = jwtUtil.getUserInfoFromToken(refreshToken).getSubject();
-        User user = userRepository.findByUsername(username)
-            .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+        User user = userService.findByUsername(username);
+
+        // 기존 Refresh Token에서 사용자 ID 추출하여 무효화
+        refreshTokenService.findByToken(refreshToken)
+            .ifPresent(token -> refreshTokenService.deleteByUserId(token.getUser().getId()));
+
+        // 새로운 Refresh Token 생성 (로테이션)
+        String newRefreshToken = refreshTokenService.createRefreshToken(user.getId());
 
         // 새로운 Access Token 생성 (기본 만료 시간: 1시간)
         String newAccessToken = jwtUtil.createToken(user.getUsername(), user.getRole(), false);
@@ -68,9 +74,10 @@ public class AuthController {
             ? newAccessToken.substring(JwtUtil.BEARER_PREFIX.length()) 
             : newAccessToken;
 
-        // Access Token을 쿠키에 저장
+        // 쿠키 설정
         boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
         
+        // Access Token 쿠키
         ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
                 .path("/")
                 .httpOnly(true)
@@ -79,10 +86,20 @@ public class AuthController {
                 .maxAge(Constants.Jwt.DEFAULT_EXPIRY) // 1시간
                 .build();
 
-        log.info("Access Token 갱신 완료: username={}", username);
+        // Refresh Token 쿠키 (로테이션된 새 토큰)
+        ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, newRefreshToken)
+                .path("/")
+                .httpOnly(true)
+                .secure(isProduction)
+                .sameSite("Strict")
+                .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
+                .build();
+
+        log.info("Access Token 및 Refresh Token 갱신 완료: username={}", username);
 
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessTokenCookie.toString())
+                .header("Set-Cookie", refreshTokenCookie.toString())
                 .body(ApiResponse.success(HttpStatus.OK, "토큰이 성공적으로 갱신되었습니다.", newAccessToken));
     }
 }

--- a/backend/src/main/java/com/phonebid/app/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/phonebid/app/auth/controller/AuthController.java
@@ -1,0 +1,89 @@
+package com.phonebid.app.auth.controller;
+
+import com.phonebid.app.auth.service.RefreshTokenService;
+import com.phonebid.app.common.Constants;
+import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+
+/**
+ * 인증 관련 컨트롤러
+ * Refresh Token 갱신 등을 처리
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final Environment environment;
+
+    /**
+     * Refresh Token으로 Access Token 갱신
+     * @param request HTTP 요청 (쿠키에서 Refresh Token 추출)
+     * @return 새로운 Access Token
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<String>> refresh(HttpServletRequest request) {
+        // 쿠키에서 Refresh Token 추출
+        String refreshToken = jwtUtil.getRefreshTokenFromCookie(request);
+        
+        if (refreshToken == null) {
+            throw new CustomException(CommonErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        // Refresh Token 검증
+        if (!refreshTokenService.validateToken(refreshToken)) {
+            throw new CustomException(CommonErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // Refresh Token에서 사용자 정보 추출
+        String username = jwtUtil.getUserInfoFromToken(refreshToken).getSubject();
+        User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+
+        // 새로운 Access Token 생성 (기본 만료 시간: 1시간)
+        String newAccessToken = jwtUtil.createToken(user.getUsername(), user.getRole(), false);
+        
+        // Bearer 접두사 제거
+        String accessTokenValue = newAccessToken.startsWith(JwtUtil.BEARER_PREFIX) 
+            ? newAccessToken.substring(JwtUtil.BEARER_PREFIX.length()) 
+            : newAccessToken;
+
+        // Access Token을 쿠키에 저장
+        boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
+        
+        ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
+                .path("/")
+                .httpOnly(true)
+                .secure(isProduction)
+                .sameSite("Strict")
+                .maxAge(Constants.Jwt.DEFAULT_EXPIRY) // 1시간
+                .build();
+
+        log.info("Access Token 갱신 완료: username={}", username);
+
+        return ResponseEntity.ok()
+                .header("Set-Cookie", accessTokenCookie.toString())
+                .body(ApiResponse.success(HttpStatus.OK, "토큰이 성공적으로 갱신되었습니다.", newAccessToken));
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/com/phonebid/app/auth/domain/RefreshToken.java
@@ -1,6 +1,6 @@
 package com.phonebid.app.auth.domain;
 
-import com.phonebid.app.common.domain.BaseEntity;
+import com.phonebid.app.common.domain.BaseTimeEntity;
 import com.phonebid.app.member.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -12,14 +12,21 @@ import org.hibernate.annotations.Comment;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Refresh Token 엔티티
+ * 
+ * immutable한 엔티티로, 생성 후 수정되지 않습니다.
+ * 만료되거나 삭제될 뿐 업데이트 로직이 없으므로 BaseTimeEntity를 상속합니다.
+ */
 @Entity
 @Table(name = "refresh_tokens", indexes = {
-    @Index(name = "idx_refresh_tokens_user_id", columnList = "user_id"),
-    @Index(name = "idx_refresh_tokens_token", columnList = "token")
+    @Index(name = "idx_refresh_tokens_user_deleted", columnList = "user_id, deleted_at"),
+    @Index(name = "idx_refresh_tokens_token", columnList = "token"),
+    @Index(name = "idx_refresh_tokens_expires_deleted", columnList = "expires_at, deleted_at")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken extends BaseEntity {
+public class RefreshToken extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -49,6 +56,18 @@ public class RefreshToken extends BaseEntity {
 
     public boolean isExpired() {
         return expiresAt.isBefore(LocalDateTime.now());
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public boolean isValid() {
+        return !isExpired() && !isDeleted();
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/com/phonebid/app/auth/domain/RefreshToken.java
@@ -1,0 +1,54 @@
+package com.phonebid.app.auth.domain;
+
+import com.phonebid.app.common.domain.BaseEntity;
+import com.phonebid.app.member.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_tokens", indexes = {
+    @Index(name = "idx_refresh_tokens_user_id", columnList = "user_id"),
+    @Index(name = "idx_refresh_tokens_token", columnList = "token")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    @Comment("Refresh Token 고유 ID (UUID)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("사용자")
+    private User user;
+
+    @Column(name = "token", nullable = false, unique = true, length = 500)
+    @Comment("Refresh Token 값")
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    @Comment("만료 시각")
+    private LocalDateTime expiresAt;
+
+    @Builder
+    public RefreshToken(User user, String token, LocalDateTime expiresAt) {
+        this.user = user;
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired() {
+        return expiresAt.isBefore(LocalDateTime.now());
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/phonebid/app/auth/repository/RefreshTokenRepository.java
@@ -39,5 +39,13 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE RefreshToken rt SET rt.deletedAt = :deletedAt WHERE rt.expiresAt < :dateTime AND rt.deletedAt IS NULL")
     void deleteByExpiresAtBefore(@Param("dateTime") LocalDateTime dateTime, @Param("deletedAt") LocalDateTime deletedAt);
+
+    /**
+     * 삭제된 지 일정 기간 이상 지난 RefreshToken 하드 삭제 (영구 삭제)
+     * 배치 작업에서 사용
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM RefreshToken rt WHERE rt.deletedAt IS NOT NULL AND rt.deletedAt < :cutoffDate")
+    int hardDeleteByDeletedAtBefore(@Param("cutoffDate") LocalDateTime cutoffDate);
 }
 

--- a/backend/src/main/java/com/phonebid/app/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/phonebid/app/auth/repository/RefreshTokenRepository.java
@@ -27,14 +27,14 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID
     /**
      * 사용자 ID로 RefreshToken 삭제
      */
-    @Modifying
+    @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query("DELETE FROM RefreshToken rt WHERE rt.user.id = :userId")
     void deleteByUserId(@Param("userId") UUID userId);
 
     /**
      * 만료된 RefreshToken 삭제
      */
-    @Modifying
+    @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :dateTime")
     void deleteByExpiresAtBefore(@Param("dateTime") LocalDateTime dateTime);
 }

--- a/backend/src/main/java/com/phonebid/app/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/phonebid/app/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,41 @@
+package com.phonebid.app.auth.repository;
+
+import com.phonebid.app.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
+
+    /**
+     * 토큰 값으로 RefreshToken 조회
+     */
+    @Query("SELECT rt FROM RefreshToken rt WHERE rt.token = :token")
+    Optional<RefreshToken> findByToken(@Param("token") String token);
+
+    /**
+     * 사용자 ID로 RefreshToken 조회
+     */
+    @Query("SELECT rt FROM RefreshToken rt WHERE rt.user.id = :userId")
+    Optional<RefreshToken> findByUserId(@Param("userId") UUID userId);
+
+    /**
+     * 사용자 ID로 RefreshToken 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM RefreshToken rt WHERE rt.user.id = :userId")
+    void deleteByUserId(@Param("userId") UUID userId);
+
+    /**
+     * 만료된 RefreshToken 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :dateTime")
+    void deleteByExpiresAtBefore(@Param("dateTime") LocalDateTime dateTime);
+}
+

--- a/backend/src/main/java/com/phonebid/app/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/phonebid/app/auth/repository/RefreshTokenRepository.java
@@ -13,29 +13,31 @@ import java.util.UUID;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
 
     /**
-     * 토큰 값으로 RefreshToken 조회
+     * 토큰 값으로 RefreshToken 조회 (삭제되지 않은 것만)
+     * BaseTimeEntity의 @SQLRestriction으로 자동 필터링되지만 명시적으로 표시
      */
-    @Query("SELECT rt FROM RefreshToken rt WHERE rt.token = :token")
+    @Query("SELECT rt FROM RefreshToken rt WHERE rt.token = :token AND rt.deletedAt IS NULL")
     Optional<RefreshToken> findByToken(@Param("token") String token);
 
     /**
-     * 사용자 ID로 RefreshToken 조회
+     * 사용자 ID로 RefreshToken 조회 (삭제되지 않은 것만)
+     * BaseTimeEntity의 @SQLRestriction으로 자동 필터링되지만 명시적으로 표시
      */
-    @Query("SELECT rt FROM RefreshToken rt WHERE rt.user.id = :userId")
+    @Query("SELECT rt FROM RefreshToken rt WHERE rt.user.id = :userId AND rt.deletedAt IS NULL")
     Optional<RefreshToken> findByUserId(@Param("userId") UUID userId);
 
     /**
-     * 사용자 ID로 RefreshToken 삭제
+     * 사용자 ID로 RefreshToken soft delete
      */
-    @Modifying(clearAutomatically = false, flushAutomatically = true)
-    @Query("DELETE FROM RefreshToken rt WHERE rt.user.id = :userId")
-    void deleteByUserId(@Param("userId") UUID userId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE RefreshToken rt SET rt.deletedAt = :deletedAt WHERE rt.user.id = :userId AND rt.deletedAt IS NULL")
+    void deleteByUserId(@Param("userId") UUID userId, @Param("deletedAt") LocalDateTime deletedAt);
 
     /**
-     * 만료된 RefreshToken 삭제
+     * 만료된 RefreshToken soft delete
      */
-    @Modifying(clearAutomatically = false, flushAutomatically = true)
-    @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :dateTime")
-    void deleteByExpiresAtBefore(@Param("dateTime") LocalDateTime dateTime);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE RefreshToken rt SET rt.deletedAt = :deletedAt WHERE rt.expiresAt < :dateTime AND rt.deletedAt IS NULL")
+    void deleteByExpiresAtBefore(@Param("dateTime") LocalDateTime dateTime, @Param("deletedAt") LocalDateTime deletedAt);
 }
 

--- a/backend/src/main/java/com/phonebid/app/auth/scheduler/RefreshTokenCleanupScheduler.java
+++ b/backend/src/main/java/com/phonebid/app/auth/scheduler/RefreshTokenCleanupScheduler.java
@@ -6,9 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+
 /**
- * 만료된 RefreshToken을 정리하는 스케줄러
- * 매일 자정에 실행되어 만료된 토큰을 삭제
+ * RefreshToken 정리 스케줄러
+ * - 만료된 RefreshToken soft delete
+ * - 삭제된 지 오래된 RefreshToken 하드 삭제 (영구 삭제)
  */
 @Slf4j
 @Component
@@ -16,6 +20,11 @@ import org.springframework.stereotype.Component;
 public class RefreshTokenCleanupScheduler {
 
     private final RefreshTokenService refreshTokenService;
+
+    /**
+     * 삭제 후 경과 기간 (월) - 3개월 이상 지난 삭제된 토큰을 하드 삭제
+     */
+    private static final int HARD_DELETE_MONTHS = 3;
 
     /**
      * 만료된 RefreshToken 정리 작업
@@ -30,6 +39,31 @@ public class RefreshTokenCleanupScheduler {
             log.info("만료된 RefreshToken 정리 작업 완료");
         } catch (Exception e) {
             log.error("만료된 RefreshToken 정리 작업 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 삭제된 지 오래된 RefreshToken 하드 삭제 작업 (영구 삭제)
+     * 매주 일요일 새벽 2시에 실행 (cron: 초 분 시 일 월 요일)
+     * deleted_at이 3개월 이상 지난 데이터를 실제 DB에서 영구 삭제하여 용량 관리
+     */
+    @Scheduled(cron = "0 0 2 ? * SUN")
+    public void hardDeleteOldDeletedTokens() {
+        LocalDateTime startTime = LocalDateTime.now();
+        log.info("=== 삭제된 RefreshToken 하드 삭제 배치 작업 시작 ===");
+        log.info("기준: 삭제된 지 {}개월 이상 지난 데이터", HARD_DELETE_MONTHS);
+
+        try {
+            int deletedCount = refreshTokenService.hardDeleteOldDeletedTokens(HARD_DELETE_MONTHS);
+            
+            LocalDateTime endTime = LocalDateTime.now();
+            Duration duration = Duration.between(startTime, endTime);
+
+            log.info("=== 삭제된 RefreshToken 하드 삭제 배치 작업 완료 ===");
+            log.info("실행 시간: {}초", duration.getSeconds());
+            log.info("삭제된 레코드 수: {}개", deletedCount);
+        } catch (Exception e) {
+            log.error("삭제된 RefreshToken 하드 삭제 배치 작업 중 오류 발생", e);
         }
     }
 }

--- a/backend/src/main/java/com/phonebid/app/auth/scheduler/RefreshTokenCleanupScheduler.java
+++ b/backend/src/main/java/com/phonebid/app/auth/scheduler/RefreshTokenCleanupScheduler.java
@@ -1,0 +1,36 @@
+package com.phonebid.app.auth.scheduler;
+
+import com.phonebid.app.auth.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 만료된 RefreshToken을 정리하는 스케줄러
+ * 매일 자정에 실행되어 만료된 토큰을 삭제
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleanupScheduler {
+
+    private final RefreshTokenService refreshTokenService;
+
+    /**
+     * 만료된 RefreshToken 정리 작업
+     * 매일 자정에 실행 (cron: 초 분 시 일 월 요일)
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void cleanupExpiredTokens() {
+        log.info("만료된 RefreshToken 정리 작업 시작");
+        
+        try {
+            refreshTokenService.deleteExpiredTokens();
+            log.info("만료된 RefreshToken 정리 작업 완료");
+        } catch (Exception e) {
+            log.error("만료된 RefreshToken 정리 작업 중 오류 발생", e);
+        }
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
@@ -110,5 +110,24 @@ public class DbRefreshTokenService implements RefreshTokenService {
 
         return true;
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String getTokenByUsername(String username) {
+        // 사용자 조회
+        User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+
+        // RefreshToken 존재 여부 확인
+        refreshTokenRepository.findByUserId(user.getId())
+            .orElseThrow(() -> new CustomException(CommonErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        // 주의: 이 메서드는 실제로 사용되지 않습니다.
+        // 서비스 레이어(KakaoService, NaverService)에서 createRefreshToken의 반환값을
+        // 저장하여 getRefreshTokenForUsername 메서드로 제공합니다.
+        // 
+        // DB에 저장된 토큰은 해시된 값이므로 원본 토큰을 재생성할 수 없습니다.
+        throw new CustomException(CommonErrorCode.REFRESH_TOKEN_NOT_FOUND);
+    }
 }
 

--- a/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
@@ -1,0 +1,109 @@
+package com.phonebid.app.auth.service;
+
+import com.phonebid.app.auth.domain.RefreshToken;
+import com.phonebid.app.auth.repository.RefreshTokenRepository;
+import com.phonebid.app.common.Constants;
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * RDB 기반 RefreshTokenService 구현체
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DbRefreshTokenService implements RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    @Transactional
+    public String createRefreshToken(UUID userId) {
+        // 기존 RefreshToken 삭제
+        refreshTokenRepository.deleteByUserId(userId);
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+
+        // RefreshToken 생성
+        String token = jwtUtil.createRefreshToken(user.getUsername());
+        LocalDateTime expiresAt = LocalDateTime.now().plus(Constants.Jwt.REFRESH_TOKEN_EXPIRY);
+
+        // DB 저장
+        RefreshToken refreshToken = RefreshToken.builder()
+            .user(user)
+            .token(token)
+            .expiresAt(expiresAt)
+            .build();
+
+        refreshTokenRepository.save(refreshToken);
+        log.info("RefreshToken 생성 완료: userId={}", userId);
+
+        return token;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<RefreshToken> findByUserId(UUID userId) {
+        return refreshTokenRepository.findByUserId(userId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByUserId(UUID userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+        log.info("RefreshToken 삭제 완료: userId={}", userId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteExpiredTokens() {
+        LocalDateTime now = LocalDateTime.now();
+        refreshTokenRepository.deleteByExpiresAtBefore(now);
+        log.info("만료된 RefreshToken 정리 완료: 기준 시각={}", now);
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        // JWT 검증
+        if (!jwtUtil.validateRefreshToken(token)) {
+            return false;
+        }
+
+        // DB에서 조회하여 존재 여부 확인
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenRepository.findByToken(token);
+        if (refreshTokenOpt.isEmpty()) {
+            return false;
+        }
+
+        RefreshToken refreshToken = refreshTokenOpt.get();
+        
+        // 만료 시간 확인
+        if (refreshToken.isExpired()) {
+            return false;
+        }
+
+        return true;
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
@@ -38,8 +38,8 @@ public class DbRefreshTokenService implements RefreshTokenService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
         
-        // 기존 RefreshToken 삭제
-        refreshTokenRepository.deleteByUserId(userId);
+        // 기존 RefreshToken soft delete
+        refreshTokenRepository.deleteByUserId(userId, LocalDateTime.now());
 
         // RefreshToken 생성
         String token = jwtUtil.createRefreshToken(user.getUsername());
@@ -75,16 +75,16 @@ public class DbRefreshTokenService implements RefreshTokenService {
     @Override
     @Transactional
     public void deleteByUserId(UUID userId) {
-        refreshTokenRepository.deleteByUserId(userId);
-        log.info("RefreshToken 삭제 완료: userId={}", userId);
+        refreshTokenRepository.deleteByUserId(userId, LocalDateTime.now());
+        log.info("RefreshToken soft delete 완료: userId={}", userId);
     }
 
     @Override
     @Transactional
     public void deleteExpiredTokens() {
         LocalDateTime now = LocalDateTime.now();
-        refreshTokenRepository.deleteByExpiresAtBefore(now);
-        log.info("만료된 RefreshToken 정리 완료: 기준 시각={}", now);
+        refreshTokenRepository.deleteByExpiresAtBefore(now, now);
+        log.info("만료된 RefreshToken soft delete 완료: 기준 시각={}", now);
     }
 
     @Override

--- a/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
@@ -2,6 +2,7 @@ package com.phonebid.app.auth.service;
 
 import com.phonebid.app.auth.domain.RefreshToken;
 import com.phonebid.app.auth.repository.RefreshTokenRepository;
+import com.phonebid.app.auth.util.TokenHashUtil;
 import com.phonebid.app.common.Constants;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
@@ -28,6 +29,7 @@ public class DbRefreshTokenService implements RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
+    private final TokenHashUtil tokenHashUtil;
 
     @Override
     @Transactional
@@ -41,12 +43,13 @@ public class DbRefreshTokenService implements RefreshTokenService {
 
         // RefreshToken 생성
         String token = jwtUtil.createRefreshToken(user.getUsername());
+        String hashedToken = tokenHashUtil.hashToken(token);
         LocalDateTime expiresAt = LocalDateTime.now().plus(Constants.Jwt.REFRESH_TOKEN_EXPIRY);
 
-        // DB 저장
+        // DB 저장 (해시된 토큰만 저장)
         RefreshToken refreshToken = RefreshToken.builder()
             .user(user)
-            .token(token)
+            .token(hashedToken)
             .expiresAt(expiresAt)
             .build();
 
@@ -59,7 +62,8 @@ public class DbRefreshTokenService implements RefreshTokenService {
     @Override
     @Transactional(readOnly = true)
     public Optional<RefreshToken> findByToken(String token) {
-        return refreshTokenRepository.findByToken(token);
+        String hashedToken = tokenHashUtil.hashToken(token);
+        return refreshTokenRepository.findByToken(hashedToken);
     }
 
     @Override
@@ -90,8 +94,9 @@ public class DbRefreshTokenService implements RefreshTokenService {
             return false;
         }
 
-        // DB에서 조회하여 존재 여부 확인
-        Optional<RefreshToken> refreshTokenOpt = refreshTokenRepository.findByToken(token);
+        // 토큰을 해시화하여 DB에서 조회
+        String hashedToken = tokenHashUtil.hashToken(token);
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenRepository.findByToken(hashedToken);
         if (refreshTokenOpt.isEmpty()) {
             return false;
         }

--- a/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
@@ -32,12 +32,12 @@ public class DbRefreshTokenService implements RefreshTokenService {
     @Override
     @Transactional
     public String createRefreshToken(UUID userId) {
-        // 기존 RefreshToken 삭제
-        refreshTokenRepository.deleteByUserId(userId);
-
-        // 사용자 조회
+        // 사용자 조회 (삭제 전에 조회하여 영속성 컨텍스트에 로드)
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+        
+        // 기존 RefreshToken 삭제
+        refreshTokenRepository.deleteByUserId(userId);
 
         // RefreshToken 생성
         String token = jwtUtil.createRefreshToken(user.getUsername());

--- a/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/DbRefreshTokenService.java
@@ -54,7 +54,6 @@ public class DbRefreshTokenService implements RefreshTokenService {
             .build();
 
         refreshTokenRepository.save(refreshToken);
-        log.info("RefreshToken 생성 완료: userId={}", userId);
 
         return token;
     }
@@ -76,7 +75,6 @@ public class DbRefreshTokenService implements RefreshTokenService {
     @Transactional
     public void deleteByUserId(UUID userId) {
         refreshTokenRepository.deleteByUserId(userId, LocalDateTime.now());
-        log.info("RefreshToken soft delete 완료: userId={}", userId);
     }
 
     @Override
@@ -84,7 +82,13 @@ public class DbRefreshTokenService implements RefreshTokenService {
     public void deleteExpiredTokens() {
         LocalDateTime now = LocalDateTime.now();
         refreshTokenRepository.deleteByExpiresAtBefore(now, now);
-        log.info("만료된 RefreshToken soft delete 완료: 기준 시각={}", now);
+    }
+
+    @Override
+    @Transactional
+    public int hardDeleteOldDeletedTokens(int months) {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusMonths(months);
+        return refreshTokenRepository.hardDeleteByDeletedAtBefore(cutoffDate);
     }
 
     @Override

--- a/backend/src/main/java/com/phonebid/app/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/RefreshTokenService.java
@@ -1,0 +1,53 @@
+package com.phonebid.app.auth.service;
+
+import com.phonebid.app.auth.domain.RefreshToken;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * RefreshToken 저장 및 조회를 위한 서비스 인터페이스
+ * 추상화를 통해 향후 RDB에서 타 DB(예: Redis)로 쉽게 교체 가능하도록 설계
+ */
+public interface RefreshTokenService {
+
+    /**
+     * RefreshToken 생성 및 저장
+     * @param userId 사용자 ID
+     * @return 생성된 RefreshToken 값
+     */
+    String createRefreshToken(UUID userId);
+
+    /**
+     * 토큰 값으로 RefreshToken 조회
+     * @param token RefreshToken 값
+     * @return RefreshToken 엔티티 (없으면 Optional.empty())
+     */
+    Optional<RefreshToken> findByToken(String token);
+
+    /**
+     * 사용자 ID로 RefreshToken 조회
+     * @param userId 사용자 ID
+     * @return RefreshToken 엔티티 (없으면 Optional.empty())
+     */
+    Optional<RefreshToken> findByUserId(UUID userId);
+
+    /**
+     * 사용자 ID로 RefreshToken 삭제
+     * @param userId 사용자 ID
+     */
+    void deleteByUserId(UUID userId);
+
+    /**
+     * 만료된 RefreshToken 삭제
+     */
+    void deleteExpiredTokens();
+
+    /**
+     * RefreshToken 유효성 검증
+     * @param token RefreshToken 값
+     * @return 유효하면 true, 그렇지 않으면 false
+     */
+    boolean validateToken(String token);
+}
+

--- a/backend/src/main/java/com/phonebid/app/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/RefreshTokenService.java
@@ -44,6 +44,14 @@ public interface RefreshTokenService {
     void deleteExpiredTokens();
 
     /**
+     * 삭제된 지 일정 기간 이상 지난 RefreshToken 하드 삭제 (영구 삭제)
+     * 배치 작업에서 사용
+     * @param months 삭제 후 경과 기간 (월)
+     * @return 삭제된 레코드 수
+     */
+    int hardDeleteOldDeletedTokens(int months);
+
+    /**
      * RefreshToken 유효성 검증
      * @param token RefreshToken 값
      * @return 유효하면 true, 그렇지 않으면 false

--- a/backend/src/main/java/com/phonebid/app/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/phonebid/app/auth/service/RefreshTokenService.java
@@ -49,5 +49,13 @@ public interface RefreshTokenService {
      * @return 유효하면 true, 그렇지 않으면 false
      */
     boolean validateToken(String token);
+
+    /**
+     * 사용자명으로 RefreshToken 값 조회
+     * @param username 사용자명
+     * @return RefreshToken 값 (해시되지 않은 원본 토큰)
+     * @throws CustomException 사용자를 찾을 수 없거나 RefreshToken을 찾을 수 없는 경우
+     */
+    String getTokenByUsername(String username);
 }
 

--- a/backend/src/main/java/com/phonebid/app/auth/util/TokenHashUtil.java
+++ b/backend/src/main/java/com/phonebid/app/auth/util/TokenHashUtil.java
@@ -1,0 +1,48 @@
+package com.phonebid.app.auth.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * RefreshToken 해싱을 위한 유틸리티 클래스
+ * HMAC-SHA256을 사용하여 토큰을 해시화합니다.
+ */
+@Slf4j
+@Component
+public class TokenHashUtil {
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    
+    private static final String ALGORITHM = "HmacSHA256";
+
+    /**
+     * 토큰을 HMAC-SHA256으로 해시화합니다.
+     * 
+     * @param token 원본 토큰
+     * @return 해시화된 토큰 (Base64 인코딩)
+     */
+    public String hashToken(String token) {
+        try {
+            Mac macInstance = Mac.getInstance(ALGORITHM);
+            byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+            SecretKeySpec secretKeySpec = new SecretKeySpec(keyBytes, ALGORITHM);
+            macInstance.init(secretKeySpec);
+            
+            byte[] hashBytes = macInstance.doFinal(token.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hashBytes);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            log.error("토큰 해시화 실패", e);
+            throw new RuntimeException("토큰 해시화 실패", e);
+        }
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/common/Constants.java
+++ b/backend/src/main/java/com/phonebid/app/common/Constants.java
@@ -25,14 +25,14 @@ public final class Constants {
         public static final Duration KEEP_LOGGED_IN_EXPIRY = Duration.ofDays(30);
         
         /**
-         * 일반 로그인 시 토큰/쿠키 만료 시간: 1시간
+         * 일반 로그인 시 토큰/쿠키 만료 시간: 30분
          */
-        public static final Duration DEFAULT_EXPIRY = Duration.ofHours(1);
+        public static final Duration DEFAULT_EXPIRY = Duration.ofMinutes(30);
         
         /**
-         * 일반 로그인 시 토큰 만료 시간 (밀리초): 60분
+         * 일반 로그인 시 토큰 만료 시간 (밀리초): 30분
          */
-        public static final long DEFAULT_EXPIRY_MILLIS = 60 * 60 * 1000L; // 60분
+        public static final long DEFAULT_EXPIRY_MILLIS = 30 * 60 * 1000L; // 30분
         
         /**
          * 로그인 상태 유지 시 토큰 만료 시간 (밀리초): 30일
@@ -40,14 +40,14 @@ public final class Constants {
         public static final long KEEP_LOGGED_IN_EXPIRY_MILLIS = 30L * 24 * 60 * 60 * 1000L; // 30일
         
         /**
-         * Refresh Token 만료 시간: 30일
+         * Refresh Token 만료 시간: 2주
          */
-        public static final Duration REFRESH_TOKEN_EXPIRY = Duration.ofDays(30);
+        public static final Duration REFRESH_TOKEN_EXPIRY = Duration.ofDays(14);
         
         /**
-         * Refresh Token 만료 시간 (밀리초): 30일
+         * Refresh Token 만료 시간 (밀리초): 2주
          */
-        public static final long REFRESH_TOKEN_EXPIRY_MILLIS = 30L * 24 * 60 * 60 * 1000L;
+        public static final long REFRESH_TOKEN_EXPIRY_MILLIS = 14L * 24 * 60 * 60 * 1000L;
         
         /**
          * Refresh Token 쿠키 이름

--- a/backend/src/main/java/com/phonebid/app/common/Constants.java
+++ b/backend/src/main/java/com/phonebid/app/common/Constants.java
@@ -38,6 +38,21 @@ public final class Constants {
          * 로그인 상태 유지 시 토큰 만료 시간 (밀리초): 30일
          */
         public static final long KEEP_LOGGED_IN_EXPIRY_MILLIS = 30L * 24 * 60 * 60 * 1000L; // 30일
+        
+        /**
+         * Refresh Token 만료 시간: 30일
+         */
+        public static final Duration REFRESH_TOKEN_EXPIRY = Duration.ofDays(30);
+        
+        /**
+         * Refresh Token 만료 시간 (밀리초): 30일
+         */
+        public static final long REFRESH_TOKEN_EXPIRY_MILLIS = 30L * 24 * 60 * 60 * 1000L;
+        
+        /**
+         * Refresh Token 쿠키 이름
+         */
+        public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
     }
 }
 

--- a/backend/src/main/java/com/phonebid/app/common/README.md
+++ b/backend/src/main/java/com/phonebid/app/common/README.md
@@ -24,7 +24,11 @@
 
 - **domain/**
   - 공통 도메인 및 베이스 엔티티 클래스
-  - `BaseEntity.java`: JPA 감사(auditing) 필드 포함 베이스 엔티티
+  - `BaseEntity.java`: JPA 감사(auditing) 필드 포함 베이스 엔티티 (일반 엔터티용)
+    - `createdAt`, `updatedAt`, `createdBy`, `updatedBy`, `deletedAt`, `deletedBy`, `isDelete` 포함
+  - `BaseTimeEntity.java`: 최소한의 시간 정보만 포함하는 베이스 엔티티 (Immutable 엔터티용)
+    - `createdAt`, `deletedAt`만 포함
+    - 수정되지 않는 엔터티(예: RefreshToken)에 사용
 
 - **config/**
   - 공통 설정 및 JPA 감사 관련 설정 클래스

--- a/backend/src/main/java/com/phonebid/app/common/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/phonebid/app/common/config/WebSecurityConfig.java
@@ -135,6 +135,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/v1/sellers/documents/temp").permitAll() // 임시 파일 업로드 엔드포인트 접근 허가 (회원가입 단계용)
                         .requestMatchers("/api/v1/auth/kakao/**").permitAll() // 카카오 OAuth 엔드포인트 접근 허가
                         .requestMatchers("/api/v1/auth/naver/**").permitAll() // 네이버 OAuth 엔드포인트 접근 허가
+                        .requestMatchers("/api/v1/auth/refresh").permitAll() // Refresh Token 갱신 엔드포인트 접근 허가
                         .requestMatchers("/api/v1/payments/portone/**").permitAll() // PortOne 결제 엔드포인트 접근 허가
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );

--- a/backend/src/main/java/com/phonebid/app/common/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/com/phonebid/app/common/domain/BaseTimeEntity.java
@@ -1,0 +1,44 @@
+package com.phonebid.app.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 최소한의 시간 정보만 포함하는 베이스 엔티티
+ * 
+ * immutable한 엔티티(예: RefreshToken)에 사용됩니다.
+ * 생성 시각(createdAt)과 삭제 시각(deletedAt)만 관리하며,
+ * 수정 시각, 생성자, 수정자, 삭제자 등의 정보는 포함하지 않습니다.
+ * 
+ * 일반 엔티티(예: User, Product)는 BaseEntity를 사용하세요.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE {h-table} SET deleted_at = CURRENT_TIMESTAMP WHERE {h-where}")
+public abstract class BaseTimeEntity implements Serializable {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    @Comment("생성 시각")
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    @Comment("삭제 시각 (soft delete)")
+    protected LocalDateTime deletedAt;
+}
+

--- a/backend/src/main/java/com/phonebid/app/common/errorcode/CommonErrorCode.java
+++ b/backend/src/main/java/com/phonebid/app/common/errorcode/CommonErrorCode.java
@@ -66,7 +66,12 @@ public enum CommonErrorCode implements ErrorCode {
 
     // 배송지 관련 에러
     DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "배송지를 찾을 수 없습니다."),
-    DEFAULT_DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "기본 배송지가 없습니다.");
+    DEFAULT_DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "기본 배송지가 없습니다."),
+
+    // Refresh Token 관련 에러
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 Refresh Token입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh Token을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/phonebid/app/common/util/CookieUtil.java
+++ b/backend/src/main/java/com/phonebid/app/common/util/CookieUtil.java
@@ -1,0 +1,104 @@
+package com.phonebid.app.common.util;
+
+import com.phonebid.app.common.Constants;
+import com.phonebid.app.jwt.JwtUtil;
+import org.springframework.core.env.Environment;
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+import java.util.Arrays;
+
+/**
+ * 쿠키 생성 유틸리티 클래스
+ * Access Token 및 Refresh Token 쿠키 생성을 공통화
+ */
+public class CookieUtil {
+
+    /**
+     * Access Token 쿠키 생성
+     * @param accessToken Access Token 값 (Bearer 접두사 포함 가능)
+     * @param isProduction 프로덕션 환경 여부
+     * @param maxAge 쿠키 만료 시간
+     * @return ResponseCookie
+     */
+    public static ResponseCookie createAccessTokenCookie(String accessToken, boolean isProduction, Duration maxAge) {
+        // Bearer 접두사 제거
+        String accessTokenValue = accessToken.startsWith(JwtUtil.BEARER_PREFIX)
+            ? accessToken.substring(JwtUtil.BEARER_PREFIX.length())
+            : accessToken;
+
+        return ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
+                .path("/")
+                .httpOnly(true) // XSS 공격 방지
+                .secure(isProduction) // 프로덕션에서만 HTTPS 필수
+                .sameSite("Strict") // CSRF 공격 방지
+                .maxAge(maxAge)
+                .build();
+    }
+
+    /**
+     * Access Token 쿠키 생성 (기본 만료 시간: 1시간)
+     * @param accessToken Access Token 값 (Bearer 접두사 포함 가능)
+     * @param isProduction 프로덕션 환경 여부
+     * @return ResponseCookie
+     */
+    public static ResponseCookie createAccessTokenCookie(String accessToken, boolean isProduction) {
+        return createAccessTokenCookie(accessToken, isProduction, Constants.Jwt.DEFAULT_EXPIRY);
+    }
+
+    /**
+     * Refresh Token 쿠키 생성
+     * @param refreshToken Refresh Token 값
+     * @param isProduction 프로덕션 환경 여부
+     * @return ResponseCookie
+     */
+    public static ResponseCookie createRefreshTokenCookie(String refreshToken, boolean isProduction) {
+        return ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .path("/")
+                .httpOnly(true) // XSS 공격 방지
+                .secure(isProduction) // 프로덕션에서만 HTTPS 필수
+                .sameSite("Strict") // CSRF 공격 방지
+                .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
+                .build();
+    }
+
+    /**
+     * Access Token 쿠키 삭제용 쿠키 생성
+     * @param isProduction 프로덕션 환경 여부
+     * @return ResponseCookie (maxAge=0으로 설정되어 삭제됨)
+     */
+    public static ResponseCookie createAccessTokenDeleteCookie(boolean isProduction) {
+        return ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, "")
+                .path("/")
+                .httpOnly(true)
+                .secure(isProduction)
+                .sameSite("Strict")
+                .maxAge(Duration.ZERO)
+                .build();
+    }
+
+    /**
+     * Refresh Token 쿠키 삭제용 쿠키 생성
+     * @param isProduction 프로덕션 환경 여부
+     * @return ResponseCookie (maxAge=0으로 설정되어 삭제됨)
+     */
+    public static ResponseCookie createRefreshTokenDeleteCookie(boolean isProduction) {
+        return ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, "")
+                .path("/")
+                .httpOnly(true)
+                .secure(isProduction)
+                .sameSite("Strict")
+                .maxAge(Duration.ZERO)
+                .build();
+    }
+
+    /**
+     * 환경에서 프로덕션 여부 확인
+     * @param environment Spring Environment
+     * @return 프로덕션 환경이면 true
+     */
+    public static boolean isProduction(Environment environment) {
+        return Arrays.asList(environment.getActiveProfiles()).contains("prod");
+    }
+}
+

--- a/backend/src/main/java/com/phonebid/app/common/util/CookieUtil.java
+++ b/backend/src/main/java/com/phonebid/app/common/util/CookieUtil.java
@@ -57,6 +57,10 @@ public class CookieUtil {
      * @return ResponseCookie
      */
     public static ResponseCookie createRefreshTokenCookie(String refreshToken, boolean isProduction) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new IllegalArgumentException("refreshToken must not be null or blank");
+        }
+
         return ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                 .path("/")
                 .httpOnly(true) // XSS 공격 방지

--- a/backend/src/main/java/com/phonebid/app/common/util/CookieUtil.java
+++ b/backend/src/main/java/com/phonebid/app/common/util/CookieUtil.java
@@ -22,6 +22,10 @@ public class CookieUtil {
      * @return ResponseCookie
      */
     public static ResponseCookie createAccessTokenCookie(String accessToken, boolean isProduction, Duration maxAge) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalArgumentException("accessToken must not be null or blank");
+        }
+
         // Bearer 접두사 제거
         String accessTokenValue = accessToken.startsWith(JwtUtil.BEARER_PREFIX)
             ? accessToken.substring(JwtUtil.BEARER_PREFIX.length())

--- a/backend/src/main/java/com/phonebid/app/common/util/CookieUtil.java
+++ b/backend/src/main/java/com/phonebid/app/common/util/CookieUtil.java
@@ -41,7 +41,7 @@ public class CookieUtil {
     }
 
     /**
-     * Access Token 쿠키 생성 (기본 만료 시간: 1시간)
+     * Access Token 쿠키 생성 (기본 만료 시간: 30분)
      * @param accessToken Access Token 값 (Bearer 접두사 포함 가능)
      * @param isProduction 프로덕션 환경 여부
      * @return ResponseCookie
@@ -62,7 +62,7 @@ public class CookieUtil {
                 .httpOnly(true) // XSS 공격 방지
                 .secure(isProduction) // 프로덕션에서만 HTTPS 필수
                 .sameSite("Strict") // CSRF 공격 방지
-                .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
+                .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 2주
                 .build();
     }
 

--- a/backend/src/main/java/com/phonebid/app/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/phonebid/app/jwt/JwtUtil.java
@@ -122,4 +122,61 @@ public class JwtUtil {
     public Claims getUserInfoFromToken(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
     }
+
+    /**
+     * Refresh Token 생성 (만료 시간: 30일)
+     * @param username 사용자명
+     * @return Refresh Token (Bearer 접두사 없이 순수 토큰만 반환)
+     */
+    public String createRefreshToken(String username) {
+        Date date = new Date();
+        
+        return Jwts.builder()
+                .setSubject(username)
+                .setExpiration(new Date(date.getTime() + Constants.Jwt.REFRESH_TOKEN_EXPIRY_MILLIS))
+                .setIssuedAt(date)
+                .signWith(key, signatureAlgorithm)
+                .compact();
+    }
+
+    /**
+     * Refresh Token 검증
+     * @param token Refresh Token
+     * @return 유효하면 true, 그렇지 않으면 false
+     */
+    public boolean validateRefreshToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid Refresh Token signature, 유효하지 않는 Refresh Token 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired Refresh Token, 만료된 Refresh Token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported Refresh Token, 지원되지 않는 Refresh Token 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("Refresh Token claims is empty, 잘못된 Refresh Token 입니다.");
+        }
+        return false;
+    }
+
+    /**
+     * 쿠키에서 Refresh Token을 가져오는 메서드
+     * @param request HTTP 요청 객체
+     * @return Refresh Token (없으면 null)
+     */
+    public String getRefreshTokenFromCookie(HttpServletRequest request) {
+        jakarta.servlet.http.Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (jakarta.servlet.http.Cookie cookie : cookies) {
+                if (Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    String tokenValue = cookie.getValue();
+                    if (StringUtils.hasText(tokenValue)) {
+                        return tokenValue;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/backend/src/main/java/com/phonebid/app/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/phonebid/app/jwt/JwtUtil.java
@@ -44,7 +44,7 @@ public class JwtUtil {
      * JWT 토큰 생성 (keepLoggedIn 파라미터 포함)
      * @param username 사용자명
      * @param role 사용자 역할
-     * @param keepLoggedIn 로그인 상태 유지 여부 (true: 30일, false: 1시간)
+     * @param keepLoggedIn 로그인 상태 유지 여부 (true: 30일, false: 30분)
      * @return JWT 토큰 (Bearer 접두사 포함)
      */
     public String createToken(String username, Role role, boolean keepLoggedIn) {
@@ -66,7 +66,7 @@ public class JwtUtil {
     }
     
     /**
-     * JWT 토큰 생성 (기본 만료 시간: 1시간)
+     * JWT 토큰 생성 (기본 만료 시간: 30분)
      * @param username 사용자명
      * @param role 사용자 역할
      * @return JWT 토큰 (Bearer 접두사 포함)
@@ -124,7 +124,7 @@ public class JwtUtil {
     }
 
     /**
-     * Refresh Token 생성 (만료 시간: 30일)
+     * Refresh Token 생성 (만료 시간: 2주)
      * @param username 사용자명
      * @return Refresh Token (Bearer 접두사 없이 순수 토큰만 반환)
      */

--- a/backend/src/main/java/com/phonebid/app/member/controller/KakaoController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/KakaoController.java
@@ -49,13 +49,13 @@ public class KakaoController {
     @GetMapping("/callback")
     public void kakaoCallback(@RequestParam String code, HttpServletResponse response) throws Exception {
         try {
-            log.info("카카오 로그인 콜백 처리 시작: code={}", code);
+            log.debug("카카오 로그인 콜백 처리 시작");
             
             // 인가 코드로 로그인 처리 및 JWT 토큰 생성
             LoginResponseDto loginResponse = kakaoService.kakaoLogin(code);
             String token = loginResponse.getAccessToken();
             
-            log.info("카카오 로그인 성공: username={}", loginResponse.getUsername());
+            log.debug("카카오 로그인 성공: username={}", loginResponse.getUsername());
             
             // Access Token과 Refresh Token을 쿠키에 저장
             boolean isProduction = CookieUtil.isProduction(environment);
@@ -95,9 +95,9 @@ public class KakaoController {
     @PostMapping("/token")
     public ResponseEntity<ApiResponse<LoginResponseDto>> exchangeKakaoToken(@RequestParam String code) {
         try {
-            log.info("프론트엔드 카카오 토큰 교환 시작: code={}", code);
+            log.debug("프론트엔드 카카오 토큰 교환 시작");
             LoginResponseDto response = kakaoService.kakaoLogin(code);
-            log.info("카카오 토큰 교환 성공: username={}", response.getUsername());
+            log.debug("카카오 토큰 교환 성공: username={}", response.getUsername());
             return ResponseEntity.ok(
                 ApiResponse.success(HttpStatus.OK, "카카오 로그인 성공", response)
             );

--- a/backend/src/main/java/com/phonebid/app/member/controller/KakaoController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/KakaoController.java
@@ -1,11 +1,14 @@
 package com.phonebid.app.member.controller;
 
 import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.common.Constants;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.KakaoErrorCode;
 import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.auth.service.RefreshTokenService;
 import com.phonebid.app.member.dto.response.LoginResponseDto;
 import com.phonebid.app.member.service.KakaoService;
+import com.phonebid.app.member.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +34,8 @@ public class KakaoController {
     
     private final KakaoService kakaoService;
     private final Environment environment;
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
     
     @Value("${oauth.kakao.client-id}")
     private String kakaoClientId;
@@ -58,10 +63,15 @@ public class KakaoController {
             
             log.info("카카오 로그인 성공: username={}", loginResponse.getUsername());
             
-            // JWT 토큰을 보안 강화된 쿠키에 저장 (Bearer 접두사 제거)
+            // Access Token과 Refresh Token을 쿠키에 저장
             boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
             
-            ResponseCookie cookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, token.substring(7))
+            // Access Token 쿠키
+            String accessTokenValue = token.startsWith(JwtUtil.BEARER_PREFIX) 
+                ? token.substring(JwtUtil.BEARER_PREFIX.length()) 
+                : token;
+            
+            ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
                     .path("/")
                     .httpOnly(true) // XSS 공격 방지
                     .secure(isProduction) // 프로덕션에서만 HTTPS 필수
@@ -69,7 +79,23 @@ public class KakaoController {
                     .maxAge(Duration.ofHours(1)) // 1시간 유효
                     .build();
             
-            response.addHeader("Set-Cookie", cookie.toString());
+            // Refresh Token 쿠키
+            String refreshToken = refreshTokenService.findByUserId(userRepository.findByUsername(loginResponse.getUsername())
+                    .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
+                    .getId())
+                .orElseThrow(() -> new RuntimeException("Refresh Token을 찾을 수 없습니다."))
+                .getToken();
+            
+            ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                    .path("/")
+                    .httpOnly(true) // XSS 공격 방지
+                    .secure(isProduction) // 프로덕션에서만 HTTPS 필수
+                    .sameSite("Strict") // CSRF 공격 방지
+                    .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
+                    .build();
+            
+            response.addHeader("Set-Cookie", accessTokenCookie.toString());
+            response.addHeader("Set-Cookie", refreshTokenCookie.toString());
             
             // 프론트엔드 홈 페이지로 리다이렉트 (쿠키에 토큰이 이미 설정됨)
             // 홈 페이지에서 initializeAuth()가 자동으로 실행되어 사용자 정보 조회

--- a/backend/src/main/java/com/phonebid/app/member/controller/KakaoController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/KakaoController.java
@@ -1,14 +1,11 @@
 package com.phonebid.app.member.controller;
 
 import com.phonebid.app.common.dto.ApiResponse;
-import com.phonebid.app.common.Constants;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.KakaoErrorCode;
-import com.phonebid.app.jwt.JwtUtil;
-import com.phonebid.app.auth.service.RefreshTokenService;
+import com.phonebid.app.common.util.CookieUtil;
 import com.phonebid.app.member.dto.response.LoginResponseDto;
 import com.phonebid.app.member.service.KakaoService;
-import com.phonebid.app.member.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
-import java.util.Arrays;
 
 /**
  * 카카오 OAuth2 인증 컨트롤러
@@ -34,8 +30,6 @@ public class KakaoController {
     
     private final KakaoService kakaoService;
     private final Environment environment;
-    private final RefreshTokenService refreshTokenService;
-    private final UserRepository userRepository;
     
     @Value("${oauth.kakao.client-id}")
     private String kakaoClientId;
@@ -64,35 +58,15 @@ public class KakaoController {
             log.info("카카오 로그인 성공: username={}", loginResponse.getUsername());
             
             // Access Token과 Refresh Token을 쿠키에 저장
-            boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
+            boolean isProduction = CookieUtil.isProduction(environment);
             
-            // Access Token 쿠키
-            String accessTokenValue = token.startsWith(JwtUtil.BEARER_PREFIX) 
-                ? token.substring(JwtUtil.BEARER_PREFIX.length()) 
-                : token;
+            // Access Token 쿠키 생성
+            ResponseCookie accessTokenCookie = CookieUtil.createAccessTokenCookie(
+                token, isProduction, Duration.ofHours(1));
             
-            ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
-                    .path("/")
-                    .httpOnly(true) // XSS 공격 방지
-                    .secure(isProduction) // 프로덕션에서만 HTTPS 필수
-                    .sameSite("Strict") // CSRF 공격 방지
-                    .maxAge(Duration.ofHours(1)) // 1시간 유효
-                    .build();
-            
-            // Refresh Token 쿠키
-            String refreshToken = refreshTokenService.findByUserId(userRepository.findByUsername(loginResponse.getUsername())
-                    .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
-                    .getId())
-                .orElseThrow(() -> new RuntimeException("Refresh Token을 찾을 수 없습니다."))
-                .getToken();
-            
-            ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
-                    .path("/")
-                    .httpOnly(true) // XSS 공격 방지
-                    .secure(isProduction) // 프로덕션에서만 HTTPS 필수
-                    .sameSite("Strict") // CSRF 공격 방지
-                    .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
-                    .build();
+            // Refresh Token 쿠키 생성 (DTO에서 직접 가져오기 - 동시성 문제 해결)
+            ResponseCookie refreshTokenCookie = CookieUtil.createRefreshTokenCookie(
+                loginResponse.getRefreshToken(), isProduction);
             
             response.addHeader("Set-Cookie", accessTokenCookie.toString());
             response.addHeader("Set-Cookie", refreshTokenCookie.toString());

--- a/backend/src/main/java/com/phonebid/app/member/controller/NaverController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/NaverController.java
@@ -49,13 +49,13 @@ public class NaverController {
     @GetMapping("/callback")
     public void naverCallback(@RequestParam String code, HttpServletResponse response) throws Exception {
         try {
-            log.info("네이버 로그인 콜백 처리 시작: code={}", code);
+            log.debug("네이버 로그인 콜백 처리 시작");
 
             // 인가 코드로 로그인 처리 및 JWT 토큰 생성
             LoginResponseDto loginResponse = naverService.naverLogin(code);
             String token = loginResponse.getAccessToken();
 
-            log.info("네이버 로그인 성공: username={}", loginResponse.getUsername());
+            log.debug("네이버 로그인 성공: username={}", loginResponse.getUsername());
 
             // Access Token과 Refresh Token을 쿠키에 저장
             boolean isProduction = CookieUtil.isProduction(environment);
@@ -94,9 +94,9 @@ public class NaverController {
     @PostMapping("/token")
     public ResponseEntity<ApiResponse<LoginResponseDto>> exchangeNaverToken(@RequestParam String code) {
         try {
-            log.info("프론트엔드 네이버 토큰 교환 시작: code={}", code);
+            log.debug("프론트엔드 네이버 토큰 교환 시작");
             LoginResponseDto response = naverService.naverLogin(code);
-            log.info("네이버 토큰 교환 성공: username={}", response.getUsername());
+            log.debug("네이버 토큰 교환 성공: username={}", response.getUsername());
             return ResponseEntity.ok(
                 ApiResponse.success(HttpStatus.OK, "네이버 로그인 성공", response)
             );

--- a/backend/src/main/java/com/phonebid/app/member/controller/NaverController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/NaverController.java
@@ -2,11 +2,14 @@ package com.phonebid.app.member.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.phonebid.app.common.dto.ApiResponse;
+import com.phonebid.app.common.Constants;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.NaverErrorCode;
 import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.auth.service.RefreshTokenService;
 import com.phonebid.app.member.dto.response.LoginResponseDto;
 import com.phonebid.app.member.service.NaverService;
+import com.phonebid.app.member.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +35,8 @@ public class NaverController {
 
     private final NaverService naverService;
     private final Environment environment;
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
 
     @Value("${oauth.naver.client-id}")
     private String naverClientId;
@@ -59,18 +64,39 @@ public class NaverController {
 
             log.info("네이버 로그인 성공: username={}", loginResponse.getUsername());
 
-            // JWT 토큰을 보안 강화된 쿠키에 저장 (Bearer 접두사 제거)
+            // Access Token과 Refresh Token을 쿠키에 저장
             boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
 
-            ResponseCookie cookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, token.substring(7))
+            // Access Token 쿠키
+            String accessTokenValue = token.startsWith(JwtUtil.BEARER_PREFIX) 
+                ? token.substring(JwtUtil.BEARER_PREFIX.length()) 
+                : token;
+            
+            ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
                     .path("/")
                     .httpOnly(true) // XSS 공격 방지
                     .secure(isProduction) // 프로덕션에서만 HTTPS 필수
                     .sameSite("Strict") // CSRF 공격 방지
                     .maxAge(Duration.ofHours(1)) // 1시간 유효
                     .build();
+            
+            // Refresh Token 쿠키
+            String refreshToken = refreshTokenService.findByUserId(userRepository.findByUsername(loginResponse.getUsername())
+                    .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
+                    .getId())
+                .orElseThrow(() -> new RuntimeException("Refresh Token을 찾을 수 없습니다."))
+                .getToken();
+            
+            ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                    .path("/")
+                    .httpOnly(true) // XSS 공격 방지
+                    .secure(isProduction) // 프로덕션에서만 HTTPS 필수
+                    .sameSite("Strict") // CSRF 공격 방지
+                    .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
+                    .build();
 
-            response.addHeader("Set-Cookie", cookie.toString());
+            response.addHeader("Set-Cookie", accessTokenCookie.toString());
+            response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
             // 프론트엔드 메인 페이지로 리다이렉트
             response.sendRedirect(frontendUrl + "/");

--- a/backend/src/main/java/com/phonebid/app/member/controller/NaverController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/NaverController.java
@@ -1,15 +1,11 @@
 package com.phonebid.app.member.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.phonebid.app.common.dto.ApiResponse;
-import com.phonebid.app.common.Constants;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.NaverErrorCode;
-import com.phonebid.app.jwt.JwtUtil;
-import com.phonebid.app.auth.service.RefreshTokenService;
+import com.phonebid.app.common.util.CookieUtil;
 import com.phonebid.app.member.dto.response.LoginResponseDto;
 import com.phonebid.app.member.service.NaverService;
-import com.phonebid.app.member.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
-import java.util.Arrays;
 
 /**
  * 네이버 OAuth2 인증 컨트롤러
@@ -35,8 +30,6 @@ public class NaverController {
 
     private final NaverService naverService;
     private final Environment environment;
-    private final RefreshTokenService refreshTokenService;
-    private final UserRepository userRepository;
 
     @Value("${oauth.naver.client-id}")
     private String naverClientId;
@@ -65,35 +58,15 @@ public class NaverController {
             log.info("네이버 로그인 성공: username={}", loginResponse.getUsername());
 
             // Access Token과 Refresh Token을 쿠키에 저장
-            boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
+            boolean isProduction = CookieUtil.isProduction(environment);
 
-            // Access Token 쿠키
-            String accessTokenValue = token.startsWith(JwtUtil.BEARER_PREFIX) 
-                ? token.substring(JwtUtil.BEARER_PREFIX.length()) 
-                : token;
+            // Access Token 쿠키 생성
+            ResponseCookie accessTokenCookie = CookieUtil.createAccessTokenCookie(
+                token, isProduction, Duration.ofHours(1));
             
-            ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
-                    .path("/")
-                    .httpOnly(true) // XSS 공격 방지
-                    .secure(isProduction) // 프로덕션에서만 HTTPS 필수
-                    .sameSite("Strict") // CSRF 공격 방지
-                    .maxAge(Duration.ofHours(1)) // 1시간 유효
-                    .build();
-            
-            // Refresh Token 쿠키
-            String refreshToken = refreshTokenService.findByUserId(userRepository.findByUsername(loginResponse.getUsername())
-                    .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
-                    .getId())
-                .orElseThrow(() -> new RuntimeException("Refresh Token을 찾을 수 없습니다."))
-                .getToken();
-            
-            ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
-                    .path("/")
-                    .httpOnly(true) // XSS 공격 방지
-                    .secure(isProduction) // 프로덕션에서만 HTTPS 필수
-                    .sameSite("Strict") // CSRF 공격 방지
-                    .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
-                    .build();
+            // Refresh Token 쿠키 생성 (DTO에서 직접 가져오기 - 동시성 문제 해결)
+            ResponseCookie refreshTokenCookie = CookieUtil.createRefreshTokenCookie(
+                loginResponse.getRefreshToken(), isProduction);
 
             response.addHeader("Set-Cookie", accessTokenCookie.toString());
             response.addHeader("Set-Cookie", refreshTokenCookie.toString());

--- a/backend/src/main/java/com/phonebid/app/member/controller/UserController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/UserController.java
@@ -9,14 +9,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.phonebid.app.common.dto.ApiResponse;
 import com.phonebid.app.common.Constants;
-import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.common.util.CookieUtil;
 import com.phonebid.app.member.dto.request.SignupRequestDto;
 import com.phonebid.app.member.dto.request.LoginRequestDto;
 import com.phonebid.app.member.dto.request.PasswordChangeRequestDto;
 import com.phonebid.app.member.dto.response.LoginResponseDto;
 import com.phonebid.app.member.service.UserService;
-import com.phonebid.app.auth.service.RefreshTokenService;
-import com.phonebid.app.member.repository.UserRepository;
 
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,8 +26,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,8 +34,6 @@ public class UserController {
 
     private final UserService userService;
     private final Environment environment;
-    private final RefreshTokenService refreshTokenService;
-    private final UserRepository userRepository;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupRequestDto requestDto) {
@@ -52,43 +46,21 @@ public class UserController {
     public ResponseEntity<ApiResponse<LoginResponseDto>> login(@Valid @RequestBody LoginRequestDto requestDto) {
         LoginResponseDto responseDto = userService.login(requestDto);
         
-        // Access Token을 쿠키에 저장
-        String accessToken = responseDto.getAccessToken();
-        boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
-        
-        // Bearer 접두사 제거하여 쿠키에 저장
-        String accessTokenValue = accessToken.startsWith(JwtUtil.BEARER_PREFIX) 
-            ? accessToken.substring(JwtUtil.BEARER_PREFIX.length()) 
-            : accessToken;
+        // 쿠키 생성
+        boolean isProduction = CookieUtil.isProduction(environment);
         
         // keepLoggedIn 값에 따라 Access Token 쿠키 만료 시간 설정
         Duration accessTokenCookieMaxAge = Boolean.TRUE.equals(requestDto.getKeepLoggedIn())
             ? Constants.Jwt.KEEP_LOGGED_IN_EXPIRY // 30일 유효
             : Constants.Jwt.DEFAULT_EXPIRY; // 1시간 유효
         
-        ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
-                .path("/")
-                .httpOnly(true) // XSS 공격 방지
-                .secure(isProduction) // 프로덕션에서만 HTTPS 필수
-                .sameSite("Strict") // CSRF 공격 방지
-                .maxAge(accessTokenCookieMaxAge)
-                .build();
+        // Access Token 쿠키 생성
+        ResponseCookie accessTokenCookie = CookieUtil.createAccessTokenCookie(
+            responseDto.getAccessToken(), isProduction, accessTokenCookieMaxAge);
 
-        // Refresh Token을 쿠키에 저장 (UserService에서 이미 생성됨)
-        String refreshToken = refreshTokenService.findByUserId(
-            userRepository.findByUsername(responseDto.getUsername())
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
-                .getId()
-        ).orElseThrow(() -> new RuntimeException("Refresh Token을 찾을 수 없습니다."))
-            .getToken();
-        
-        ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
-                .path("/")
-                .httpOnly(true) // XSS 공격 방지
-                .secure(isProduction) // 프로덕션에서만 HTTPS 필수
-                .sameSite("Strict") // CSRF 공격 방지
-                .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
-                .build();
+        // Refresh Token 쿠키 생성 (DTO에서 직접 가져오기 - 동시성 문제 해결)
+        ResponseCookie refreshTokenCookie = CookieUtil.createRefreshTokenCookie(
+            responseDto.getRefreshToken(), isProduction);
         
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessTokenCookie.toString())
@@ -99,31 +71,15 @@ public class UserController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout() {
         String username = getCurrentUsername();
-        UUID userId = userRepository.findByUsername(username)
-            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
-            .getId();
         
-        // Refresh Token 삭제
-        refreshTokenService.deleteByUserId(userId);
+        // Refresh Token 삭제 (서비스 레이어에서 처리)
+        userService.logout(username);
         
         // 쿠키 삭제를 위한 빈 쿠키 설정
-        boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
+        boolean isProduction = CookieUtil.isProduction(environment);
         
-        ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, "")
-                .path("/")
-                .httpOnly(true)
-                .secure(isProduction)
-                .sameSite("Strict")
-                .maxAge(Duration.ZERO)
-                .build();
-        
-        ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, "")
-                .path("/")
-                .httpOnly(true)
-                .secure(isProduction)
-                .sameSite("Strict")
-                .maxAge(Duration.ZERO)
-                .build();
+        ResponseCookie accessTokenCookie = CookieUtil.createAccessTokenDeleteCookie(isProduction);
+        ResponseCookie refreshTokenCookie = CookieUtil.createRefreshTokenDeleteCookie(isProduction);
         
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessTokenCookie.toString())
@@ -134,13 +90,8 @@ public class UserController {
     @DeleteMapping("/profile")
     public ResponseEntity<ApiResponse<Void>> deleteProfile() {
         String username = getCurrentUsername();
-        UUID userId = userRepository.findByUsername(username)
-            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
-            .getId();
         
-        // Refresh Token 삭제
-        refreshTokenService.deleteByUserId(userId);
-        
+        // 회원 탈퇴 처리 (서비스 레이어에서 RefreshToken 삭제 포함)
         userService.deleteProfile(username);
         
         return ResponseEntity.ok()

--- a/backend/src/main/java/com/phonebid/app/member/controller/UserController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/UserController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.phonebid.app.common.dto.ApiResponse;
 import com.phonebid.app.common.Constants;
 import com.phonebid.app.common.util.CookieUtil;
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.member.dto.request.SignupRequestDto;
 import com.phonebid.app.member.dto.request.LoginRequestDto;
 import com.phonebid.app.member.dto.request.PasswordChangeRequestDto;
@@ -113,7 +115,7 @@ public class UserController {
     private String getCurrentUsername() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
-            throw new RuntimeException("인증되지 않은 사용자입니다.");
+            throw new CustomException(CommonErrorCode.AUTHENTICATION_ERROR);
         }
         return authentication.getName();
     }

--- a/backend/src/main/java/com/phonebid/app/member/controller/UserController.java
+++ b/backend/src/main/java/com/phonebid/app/member/controller/UserController.java
@@ -15,6 +15,8 @@ import com.phonebid.app.member.dto.request.LoginRequestDto;
 import com.phonebid.app.member.dto.request.PasswordChangeRequestDto;
 import com.phonebid.app.member.dto.response.LoginResponseDto;
 import com.phonebid.app.member.service.UserService;
+import com.phonebid.app.auth.service.RefreshTokenService;
+import com.phonebid.app.member.repository.UserRepository;
 
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,6 +38,8 @@ public class UserController {
 
     private final UserService userService;
     private final Environment environment;
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupRequestDto requestDto) {
@@ -47,36 +52,95 @@ public class UserController {
     public ResponseEntity<ApiResponse<LoginResponseDto>> login(@Valid @RequestBody LoginRequestDto requestDto) {
         LoginResponseDto responseDto = userService.login(requestDto);
         
-        // JWT 토큰을 쿠키에 저장
-        String token = responseDto.getAccessToken();
+        // Access Token을 쿠키에 저장
+        String accessToken = responseDto.getAccessToken();
         boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
         
         // Bearer 접두사 제거하여 쿠키에 저장
-        String tokenValue = token.startsWith(JwtUtil.BEARER_PREFIX) 
-            ? token.substring(JwtUtil.BEARER_PREFIX.length()) 
-            : token;
+        String accessTokenValue = accessToken.startsWith(JwtUtil.BEARER_PREFIX) 
+            ? accessToken.substring(JwtUtil.BEARER_PREFIX.length()) 
+            : accessToken;
         
-        // keepLoggedIn 값에 따라 쿠키 만료 시간 설정 (토큰 만료 시간과 동일하게)
-        Duration cookieMaxAge = Boolean.TRUE.equals(requestDto.getKeepLoggedIn())
+        // keepLoggedIn 값에 따라 Access Token 쿠키 만료 시간 설정
+        Duration accessTokenCookieMaxAge = Boolean.TRUE.equals(requestDto.getKeepLoggedIn())
             ? Constants.Jwt.KEEP_LOGGED_IN_EXPIRY // 30일 유효
             : Constants.Jwt.DEFAULT_EXPIRY; // 1시간 유효
         
-        ResponseCookie cookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, tokenValue)
+        ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, accessTokenValue)
                 .path("/")
                 .httpOnly(true) // XSS 공격 방지
                 .secure(isProduction) // 프로덕션에서만 HTTPS 필수
-                .sameSite("Lax") // CSRF 공격 방지
-                .maxAge(cookieMaxAge)
+                .sameSite("Strict") // CSRF 공격 방지
+                .maxAge(accessTokenCookieMaxAge)
+                .build();
+
+        // Refresh Token을 쿠키에 저장 (UserService에서 이미 생성됨)
+        String refreshToken = refreshTokenService.findByUserId(
+            userRepository.findByUsername(responseDto.getUsername())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
+                .getId()
+        ).orElseThrow(() -> new RuntimeException("Refresh Token을 찾을 수 없습니다."))
+            .getToken();
+        
+        ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .path("/")
+                .httpOnly(true) // XSS 공격 방지
+                .secure(isProduction) // 프로덕션에서만 HTTPS 필수
+                .sameSite("Strict") // CSRF 공격 방지
+                .maxAge(Constants.Jwt.REFRESH_TOKEN_EXPIRY) // 30일
                 .build();
         
         return ResponseEntity.ok()
-                .header("Set-Cookie", cookie.toString())
+                .header("Set-Cookie", accessTokenCookie.toString())
+                .header("Set-Cookie", refreshTokenCookie.toString())
                 .body(ApiResponse.success(HttpStatus.OK, "로그인이 성공적으로 완료되었습니다.", responseDto));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout() {
+        String username = getCurrentUsername();
+        UUID userId = userRepository.findByUsername(username)
+            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
+            .getId();
+        
+        // Refresh Token 삭제
+        refreshTokenService.deleteByUserId(userId);
+        
+        // 쿠키 삭제를 위한 빈 쿠키 설정
+        boolean isProduction = Arrays.asList(environment.getActiveProfiles()).contains("prod");
+        
+        ResponseCookie accessTokenCookie = ResponseCookie.from(JwtUtil.AUTHORIZATION_HEADER, "")
+                .path("/")
+                .httpOnly(true)
+                .secure(isProduction)
+                .sameSite("Strict")
+                .maxAge(Duration.ZERO)
+                .build();
+        
+        ResponseCookie refreshTokenCookie = ResponseCookie.from(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, "")
+                .path("/")
+                .httpOnly(true)
+                .secure(isProduction)
+                .sameSite("Strict")
+                .maxAge(Duration.ZERO)
+                .build();
+        
+        return ResponseEntity.ok()
+                .header("Set-Cookie", accessTokenCookie.toString())
+                .header("Set-Cookie", refreshTokenCookie.toString())
+                .body(ApiResponse.success(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다.", null));
     }
 
     @DeleteMapping("/profile")
     public ResponseEntity<ApiResponse<Void>> deleteProfile() {
         String username = getCurrentUsername();
+        UUID userId = userRepository.findByUsername(username)
+            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."))
+            .getId();
+        
+        // Refresh Token 삭제
+        refreshTokenService.deleteByUserId(userId);
+        
         userService.deleteProfile(username);
         
         return ResponseEntity.ok()

--- a/backend/src/main/java/com/phonebid/app/member/dto/response/LoginResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/member/dto/response/LoginResponseDto.java
@@ -1,5 +1,6 @@
 package com.phonebid.app.member.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,10 @@ import lombok.NoArgsConstructor;
 public class LoginResponseDto {
     
     private String accessToken;
+    
+    @JsonIgnore // JSON 직렬화 시 제외 (쿠키로만 전달)
+    private String refreshToken;
+    
     private String tokenType;
     private String username;
     private String nickname;
@@ -24,6 +29,17 @@ public class LoginResponseDto {
     public static LoginResponseDto of(String accessToken, String username, String nickname, String role) {
         return LoginResponseDto.builder()
                 .accessToken(accessToken)
+                .tokenType("Bearer")
+                .username(username)
+                .nickname(nickname)
+                .role(role)
+                .build();
+    }
+    
+    public static LoginResponseDto of(String accessToken, String refreshToken, String username, String nickname, String role) {
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .tokenType("Bearer")
                 .username(username)
                 .nickname(nickname)

--- a/backend/src/main/java/com/phonebid/app/member/service/KakaoService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/KakaoService.java
@@ -102,7 +102,7 @@ public class KakaoService {
                 kakaoUser = sameEmailUser;
                 kakaoUser.updateProvider(Provider.KAKAO);
                 kakaoUser.updateProviderId(providerId);
-                log.info("기존 사용자에 카카오 연동: username={}", kakaoUser.getUsername());
+                log.info("기존 사용자에 카카오 연동 완료: username={}", kakaoUser.getUsername());
             } else {
                 // 신규 회원가입 - 카카오 이메일을 그대로 username으로 사용
                 String password = UUID.randomUUID().toString();
@@ -253,7 +253,7 @@ public class KakaoService {
                 ? kakaoAccount.get("name").asText() 
                 : nickname;
             
-            log.info("카카오 사용자 정보 조회 성공: id={}", id);
+            log.debug("카카오 사용자 정보 조회 성공: id={}", id);
             return KakaoUserInfoDto.of(id, nickname, email, name, phone);
         } catch (JsonProcessingException e) {
             log.error("카카오 사용자 정보 응답 파싱 실패", e);

--- a/backend/src/main/java/com/phonebid/app/member/service/KakaoService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/KakaoService.java
@@ -68,12 +68,13 @@ public class KakaoService {
             
             // 4. Refresh Token 생성 및 저장
             refreshTokenService.deleteByUserId(kakaoUser.getId());
-            refreshTokenService.createRefreshToken(kakaoUser.getId());
+            String refreshToken = refreshTokenService.createRefreshToken(kakaoUser.getId());
             
             // 5. JWT Access Token 생성 및 반환
             String accessToken = jwtUtil.createToken(kakaoUser.getUsername(), kakaoUser.getRole(), false);
             
-            return LoginResponseDto.of(accessToken, kakaoUser.getUsername(), kakaoUser.getNickname(), kakaoUser.getRole().name());
+            // 6. DTO에 RefreshToken 포함하여 반환
+            return LoginResponseDto.of(accessToken, refreshToken, kakaoUser.getUsername(), kakaoUser.getNickname(), kakaoUser.getRole().name());
         } catch (Exception e) {
             log.error("카카오 로그인 처리 중 예상치 못한 오류 발생", e);
             throw new CustomException(KakaoErrorCode.KAKAO_LOGIN_PROCESSING_FAILED);

--- a/backend/src/main/java/com/phonebid/app/member/service/KakaoService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/KakaoService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.KakaoErrorCode;
 import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.auth.service.RefreshTokenService;
 import com.phonebid.app.member.domain.Provider;
 import com.phonebid.app.member.domain.Role;
 import com.phonebid.app.member.domain.User;
@@ -39,6 +40,7 @@ public class KakaoService {
     private final UserRepository userRepository;
     private final WebClient webClient;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
     
     @Value("${oauth.kakao.client-id}")
     private String clientId;
@@ -55,19 +57,23 @@ public class KakaoService {
     @Transactional
     public LoginResponseDto kakaoLogin(String code) throws CustomException {
         try {
-            // 1. 인가 코드로 액세스 토큰 요청
-            String accessToken = getToken(code);
+            // 1. 인가 코드로 카카오 액세스 토큰 요청
+            String kakaoAccessToken = getToken(code);
             
-            // 2. 액세스 토큰으로 카카오 사용자 정보 가져오기
-            KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+            // 2. 카카오 액세스 토큰으로 카카오 사용자 정보 가져오기
+            KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(kakaoAccessToken);
             
             // 3. 필요시 회원가입 처리
             User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
             
-            // 4. JWT 토큰 생성 및 반환
-            String token = jwtUtil.createToken(kakaoUser.getUsername(), kakaoUser.getRole());
+            // 4. Refresh Token 생성 및 저장
+            refreshTokenService.deleteByUserId(kakaoUser.getId());
+            refreshTokenService.createRefreshToken(kakaoUser.getId());
             
-            return LoginResponseDto.of(token, kakaoUser.getUsername(), kakaoUser.getNickname(), kakaoUser.getRole().name());
+            // 5. JWT Access Token 생성 및 반환
+            String accessToken = jwtUtil.createToken(kakaoUser.getUsername(), kakaoUser.getRole(), false);
+            
+            return LoginResponseDto.of(accessToken, kakaoUser.getUsername(), kakaoUser.getNickname(), kakaoUser.getRole().name());
         } catch (Exception e) {
             log.error("카카오 로그인 처리 중 예상치 못한 오류 발생", e);
             throw new CustomException(KakaoErrorCode.KAKAO_LOGIN_PROCESSING_FAILED);

--- a/backend/src/main/java/com/phonebid/app/member/service/NaverService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/NaverService.java
@@ -7,6 +7,7 @@ import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.NaverErrorCode;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.auth.service.RefreshTokenService;
 import com.phonebid.app.member.domain.Provider;
 import com.phonebid.app.member.domain.Role;
 import com.phonebid.app.member.domain.User;
@@ -41,6 +42,7 @@ public class NaverService {
     private final UserRepository userRepository;
     private final WebClient webClient;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
     
     @Value("${oauth.naver.client-id}")
     private String clientId;
@@ -60,19 +62,23 @@ public class NaverService {
     @Transactional
     public LoginResponseDto naverLogin(String code) throws CustomException {
         try {
-            // 1. 인가 코드로 액세스 토큰 요청
-            String accessToken = getToken(code);
+            // 1. 인가 코드로 네이버 액세스 토큰 요청
+            String naverAccessToken = getToken(code);
             
-            // 2. 액세스 토큰으로 네이버 사용자 정보 가져오기
-            NaverUserInfoDto naverUserInfo = getNaverUserInfo(accessToken);
+            // 2. 네이버 액세스 토큰으로 네이버 사용자 정보 가져오기
+            NaverUserInfoDto naverUserInfo = getNaverUserInfo(naverAccessToken);
             
             // 3. 필요시 회원가입 처리
             User naverUser = registerNaverUserIfNeeded(naverUserInfo);
             
-            // 4. JWT 토큰 생성 및 반환
-            String token = jwtUtil.createToken(naverUser.getUsername(), naverUser.getRole());
+            // 4. Refresh Token 생성 및 저장
+            refreshTokenService.deleteByUserId(naverUser.getId());
+            refreshTokenService.createRefreshToken(naverUser.getId());
             
-            return LoginResponseDto.of(token, naverUser.getUsername(), naverUser.getNickname(), naverUser.getRole().name());
+            // 5. JWT Access Token 생성 및 반환
+            String accessToken = jwtUtil.createToken(naverUser.getUsername(), naverUser.getRole(), false);
+            
+            return LoginResponseDto.of(accessToken, naverUser.getUsername(), naverUser.getNickname(), naverUser.getRole().name());
         } catch (Exception e) {
             log.error("네이버 로그인 처리 중 예상치 못한 오류 발생", e);
             throw new CustomException(NaverErrorCode.NAVER_LOGIN_PROCESSING_FAILED);

--- a/backend/src/main/java/com/phonebid/app/member/service/NaverService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/NaverService.java
@@ -107,7 +107,7 @@ public class NaverService {
                 naverUser = sameEmailUser;
                 naverUser.updateProvider(Provider.NAVER);
                 naverUser.updateProviderId(providerId);
-                log.info("기존 사용자에 네이버 연동: username={}", naverUser.getUsername());
+                log.info("기존 사용자에 네이버 연동 완료: username={}", naverUser.getUsername());
             } else {
                 // 신규 회원가입 - 네이버 이메일을 그대로 username으로 사용
                 String password = UUID.randomUUID().toString();
@@ -261,7 +261,7 @@ public class NaverService {
             String phone = formatPhoneNumber(responseNode.get("mobile").asText());
             String nickname = responseNode.has("nickname") ? responseNode.get("nickname").asText() : name;
             
-            log.info("네이버 사용자 정보 조회 성공: id={}", id);
+            log.debug("네이버 사용자 정보 조회 성공: id={}", id);
             return NaverUserInfoDto.of(id, email, name, phone, nickname);
         } catch (JsonProcessingException e) {
             log.error("네이버 사용자 정보 응답 파싱 실패", e);

--- a/backend/src/main/java/com/phonebid/app/member/service/NaverService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/NaverService.java
@@ -73,12 +73,13 @@ public class NaverService {
             
             // 4. Refresh Token 생성 및 저장
             refreshTokenService.deleteByUserId(naverUser.getId());
-            refreshTokenService.createRefreshToken(naverUser.getId());
+            String refreshToken = refreshTokenService.createRefreshToken(naverUser.getId());
             
             // 5. JWT Access Token 생성 및 반환
             String accessToken = jwtUtil.createToken(naverUser.getUsername(), naverUser.getRole(), false);
             
-            return LoginResponseDto.of(accessToken, naverUser.getUsername(), naverUser.getNickname(), naverUser.getRole().name());
+            // 6. DTO에 RefreshToken 포함하여 반환
+            return LoginResponseDto.of(accessToken, refreshToken, naverUser.getUsername(), naverUser.getNickname(), naverUser.getRole().name());
         } catch (Exception e) {
             log.error("네이버 로그인 처리 중 예상치 못한 오류 발생", e);
             throw new CustomException(NaverErrorCode.NAVER_LOGIN_PROCESSING_FAILED);

--- a/backend/src/main/java/com/phonebid/app/member/service/UserService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/UserService.java
@@ -151,4 +151,17 @@ public class UserService {
             .filter(user -> !user.isDeleted())
             .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
     }
+
+    /**
+     * 사용자명으로 활성 사용자 조회
+     * 삭제되지 않은 사용자만 조회하며, 없으면 예외 발생
+     * @param username 사용자명
+     * @return 활성 사용자 엔티티
+     * @throws CustomException 사용자를 찾을 수 없을 경우
+     */
+    public User findByUsername(String username) {
+        return userRepository.findByUsername(username)
+            .filter(user -> !user.isDeleted())
+            .orElseThrow(() -> new CustomException(CommonErrorCode.USER_NOT_FOUND));
+    }
 }   

--- a/backend/src/main/java/com/phonebid/app/member/service/UserService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/UserService.java
@@ -92,14 +92,15 @@ public class UserService {
 
         // 기존 Refresh Token 삭제 및 새로 생성
         refreshTokenService.deleteByUserId(user.getId());
-        refreshTokenService.createRefreshToken(user.getId());
+        String refreshToken = refreshTokenService.createRefreshToken(user.getId());
         
         // Access Token 생성 (keepLoggedIn 값에 따라 만료 시간 결정)
         String accessToken = jwtUtil.createToken(user.getUsername(), user.getRole(), keepLoggedIn);
         
-        // LoginResponseDto 생성 및 반환 (Refresh Token은 쿠키로만 전달되므로 응답에는 포함하지 않음)
+        // LoginResponseDto 생성 및 반환
         return LoginResponseDto.of(
-            accessToken, 
+            accessToken,
+            refreshToken, // 추가된 부분
             user.getUsername(), 
             user.getNickname(), 
             user.getRole().name()
@@ -132,11 +133,23 @@ public class UserService {
     }
 
     /**
+     * 로그아웃 처리 (RefreshToken 삭제)
+     */
+    @Transactional
+    public void logout(String username) {
+        User user = findByUsername(username);
+        refreshTokenService.deleteByUserId(user.getId());
+    }
+
+    /**
      * 회원 탈퇴 (소프트 삭제)
      */
     @Transactional
     public void deleteProfile(String username) {
         User user = loadActiveUser(username);
+
+        // RefreshToken 삭제
+        refreshTokenService.deleteByUserId(user.getId());
 
         // 소프트 삭제 (삭제한 사용자 정보 기록)
         user.softDelete(username);

--- a/backend/src/main/java/com/phonebid/app/member/service/UserService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/UserService.java
@@ -13,6 +13,7 @@ import com.phonebid.app.member.domain.User;
 import com.phonebid.app.member.domain.Role;
 import com.phonebid.app.member.repository.UserRepository;
 import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.auth.service.RefreshTokenService;
 
 import lombok.RequiredArgsConstructor;
 import java.util.Optional;
@@ -24,6 +25,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
 
     /**
      * 회원 가입
@@ -88,12 +90,16 @@ public class UserService {
             throw new CustomException(CommonErrorCode.INVALID_CREDENTIALS);
         }
 
-        // JWT 토큰 생성 (keepLoggedIn 값에 따라 만료 시간 결정)
-        String token = jwtUtil.createToken(user.getUsername(), user.getRole(), keepLoggedIn);
+        // 기존 Refresh Token 삭제 및 새로 생성
+        refreshTokenService.deleteByUserId(user.getId());
+        refreshTokenService.createRefreshToken(user.getId());
         
-        // LoginResponseDto 생성 및 반환
+        // Access Token 생성 (keepLoggedIn 값에 따라 만료 시간 결정)
+        String accessToken = jwtUtil.createToken(user.getUsername(), user.getRole(), keepLoggedIn);
+        
+        // LoginResponseDto 생성 및 반환 (Refresh Token은 쿠키로만 전달되므로 응답에는 포함하지 않음)
         return LoginResponseDto.of(
-            token, 
+            accessToken, 
             user.getUsername(), 
             user.getNickname(), 
             user.getRole().name()

--- a/backend/src/main/java/com/phonebid/app/member/service/UserService.java
+++ b/backend/src/main/java/com/phonebid/app/member/service/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
     /**
      * 로그인
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public LoginResponseDto login(LoginRequestDto requestDto) {
         String username = requestDto.getUsername();
         String password = requestDto.getPassword();

--- a/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/phonebid/app/security/JwtAuthorizationFilter.java
@@ -50,7 +50,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         return path.equals("/api/v1/users/login")
             || path.equals("/api/v1/users/signup")
             || path.startsWith("/api/v1/auth/kakao")
-            || path.startsWith("/api/v1/auth/naver");
+            || path.startsWith("/api/v1/auth/naver")
+            || path.equals("/api/v1/auth/refresh");
             // || path.startsWith("/api/v1/payments/portone");
     }
 

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -18,35 +18,35 @@ spring:
         format_sql: true
     show-sql: false
 
-# JWT 테스트용 시크릿 키 (환경 변수가 없을 경우)
+# JWT 시크릿 키 (환경 변수 필수)
 jwt:
   secret:
-    key: ${JWT_SECRET_KEY:dGVzdFNlY3JldEtleUZvckp3dFV0aWxUZXN0aW5nUHVycG9zZXNPbmx5MTIzNDU2Nzg5}
+    key: ${JWT_SECRET_KEY}
 
-# OAuth 테스트용 더미 값 (환경 변수가 없을 경우)
+# OAuth 설정 (환경 변수 필수)
 oauth:
   kakao:
-    client-id: ${KAKAO_CLIENT_ID:test-kakao-client-id}
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/api/v1/auth/kakao/callback}
+    client-id: ${KAKAO_CLIENT_ID}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
   naver:
-    client-id: ${NAVER_CLIENT_ID:test-naver-client-id}
-    client-secret: ${NAVER_CLIENT_SECRET:test-naver-client-secret}
-    redirect-uri: ${NAVER_REDIRECT_URI:http://localhost:8080/api/v1/auth/naver/callback}
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+    redirect-uri: ${NAVER_REDIRECT_URI}
 
-# AWS 테스트용 더미 값 (환경 변수가 없을 경우)
+# AWS 설정 (환경 변수 필수)
 cloud:
   aws:
     credentials:
-      access-key: ${AWS_ACCESS_KEY:test-access-key}
-      secret-key: ${AWS_SECRET_KEY:test-secret-key}
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
     s3:
-      bucket: ${AWS_S3_BUCKET:test-bucket}
+      bucket: ${AWS_S3_BUCKET}
 
-# PortOne 테스트용 더미 값 (환경 변수가 없을 경우)
+# PortOne 설정 (환경 변수 필수)
 portone:
   v2:
-    store-id: ${PORTONE_STORE_ID:test-store-id}
-    api-secret: ${PORTONE_API_SECRET:test-api-secret}
-    channel-key: ${PORTONE_CHANNEL_KEY:test-channel-key}
-    webhook-secret: ${PORTONE_WEBHOOK_SECRET:test-webhook-secret}
+    store-id: ${PORTONE_STORE_ID}
+    api-secret: ${PORTONE_API_SECRET}
+    channel-key: ${PORTONE_CHANNEL_KEY}
+    webhook-secret: ${PORTONE_WEBHOOK_SECRET}
 

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,0 +1,52 @@
+# Test 환경 설정
+# 테스트 실행 시 이 설정이 우선 적용됩니다
+# 환경 변수를 무시하고 테스트용 설정을 강제로 사용합니다
+
+spring:
+  datasource:
+    url: ${TEST_DATABASE_URL:jdbc:postgresql://localhost:5433/phonebid}
+    username: ${TEST_DATABASE_USER:phonebid}
+    password: ${TEST_DATABASE_PASSWORD:phonebid}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    show-sql: false
+
+# JWT 테스트용 시크릿 키 (환경 변수가 없을 경우)
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY:dGVzdFNlY3JldEtleUZvckp3dFV0aWxUZXN0aW5nUHVycG9zZXNPbmx5MTIzNDU2Nzg5}
+
+# OAuth 테스트용 더미 값 (환경 변수가 없을 경우)
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID:test-kakao-client-id}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/api/v1/auth/kakao/callback}
+  naver:
+    client-id: ${NAVER_CLIENT_ID:test-naver-client-id}
+    client-secret: ${NAVER_CLIENT_SECRET:test-naver-client-secret}
+    redirect-uri: ${NAVER_REDIRECT_URI:http://localhost:8080/api/v1/auth/naver/callback}
+
+# AWS 테스트용 더미 값 (환경 변수가 없을 경우)
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY:test-access-key}
+      secret-key: ${AWS_SECRET_KEY:test-secret-key}
+    s3:
+      bucket: ${AWS_S3_BUCKET:test-bucket}
+
+# PortOne 테스트용 더미 값 (환경 변수가 없을 경우)
+portone:
+  v2:
+    store-id: ${PORTONE_STORE_ID:test-store-id}
+    api-secret: ${PORTONE_API_SECRET:test-api-secret}
+    channel-key: ${PORTONE_CHANNEL_KEY:test-channel-key}
+    webhook-secret: ${PORTONE_WEBHOOK_SECRET:test-webhook-secret}
+

--- a/backend/src/test/java/com/phonebid/app/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/phonebid/app/auth/controller/AuthControllerTest.java
@@ -1,0 +1,212 @@
+package com.phonebid.app.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phonebid.app.auth.service.RefreshTokenService;
+import com.phonebid.app.common.Constants;
+import com.phonebid.app.common.exception.GlobalExceptionHandler;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.member.domain.Role;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthController 테스트")
+class AuthControllerTest {
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private Environment environment;
+
+    @InjectMocks
+    private AuthController authController;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private User testUser;
+    private String testRefreshToken;
+    private String testAccessToken;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(authController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+
+        testUser = User.builder()
+                .username("testuser")
+                .email("test@example.com")
+                .name("테스트 사용자")
+                .nickname("테스트닉네임")
+                .role(Role.CONSUMER)
+                .build();
+
+        testRefreshToken = "test.refresh.token";
+        testAccessToken = "Bearer test.access.token";
+
+        // lenient()를 사용하여 일부 테스트에서 사용되지 않아도 되는 stubbing 허용
+        lenient().when(environment.getActiveProfiles()).thenReturn(new String[]{"test"});
+    }
+
+    @Test
+    @DisplayName("유효한 Refresh Token으로 Access Token 갱신 성공")
+    void refresh_WithValidRefreshToken_ShouldReturnNewAccessToken() throws Exception {
+        // given
+        Claims claims = Jwts.claims().setSubject("testuser");
+        
+        when(jwtUtil.getRefreshTokenFromCookie(any())).thenReturn(testRefreshToken);
+        when(refreshTokenService.validateToken(testRefreshToken)).thenReturn(true);
+        when(jwtUtil.getUserInfoFromToken(testRefreshToken)).thenReturn(claims);
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(testUser));
+        when(jwtUtil.createToken(testUser.getUsername(), testUser.getRole(), false))
+                .thenReturn(testAccessToken);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                testRefreshToken
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("토큰이 성공적으로 갱신되었습니다."))
+                .andExpect(jsonPath("$.data").value(testAccessToken))
+                .andExpect(header().exists("Set-Cookie"));
+
+        verify(jwtUtil).getRefreshTokenFromCookie(any());
+        verify(refreshTokenService).validateToken(testRefreshToken);
+        verify(jwtUtil).getUserInfoFromToken(testRefreshToken);
+        verify(userRepository).findByUsername("testuser");
+        verify(jwtUtil).createToken(testUser.getUsername(), testUser.getRole(), false);
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 없는 경우 예외 발생")
+    void refresh_WithoutRefreshToken_ShouldThrowException() throws Exception {
+        // given
+        when(jwtUtil.getRefreshTokenFromCookie(any())).thenReturn(null);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
+
+        verify(jwtUtil).getRefreshTokenFromCookie(any());
+        verify(refreshTokenService, never()).validateToken(anyString());
+        verify(jwtUtil, never()).getUserInfoFromToken(anyString());
+        verify(userRepository, never()).findByUsername(anyString());
+        verify(jwtUtil, never()).createToken(anyString(), any(Role.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 Refresh Token 처리")
+    void refresh_WithInvalidRefreshToken_ShouldThrowException() throws Exception {
+        // given
+        when(jwtUtil.getRefreshTokenFromCookie(any())).thenReturn(testRefreshToken);
+        when(refreshTokenService.validateToken(testRefreshToken)).thenReturn(false);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                testRefreshToken
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_REFRESH_TOKEN.getMessage()));
+
+        verify(jwtUtil).getRefreshTokenFromCookie(any());
+        verify(refreshTokenService).validateToken(testRefreshToken);
+        verify(jwtUtil, never()).getUserInfoFromToken(anyString());
+        verify(userRepository, never()).findByUsername(anyString());
+        verify(jwtUtil, never()).createToken(anyString(), any(Role.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("만료된 Refresh Token 처리")
+    void refresh_WithExpiredRefreshToken_ShouldThrowException() throws Exception {
+        // given
+        when(jwtUtil.getRefreshTokenFromCookie(any())).thenReturn(testRefreshToken);
+        when(refreshTokenService.validateToken(testRefreshToken)).thenReturn(false);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                testRefreshToken
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_REFRESH_TOKEN.getMessage()));
+
+        verify(jwtUtil).getRefreshTokenFromCookie(any());
+        verify(refreshTokenService).validateToken(testRefreshToken);
+        verify(jwtUtil, never()).getUserInfoFromToken(anyString());
+        verify(userRepository, never()).findByUsername(anyString());
+        verify(jwtUtil, never()).createToken(anyString(), any(Role.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("Refresh Token에 해당하는 사용자가 없는 경우 예외 발생")
+    void refresh_WithNonExistentUser_ShouldThrowException() throws Exception {
+        // given
+        Claims claims = Jwts.claims().setSubject("nonexistent");
+        
+        when(jwtUtil.getRefreshTokenFromCookie(any())).thenReturn(testRefreshToken);
+        when(refreshTokenService.validateToken(testRefreshToken)).thenReturn(true);
+        when(jwtUtil.getUserInfoFromToken(testRefreshToken)).thenReturn(claims);
+        when(userRepository.findByUsername("nonexistent")).thenReturn(Optional.empty());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                testRefreshToken
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.USER_NOT_FOUND.getMessage()));
+
+        verify(jwtUtil).getRefreshTokenFromCookie(any());
+        verify(refreshTokenService).validateToken(testRefreshToken);
+        verify(jwtUtil).getUserInfoFromToken(testRefreshToken);
+        verify(userRepository).findByUsername("nonexistent");
+        verify(jwtUtil, never()).createToken(anyString(), any(Role.class), anyBoolean());
+    }
+}
+

--- a/backend/src/test/java/com/phonebid/app/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/phonebid/app/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.phonebid.app.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phonebid.app.auth.domain.RefreshToken;
 import com.phonebid.app.auth.service.RefreshTokenService;
 import com.phonebid.app.common.Constants;
 import com.phonebid.app.common.exception.GlobalExceptionHandler;
@@ -8,9 +9,12 @@ import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.jwt.JwtUtil;
 import com.phonebid.app.member.domain.Role;
 import com.phonebid.app.member.domain.User;
-import com.phonebid.app.member.repository.UserRepository;
+import com.phonebid.app.member.service.UserService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,8 +27,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -41,7 +43,7 @@ class AuthControllerTest {
     private RefreshTokenService refreshTokenService;
 
     @Mock
-    private UserRepository userRepository;
+    private UserService userService;
 
     @Mock
     private JwtUtil jwtUtil;
@@ -58,6 +60,8 @@ class AuthControllerTest {
     private User testUser;
     private String testRefreshToken;
     private String testAccessToken;
+    private String newRefreshToken;
+    private RefreshToken refreshTokenEntity;
 
     @BeforeEach
     void setUp() {
@@ -76,21 +80,32 @@ class AuthControllerTest {
 
         testRefreshToken = "test.refresh.token";
         testAccessToken = "Bearer test.access.token";
+        newRefreshToken = "new.refresh.token";
+        
+        refreshTokenEntity = RefreshToken.builder()
+                .user(testUser)
+                .token(testRefreshToken)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
 
         // lenient()를 사용하여 일부 테스트에서 사용되지 않아도 되는 stubbing 허용
         lenient().when(environment.getActiveProfiles()).thenReturn(new String[]{"test"});
     }
 
     @Test
-    @DisplayName("유효한 Refresh Token으로 Access Token 갱신 성공")
-    void refresh_WithValidRefreshToken_ShouldReturnNewAccessToken() throws Exception {
+    @DisplayName("유효한 Refresh Token으로 Access Token 갱신 및 Refresh Token 로테이션 성공")
+    void refresh_WithValidRefreshToken_ShouldReturnNewAccessTokenAndRotateRefreshToken() throws Exception {
         // given
         Claims claims = Jwts.claims().setSubject("testuser");
         
         when(jwtUtil.getRefreshTokenFromCookie(any())).thenReturn(testRefreshToken);
         when(refreshTokenService.validateToken(testRefreshToken)).thenReturn(true);
         when(jwtUtil.getUserInfoFromToken(testRefreshToken)).thenReturn(claims);
-        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(testUser));
+        when(userService.findByUsername("testuser")).thenReturn(testUser);
+        when(refreshTokenService.findByToken(testRefreshToken))
+                .thenReturn(Optional.of(refreshTokenEntity));
+        when(refreshTokenService.createRefreshToken(testUser.getId()))
+                .thenReturn(newRefreshToken);
         when(jwtUtil.createToken(testUser.getUsername(), testUser.getRole(), false))
                 .thenReturn(testAccessToken);
 
@@ -105,12 +120,19 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value("OK"))
                 .andExpect(jsonPath("$.message").value("토큰이 성공적으로 갱신되었습니다."))
                 .andExpect(jsonPath("$.data").value(testAccessToken))
-                .andExpect(header().exists("Set-Cookie"));
+                .andExpect(header().stringValues("Set-Cookie", 
+                        org.hamcrest.Matchers.hasItems(
+                                org.hamcrest.Matchers.containsString(JwtUtil.AUTHORIZATION_HEADER),
+                                org.hamcrest.Matchers.containsString(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME)
+                        )));
 
         verify(jwtUtil).getRefreshTokenFromCookie(any());
         verify(refreshTokenService).validateToken(testRefreshToken);
         verify(jwtUtil).getUserInfoFromToken(testRefreshToken);
-        verify(userRepository).findByUsername("testuser");
+        verify(userService).findByUsername("testuser");
+        verify(refreshTokenService).findByToken(testRefreshToken);
+        verify(refreshTokenService).deleteByUserId(testUser.getId());
+        verify(refreshTokenService).createRefreshToken(testUser.getId());
         verify(jwtUtil).createToken(testUser.getUsername(), testUser.getRole(), false);
     }
 
@@ -129,7 +151,7 @@ class AuthControllerTest {
         verify(jwtUtil).getRefreshTokenFromCookie(any());
         verify(refreshTokenService, never()).validateToken(anyString());
         verify(jwtUtil, never()).getUserInfoFromToken(anyString());
-        verify(userRepository, never()).findByUsername(anyString());
+        verify(userService, never()).findByUsername(anyString());
         verify(jwtUtil, never()).createToken(anyString(), any(Role.class), anyBoolean());
     }
 
@@ -153,7 +175,7 @@ class AuthControllerTest {
         verify(jwtUtil).getRefreshTokenFromCookie(any());
         verify(refreshTokenService).validateToken(testRefreshToken);
         verify(jwtUtil, never()).getUserInfoFromToken(anyString());
-        verify(userRepository, never()).findByUsername(anyString());
+        verify(userService, never()).findByUsername(anyString());
         verify(jwtUtil, never()).createToken(anyString(), any(Role.class), anyBoolean());
     }
 
@@ -177,7 +199,7 @@ class AuthControllerTest {
         verify(jwtUtil).getRefreshTokenFromCookie(any());
         verify(refreshTokenService).validateToken(testRefreshToken);
         verify(jwtUtil, never()).getUserInfoFromToken(anyString());
-        verify(userRepository, never()).findByUsername(anyString());
+        verify(userService, never()).findByUsername(anyString());
         verify(jwtUtil, never()).createToken(anyString(), any(Role.class), anyBoolean());
     }
 
@@ -190,7 +212,8 @@ class AuthControllerTest {
         when(jwtUtil.getRefreshTokenFromCookie(any())).thenReturn(testRefreshToken);
         when(refreshTokenService.validateToken(testRefreshToken)).thenReturn(true);
         when(jwtUtil.getUserInfoFromToken(testRefreshToken)).thenReturn(claims);
-        when(userRepository.findByUsername("nonexistent")).thenReturn(Optional.empty());
+        when(userService.findByUsername("nonexistent"))
+                .thenThrow(new com.phonebid.app.common.exception.CustomException(CommonErrorCode.USER_NOT_FOUND));
 
         // when & then
         mockMvc.perform(post("/api/v1/auth/refresh")
@@ -205,7 +228,7 @@ class AuthControllerTest {
         verify(jwtUtil).getRefreshTokenFromCookie(any());
         verify(refreshTokenService).validateToken(testRefreshToken);
         verify(jwtUtil).getUserInfoFromToken(testRefreshToken);
-        verify(userRepository).findByUsername("nonexistent");
+        verify(userService).findByUsername("nonexistent");
         verify(jwtUtil, never()).createToken(anyString(), any(Role.class), anyBoolean());
     }
 }

--- a/backend/src/test/java/com/phonebid/app/auth/integration/AuthFlowIntegrationTest.java
+++ b/backend/src/test/java/com/phonebid/app/auth/integration/AuthFlowIntegrationTest.java
@@ -98,12 +98,15 @@ class AuthFlowIntegrationTest {
 
     @Test
     @DisplayName("로그인 시 기존 RefreshToken 삭제 확인")
-    void login_ShouldDeleteExistingRefreshToken() {
+    void login_ShouldDeleteExistingRefreshToken() throws InterruptedException {
         // given - 기존 RefreshToken 생성
         String oldRefreshToken = refreshTokenService.createRefreshToken(testUser.getId());
         Optional<RefreshToken> oldTokenOpt = refreshTokenService.findByUserId(testUser.getId());
         assertThat(oldTokenOpt).isPresent();
         assertThat(oldTokenOpt.get().getToken()).isEqualTo(oldRefreshToken);
+
+        // JWT 토큰 생성 시 issuedAt 시간이 다르도록 약간의 지연 추가
+        Thread.sleep(100);
 
         // when - 로그인 (새로운 RefreshToken 생성)
         userService.login(loginRequest);
@@ -111,30 +114,52 @@ class AuthFlowIntegrationTest {
         // then - 기존 토큰이 삭제되고 새로운 토큰이 생성되었는지 확인
         Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
         assertThat(newRefreshTokenOpt).isPresent();
-        assertThat(newRefreshTokenOpt.get().getToken()).isNotEqualTo(oldRefreshToken);
+        String newRefreshToken = newRefreshTokenOpt.get().getToken();
+        assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken);
+        
+        // 기존 토큰이 더 이상 존재하지 않는지 확인
+        Optional<RefreshToken> deletedTokenOpt = refreshTokenService.findByToken(oldRefreshToken);
+        assertThat(deletedTokenOpt).isEmpty();
     }
 
     @Test
-    @DisplayName("RefreshToken으로 AccessToken 갱신 성공")
-    void refresh_WithValidRefreshToken_ShouldReturnNewAccessToken() throws Exception {
+    @DisplayName("RefreshToken으로 AccessToken 갱신 및 RefreshToken 로테이션 성공")
+    void refresh_WithValidRefreshToken_ShouldReturnNewAccessTokenAndRotateRefreshToken() throws Exception {
         // given - 로그인하여 RefreshToken 생성
-        LoginResponseDto loginResponse = userService.login(loginRequest);
+        userService.login(loginRequest);
         Optional<RefreshToken> refreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
         assertThat(refreshTokenOpt).isPresent();
-        String refreshToken = refreshTokenOpt.get().getToken();
+        String oldRefreshToken = refreshTokenOpt.get().getToken();
+        
+        // JWT 토큰 생성 시 issuedAt 시간이 다르도록 약간의 지연 추가
+        Thread.sleep(100);
 
-        // when & then - RefreshToken으로 AccessToken 갱신
+        // when - RefreshToken으로 AccessToken 갱신 (로테이션 발생)
         mockMvc.perform(post("/api/v1/auth/refresh")
                         .cookie(new jakarta.servlet.http.Cookie(
                                 Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
-                                refreshToken
+                                oldRefreshToken
                         ))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("OK"))
                 .andExpect(jsonPath("$.message").value("토큰이 성공적으로 갱신되었습니다."))
                 .andExpect(jsonPath("$.data").exists())
-                .andExpect(header().exists("Set-Cookie"));
+                .andExpect(header().stringValues("Set-Cookie", 
+                        org.hamcrest.Matchers.hasItems(
+                                org.hamcrest.Matchers.containsString(JwtUtil.AUTHORIZATION_HEADER),
+                                org.hamcrest.Matchers.containsString(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME)
+                        )));
+
+        // then - 새로운 RefreshToken이 생성되었고 기존 토큰과 다른지 확인
+        Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(newRefreshTokenOpt).isPresent();
+        String newRefreshToken = newRefreshTokenOpt.get().getToken();
+        assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken); // 새로운 토큰
+        
+        // 기존 RefreshToken이 무효화되었는지 확인 (findByToken으로 조회 시 없어야 함)
+        Optional<RefreshToken> oldTokenOpt = refreshTokenService.findByToken(oldRefreshToken);
+        assertThat(oldTokenOpt).isEmpty(); // 기존 토큰은 삭제됨
     }
 
     @Test
@@ -214,7 +239,7 @@ class AuthFlowIntegrationTest {
         assertThat(refreshTokenOpt).isPresent();
         String refreshToken = refreshTokenOpt.get().getToken();
 
-        // 2. RefreshToken으로 AccessToken 갱신
+        // 2. RefreshToken으로 AccessToken 갱신 (로테이션 발생)
         mockMvc.perform(post("/api/v1/auth/refresh")
                         .cookie(new jakarta.servlet.http.Cookie(
                                 Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
@@ -223,6 +248,15 @@ class AuthFlowIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").exists());
+        
+        // 기존 RefreshToken이 무효화되었는지 확인
+        Optional<RefreshToken> oldTokenOpt = refreshTokenService.findByToken(refreshToken);
+        assertThat(oldTokenOpt).isEmpty();
+        
+        // 새로운 RefreshToken 조회
+        Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(newRefreshTokenOpt).isPresent();
+        String newRefreshToken = newRefreshTokenOpt.get().getToken();
 
         // 3. SecurityContext 설정 (인증된 사용자로 설정)
         org.springframework.security.core.userdetails.UserDetails userDetails = 
@@ -246,7 +280,7 @@ class AuthFlowIntegrationTest {
                         ))
                         .cookie(new jakarta.servlet.http.Cookie(
                                 Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
-                                refreshToken
+                                newRefreshToken
                         ))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
@@ -259,7 +293,7 @@ class AuthFlowIntegrationTest {
         mockMvc.perform(post("/api/v1/auth/refresh")
                         .cookie(new jakarta.servlet.http.Cookie(
                                 Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
-                                refreshToken
+                                newRefreshToken
                         ))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized());

--- a/backend/src/test/java/com/phonebid/app/auth/integration/AuthFlowIntegrationTest.java
+++ b/backend/src/test/java/com/phonebid/app/auth/integration/AuthFlowIntegrationTest.java
@@ -103,33 +103,34 @@ class AuthFlowIntegrationTest {
         String oldRefreshToken = refreshTokenService.createRefreshToken(testUser.getId());
         Optional<RefreshToken> oldTokenOpt = refreshTokenService.findByUserId(testUser.getId());
         assertThat(oldTokenOpt).isPresent();
-        assertThat(oldTokenOpt.get().getToken()).isEqualTo(oldRefreshToken);
 
         // JWT 토큰 생성 시 issuedAt 시간이 다르도록 약간의 지연 추가
         Thread.sleep(100);
 
         // when - 로그인 (새로운 RefreshToken 생성)
-        userService.login(loginRequest);
+        LoginResponseDto loginResponse = userService.login(loginRequest);
+        String newRefreshToken = loginResponse.getRefreshToken();
 
         // then - 기존 토큰이 삭제되고 새로운 토큰이 생성되었는지 확인
-        Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
-        assertThat(newRefreshTokenOpt).isPresent();
-        String newRefreshToken = newRefreshTokenOpt.get().getToken();
+        assertThat(newRefreshToken).isNotNull();
         assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken);
         
         // 기존 토큰이 더 이상 존재하지 않는지 확인
         Optional<RefreshToken> deletedTokenOpt = refreshTokenService.findByToken(oldRefreshToken);
         assertThat(deletedTokenOpt).isEmpty();
+        
+        // 새로운 토큰이 DB에 저장되었는지 확인
+        Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(newRefreshTokenOpt).isPresent();
     }
 
     @Test
     @DisplayName("RefreshToken으로 AccessToken 갱신 및 RefreshToken 로테이션 성공")
     void refresh_WithValidRefreshToken_ShouldReturnNewAccessTokenAndRotateRefreshToken() throws Exception {
         // given - 로그인하여 RefreshToken 생성
-        userService.login(loginRequest);
-        Optional<RefreshToken> refreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
-        assertThat(refreshTokenOpt).isPresent();
-        String oldRefreshToken = refreshTokenOpt.get().getToken();
+        LoginResponseDto loginResponse = userService.login(loginRequest);
+        String oldRefreshToken = loginResponse.getRefreshToken();
+        assertThat(oldRefreshToken).isNotNull();
         
         // JWT 토큰 생성 시 issuedAt 시간이 다르도록 약간의 지연 추가
         Thread.sleep(100);
@@ -151,15 +152,13 @@ class AuthFlowIntegrationTest {
                                 org.hamcrest.Matchers.containsString(Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME)
                         )));
 
-        // then - 새로운 RefreshToken이 생성되었고 기존 토큰과 다른지 확인
-        Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
-        assertThat(newRefreshTokenOpt).isPresent();
-        String newRefreshToken = newRefreshTokenOpt.get().getToken();
-        assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken); // 새로운 토큰
-        
-        // 기존 RefreshToken이 무효화되었는지 확인 (findByToken으로 조회 시 없어야 함)
+        // then - 기존 RefreshToken이 무효화되었는지 확인 (findByToken으로 조회 시 없어야 함)
         Optional<RefreshToken> oldTokenOpt = refreshTokenService.findByToken(oldRefreshToken);
         assertThat(oldTokenOpt).isEmpty(); // 기존 토큰은 삭제됨
+        
+        // 새로운 RefreshToken이 생성되었는지 확인
+        Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(newRefreshTokenOpt).isPresent();
     }
 
     @Test
@@ -203,15 +202,11 @@ class AuthFlowIntegrationTest {
         org.springframework.security.core.context.SecurityContextHolder.getContext()
                 .setAuthentication(authentication);
 
-        // when - 로그아웃
+        // when - 로그아웃 (refreshToken 쿠키는 필요 없음 - getCurrentUsername()으로 사용자 식별)
         mockMvc.perform(post("/api/v1/users/logout")
                         .cookie(new jakarta.servlet.http.Cookie(
                                 JwtUtil.AUTHORIZATION_HEADER,
                                 accessToken
-                        ))
-                        .cookie(new jakarta.servlet.http.Cookie(
-                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
-                                refreshTokenOpt.get().getToken()
                         ))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -235,9 +230,8 @@ class AuthFlowIntegrationTest {
         assertThat(loginResponse.getAccessToken()).isNotNull();
 
         String accessToken = loginResponse.getAccessToken().substring(7);
-        Optional<RefreshToken> refreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
-        assertThat(refreshTokenOpt).isPresent();
-        String refreshToken = refreshTokenOpt.get().getToken();
+        String refreshToken = loginResponse.getRefreshToken();
+        assertThat(refreshToken).isNotNull();
 
         // 2. RefreshToken으로 AccessToken 갱신 (로테이션 발생)
         mockMvc.perform(post("/api/v1/auth/refresh")
@@ -253,10 +247,9 @@ class AuthFlowIntegrationTest {
         Optional<RefreshToken> oldTokenOpt = refreshTokenService.findByToken(refreshToken);
         assertThat(oldTokenOpt).isEmpty();
         
-        // 새로운 RefreshToken 조회
+        // 새로운 RefreshToken이 생성되었는지 확인
         Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
         assertThat(newRefreshTokenOpt).isPresent();
-        String newRefreshToken = newRefreshTokenOpt.get().getToken();
 
         // 3. SecurityContext 설정 (인증된 사용자로 설정)
         org.springframework.security.core.userdetails.UserDetails userDetails = 
@@ -272,15 +265,11 @@ class AuthFlowIntegrationTest {
         org.springframework.security.core.context.SecurityContextHolder.getContext()
                 .setAuthentication(authentication);
 
-        // 4. 로그아웃
+        // 4. 로그아웃 (refreshToken 쿠키는 필요 없음 - getCurrentUsername()으로 사용자 식별)
         mockMvc.perform(post("/api/v1/users/logout")
                         .cookie(new jakarta.servlet.http.Cookie(
                                 JwtUtil.AUTHORIZATION_HEADER,
                                 accessToken
-                        ))
-                        .cookie(new jakarta.servlet.http.Cookie(
-                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
-                                newRefreshToken
                         ))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
@@ -289,11 +278,11 @@ class AuthFlowIntegrationTest {
         Optional<RefreshToken> deletedTokenOpt = refreshTokenService.findByUserId(testUser.getId());
         assertThat(deletedTokenOpt).isEmpty();
 
-        // 6. 삭제된 RefreshToken으로 갱신 시도 시 실패
+        // 6. 무효화된 RefreshToken으로 갱신 시도 시 실패
         mockMvc.perform(post("/api/v1/auth/refresh")
                         .cookie(new jakarta.servlet.http.Cookie(
                                 Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
-                                newRefreshToken
+                                refreshToken
                         ))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized());

--- a/backend/src/test/java/com/phonebid/app/auth/integration/AuthFlowIntegrationTest.java
+++ b/backend/src/test/java/com/phonebid/app/auth/integration/AuthFlowIntegrationTest.java
@@ -1,0 +1,271 @@
+package com.phonebid.app.auth.integration;
+
+import com.phonebid.app.auth.domain.RefreshToken;
+import com.phonebid.app.auth.service.RefreshTokenService;
+import com.phonebid.app.common.Constants;
+import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.member.domain.Role;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.dto.request.LoginRequestDto;
+import com.phonebid.app.member.dto.response.LoginResponseDto;
+import com.phonebid.app.member.repository.UserRepository;
+import com.phonebid.app.member.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("인증 플로우 통합 테스트")
+class AuthFlowIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User testUser;
+    private LoginRequestDto loginRequest;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자 생성
+        String username = "testuser_" + UUID.randomUUID().toString().substring(0, 8);
+        String password = "password123";
+        String encodedPassword = passwordEncoder.encode(password);
+
+        testUser = User.builder()
+                .username(username)
+                .password(encodedPassword)
+                .email(username + "@test.com")
+                .name("테스트 사용자")
+                .nickname("테스트닉네임")
+                .role(Role.CONSUMER)
+                .build();
+
+        testUser = userRepository.save(testUser);
+
+        loginRequest = LoginRequestDto.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+
+    @Test
+    @DisplayName("로그인 → RefreshToken 생성 확인")
+    void login_ShouldCreateRefreshToken() {
+        // when
+        LoginResponseDto loginResponse = userService.login(loginRequest);
+
+        // then
+        assertThat(loginResponse).isNotNull();
+        assertThat(loginResponse.getAccessToken()).isNotNull();
+        assertThat(loginResponse.getAccessToken()).startsWith("Bearer ");
+
+        // RefreshToken이 DB에 저장되었는지 확인
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(refreshTokenOpt).isPresent();
+        assertThat(refreshTokenOpt.get().getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(refreshTokenOpt.get().getToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("로그인 시 기존 RefreshToken 삭제 확인")
+    void login_ShouldDeleteExistingRefreshToken() {
+        // given - 기존 RefreshToken 생성
+        String oldRefreshToken = refreshTokenService.createRefreshToken(testUser.getId());
+        Optional<RefreshToken> oldTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(oldTokenOpt).isPresent();
+        assertThat(oldTokenOpt.get().getToken()).isEqualTo(oldRefreshToken);
+
+        // when - 로그인 (새로운 RefreshToken 생성)
+        userService.login(loginRequest);
+
+        // then - 기존 토큰이 삭제되고 새로운 토큰이 생성되었는지 확인
+        Optional<RefreshToken> newRefreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(newRefreshTokenOpt).isPresent();
+        assertThat(newRefreshTokenOpt.get().getToken()).isNotEqualTo(oldRefreshToken);
+    }
+
+    @Test
+    @DisplayName("RefreshToken으로 AccessToken 갱신 성공")
+    void refresh_WithValidRefreshToken_ShouldReturnNewAccessToken() throws Exception {
+        // given - 로그인하여 RefreshToken 생성
+        LoginResponseDto loginResponse = userService.login(loginRequest);
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(refreshTokenOpt).isPresent();
+        String refreshToken = refreshTokenOpt.get().getToken();
+
+        // when & then - RefreshToken으로 AccessToken 갱신
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                refreshToken
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("토큰이 성공적으로 갱신되었습니다."))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(header().exists("Set-Cookie"));
+    }
+
+    @Test
+    @DisplayName("만료된 RefreshToken으로 갱신 시도 시 실패")
+    void refresh_WithExpiredRefreshToken_ShouldFail() throws Exception {
+        // given - 만료된 RefreshToken 생성
+        // 실제 만료된 JWT 토큰 생성은 복잡하므로, 유효하지 않은 토큰으로 테스트
+        String expiredTokenValue = "expired.invalid.token";
+
+        // when & then - 만료된/유효하지 않은 토큰으로 갱신 시도 (JWT 검증 실패)
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                expiredTokenValue
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그아웃 → RefreshToken 삭제 확인")
+    void logout_ShouldDeleteRefreshToken() throws Exception {
+        // given - 로그인하여 RefreshToken 생성
+        LoginResponseDto loginResponse = userService.login(loginRequest);
+        String accessToken = loginResponse.getAccessToken().substring(7); // "Bearer " 제거
+        
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(refreshTokenOpt).isPresent();
+
+        // SecurityContext 설정 (인증된 사용자로 설정)
+        org.springframework.security.core.userdetails.UserDetails userDetails = 
+                org.springframework.security.core.userdetails.User.builder()
+                        .username(testUser.getUsername())
+                        .password(testUser.getPassword())
+                        .authorities(testUser.getRole().name())
+                        .build();
+        
+        org.springframework.security.authentication.UsernamePasswordAuthenticationToken authentication =
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        org.springframework.security.core.context.SecurityContextHolder.getContext()
+                .setAuthentication(authentication);
+
+        // when - 로그아웃
+        mockMvc.perform(post("/api/v1/users/logout")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                JwtUtil.AUTHORIZATION_HEADER,
+                                accessToken
+                        ))
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                refreshTokenOpt.get().getToken()
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("로그아웃이 성공적으로 완료되었습니다."))
+                .andExpect(header().exists("Set-Cookie"));
+
+        // then - RefreshToken이 삭제되었는지 확인
+        Optional<RefreshToken> deletedTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(deletedTokenOpt).isEmpty();
+        
+        // SecurityContext 정리
+        org.springframework.security.core.context.SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("전체 플로우: 로그인 → 토큰 갱신 → 로그아웃")
+    void fullAuthFlow_LoginRefreshLogout() throws Exception {
+        // 1. 로그인
+        LoginResponseDto loginResponse = userService.login(loginRequest);
+        assertThat(loginResponse).isNotNull();
+        assertThat(loginResponse.getAccessToken()).isNotNull();
+
+        String accessToken = loginResponse.getAccessToken().substring(7);
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(refreshTokenOpt).isPresent();
+        String refreshToken = refreshTokenOpt.get().getToken();
+
+        // 2. RefreshToken으로 AccessToken 갱신
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                refreshToken
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists());
+
+        // 3. SecurityContext 설정 (인증된 사용자로 설정)
+        org.springframework.security.core.userdetails.UserDetails userDetails = 
+                org.springframework.security.core.userdetails.User.builder()
+                        .username(testUser.getUsername())
+                        .password(testUser.getPassword())
+                        .authorities(testUser.getRole().name())
+                        .build();
+        
+        org.springframework.security.authentication.UsernamePasswordAuthenticationToken authentication =
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        org.springframework.security.core.context.SecurityContextHolder.getContext()
+                .setAuthentication(authentication);
+
+        // 4. 로그아웃
+        mockMvc.perform(post("/api/v1/users/logout")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                JwtUtil.AUTHORIZATION_HEADER,
+                                accessToken
+                        ))
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                refreshToken
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // 5. RefreshToken이 삭제되었는지 확인
+        Optional<RefreshToken> deletedTokenOpt = refreshTokenService.findByUserId(testUser.getId());
+        assertThat(deletedTokenOpt).isEmpty();
+
+        // 6. 삭제된 RefreshToken으로 갱신 시도 시 실패
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie(
+                                Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME,
+                                refreshToken
+                        ))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+        
+        // SecurityContext 정리
+        org.springframework.security.core.context.SecurityContextHolder.clearContext();
+    }
+}
+

--- a/backend/src/test/java/com/phonebid/app/auth/service/DbRefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/phonebid/app/auth/service/DbRefreshTokenServiceTest.java
@@ -2,6 +2,7 @@ package com.phonebid.app.auth.service;
 
 import com.phonebid.app.auth.domain.RefreshToken;
 import com.phonebid.app.auth.repository.RefreshTokenRepository;
+import com.phonebid.app.auth.util.TokenHashUtil;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.jwt.JwtUtil;
@@ -39,6 +40,9 @@ class DbRefreshTokenServiceTest {
     @Mock
     private JwtUtil jwtUtil;
 
+    @Mock
+    private TokenHashUtil tokenHashUtil;
+
     @InjectMocks
     private DbRefreshTokenService dbRefreshTokenService;
 
@@ -46,11 +50,13 @@ class DbRefreshTokenServiceTest {
     private UUID testUserId;
     private RefreshToken existingRefreshToken;
     private String testToken;
+    private String hashedToken;
 
     @BeforeEach
     void setUp() {
         testUserId = UUID.randomUUID();
         testToken = "test.refresh.token";
+        hashedToken = "hashed.test.refresh.token";
 
         testUser = User.builder()
                 .username("testuser")
@@ -71,7 +77,7 @@ class DbRefreshTokenServiceTest {
 
         existingRefreshToken = RefreshToken.builder()
                 .user(testUser)
-                .token("old.refresh.token")
+                .token("hashed.old.refresh.token")
                 .expiresAt(LocalDateTime.now().plusDays(30))
                 .build();
     }
@@ -82,6 +88,7 @@ class DbRefreshTokenServiceTest {
         // given
         when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
         when(jwtUtil.createRefreshToken(testUser.getUsername())).thenReturn(testToken);
+        when(tokenHashUtil.hashToken(testToken)).thenReturn(hashedToken);
         when(refreshTokenRepository.save(any(RefreshToken.class))).thenAnswer(invocation -> {
             RefreshToken token = invocation.getArgument(0);
             return token;
@@ -95,6 +102,7 @@ class DbRefreshTokenServiceTest {
         verify(refreshTokenRepository).deleteByUserId(testUserId);
         verify(userRepository).findById(testUserId);
         verify(jwtUtil).createRefreshToken(testUser.getUsername());
+        verify(tokenHashUtil).hashToken(testToken);
         verify(refreshTokenRepository).save(any(RefreshToken.class));
     }
 
@@ -104,6 +112,7 @@ class DbRefreshTokenServiceTest {
         // given
         when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
         when(jwtUtil.createRefreshToken(testUser.getUsername())).thenReturn(testToken);
+        when(tokenHashUtil.hashToken(testToken)).thenReturn(hashedToken);
         when(refreshTokenRepository.save(any(RefreshToken.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
@@ -124,9 +133,10 @@ class DbRefreshTokenServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.USER_NOT_FOUND);
 
-        verify(refreshTokenRepository).deleteByUserId(testUserId);
         verify(userRepository).findById(testUserId);
+        verify(refreshTokenRepository, never()).deleteByUserId(any(UUID.class));
         verify(jwtUtil, never()).createRefreshToken(anyString());
+        verify(tokenHashUtil, never()).hashToken(anyString());
         verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
     }
 
@@ -134,7 +144,8 @@ class DbRefreshTokenServiceTest {
     @DisplayName("토큰으로 RefreshToken 조회 성공")
     void findByToken_ShouldReturnRefreshToken() {
         // given
-        when(refreshTokenRepository.findByToken(testToken))
+        when(tokenHashUtil.hashToken(testToken)).thenReturn(hashedToken);
+        when(refreshTokenRepository.findByToken(hashedToken))
                 .thenReturn(Optional.of(existingRefreshToken));
 
         // when
@@ -142,15 +153,17 @@ class DbRefreshTokenServiceTest {
 
         // then
         assertThat(result).isPresent();
-        assertThat(result.get().getToken()).isEqualTo("old.refresh.token");
-        verify(refreshTokenRepository).findByToken(testToken);
+        assertThat(result.get().getToken()).isEqualTo("hashed.old.refresh.token");
+        verify(tokenHashUtil).hashToken(testToken);
+        verify(refreshTokenRepository).findByToken(hashedToken);
     }
 
     @Test
     @DisplayName("존재하지 않는 토큰으로 조회 시 Optional.empty() 반환")
     void findByToken_WithNonExistentToken_ShouldReturnEmpty() {
         // given
-        when(refreshTokenRepository.findByToken(testToken))
+        when(tokenHashUtil.hashToken(testToken)).thenReturn(hashedToken);
+        when(refreshTokenRepository.findByToken(hashedToken))
                 .thenReturn(Optional.empty());
 
         // when
@@ -158,7 +171,8 @@ class DbRefreshTokenServiceTest {
 
         // then
         assertThat(result).isEmpty();
-        verify(refreshTokenRepository).findByToken(testToken);
+        verify(tokenHashUtil).hashToken(testToken);
+        verify(refreshTokenRepository).findByToken(hashedToken);
     }
 
     @Test
@@ -224,12 +238,13 @@ class DbRefreshTokenServiceTest {
         // given
         RefreshToken validToken = RefreshToken.builder()
                 .user(testUser)
-                .token(testToken)
+                .token(hashedToken)
                 .expiresAt(LocalDateTime.now().plusDays(30))
                 .build();
 
         when(jwtUtil.validateRefreshToken(testToken)).thenReturn(true);
-        when(refreshTokenRepository.findByToken(testToken))
+        when(tokenHashUtil.hashToken(testToken)).thenReturn(hashedToken);
+        when(refreshTokenRepository.findByToken(hashedToken))
                 .thenReturn(Optional.of(validToken));
 
         // when
@@ -238,7 +253,8 @@ class DbRefreshTokenServiceTest {
         // then
         assertThat(result).isTrue();
         verify(jwtUtil).validateRefreshToken(testToken);
-        verify(refreshTokenRepository).findByToken(testToken);
+        verify(tokenHashUtil).hashToken(testToken);
+        verify(refreshTokenRepository).findByToken(hashedToken);
     }
 
     @Test
@@ -261,7 +277,8 @@ class DbRefreshTokenServiceTest {
     void validateToken_WithNonExistentToken_ShouldReturnFalse() {
         // given
         when(jwtUtil.validateRefreshToken(testToken)).thenReturn(true);
-        when(refreshTokenRepository.findByToken(testToken))
+        when(tokenHashUtil.hashToken(testToken)).thenReturn(hashedToken);
+        when(refreshTokenRepository.findByToken(hashedToken))
                 .thenReturn(Optional.empty());
 
         // when
@@ -270,7 +287,8 @@ class DbRefreshTokenServiceTest {
         // then
         assertThat(result).isFalse();
         verify(jwtUtil).validateRefreshToken(testToken);
-        verify(refreshTokenRepository).findByToken(testToken);
+        verify(tokenHashUtil).hashToken(testToken);
+        verify(refreshTokenRepository).findByToken(hashedToken);
     }
 
     @Test
@@ -279,12 +297,13 @@ class DbRefreshTokenServiceTest {
         // given
         RefreshToken expiredToken = RefreshToken.builder()
                 .user(testUser)
-                .token(testToken)
+                .token(hashedToken)
                 .expiresAt(LocalDateTime.now().minusDays(1))
                 .build();
 
         when(jwtUtil.validateRefreshToken(testToken)).thenReturn(true);
-        when(refreshTokenRepository.findByToken(testToken))
+        when(tokenHashUtil.hashToken(testToken)).thenReturn(hashedToken);
+        when(refreshTokenRepository.findByToken(hashedToken))
                 .thenReturn(Optional.of(expiredToken));
 
         // when
@@ -293,7 +312,8 @@ class DbRefreshTokenServiceTest {
         // then
         assertThat(result).isFalse();
         verify(jwtUtil).validateRefreshToken(testToken);
-        verify(refreshTokenRepository).findByToken(testToken);
+        verify(tokenHashUtil).hashToken(testToken);
+        verify(refreshTokenRepository).findByToken(hashedToken);
     }
 }
 

--- a/backend/src/test/java/com/phonebid/app/auth/service/DbRefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/phonebid/app/auth/service/DbRefreshTokenServiceTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -99,7 +100,7 @@ class DbRefreshTokenServiceTest {
 
         // then
         assertThat(result).isEqualTo(testToken);
-        verify(refreshTokenRepository).deleteByUserId(testUserId);
+        verify(refreshTokenRepository).deleteByUserId(eq(testUserId), any(LocalDateTime.class));
         verify(userRepository).findById(testUserId);
         verify(jwtUtil).createRefreshToken(testUser.getUsername());
         verify(tokenHashUtil).hashToken(testToken);
@@ -119,7 +120,7 @@ class DbRefreshTokenServiceTest {
         dbRefreshTokenService.createRefreshToken(testUserId);
 
         // then
-        verify(refreshTokenRepository).deleteByUserId(testUserId);
+        verify(refreshTokenRepository).deleteByUserId(eq(testUserId), any(LocalDateTime.class));
     }
 
     @Test
@@ -134,7 +135,7 @@ class DbRefreshTokenServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.USER_NOT_FOUND);
 
         verify(userRepository).findById(testUserId);
-        verify(refreshTokenRepository, never()).deleteByUserId(any(UUID.class));
+        verify(refreshTokenRepository, never()).deleteByUserId(any(UUID.class), any(LocalDateTime.class));
         verify(jwtUtil, never()).createRefreshToken(anyString());
         verify(tokenHashUtil, never()).hashToken(anyString());
         verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
@@ -207,29 +208,44 @@ class DbRefreshTokenServiceTest {
     }
 
     @Test
-    @DisplayName("사용자 ID로 RefreshToken 삭제 성공")
-    void deleteByUserId_ShouldDeleteToken() {
+    @DisplayName("사용자 ID로 RefreshToken soft delete 성공")
+    void deleteByUserId_ShouldSoftDeleteToken() {
         // given
-        doNothing().when(refreshTokenRepository).deleteByUserId(testUserId);
+        doNothing().when(refreshTokenRepository).deleteByUserId(eq(testUserId), any(LocalDateTime.class));
 
         // when
         dbRefreshTokenService.deleteByUserId(testUserId);
 
         // then
-        verify(refreshTokenRepository).deleteByUserId(testUserId);
+        verify(refreshTokenRepository).deleteByUserId(eq(testUserId), any(LocalDateTime.class));
     }
 
     @Test
-    @DisplayName("만료된 RefreshToken 삭제 성공")
-    void deleteExpiredTokens_ShouldDeleteExpiredTokens() {
+    @DisplayName("만료된 RefreshToken soft delete 성공")
+    void deleteExpiredTokens_ShouldSoftDeleteExpiredTokens() {
         // given
-        doNothing().when(refreshTokenRepository).deleteByExpiresAtBefore(any(LocalDateTime.class));
+        doNothing().when(refreshTokenRepository).deleteByExpiresAtBefore(any(LocalDateTime.class), any(LocalDateTime.class));
 
         // when
         dbRefreshTokenService.deleteExpiredTokens();
 
         // then
-        verify(refreshTokenRepository).deleteByExpiresAtBefore(any(LocalDateTime.class));
+        verify(refreshTokenRepository).deleteByExpiresAtBefore(any(LocalDateTime.class), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("삭제된 지 오래된 RefreshToken 하드 삭제 성공")
+    void hardDeleteOldDeletedTokens_ShouldHardDeleteOldTokens() {
+        // given
+        int months = 3;
+        when(refreshTokenRepository.hardDeleteByDeletedAtBefore(any(LocalDateTime.class))).thenReturn(5);
+
+        // when
+        int deletedCount = dbRefreshTokenService.hardDeleteOldDeletedTokens(months);
+
+        // then
+        assertThat(deletedCount).isEqualTo(5);
+        verify(refreshTokenRepository).hardDeleteByDeletedAtBefore(any(LocalDateTime.class));
     }
 
     @Test

--- a/backend/src/test/java/com/phonebid/app/auth/service/DbRefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/phonebid/app/auth/service/DbRefreshTokenServiceTest.java
@@ -1,0 +1,299 @@
+package com.phonebid.app.auth.service;
+
+import com.phonebid.app.auth.domain.RefreshToken;
+import com.phonebid.app.auth.repository.RefreshTokenRepository;
+import com.phonebid.app.common.exception.CustomException;
+import com.phonebid.app.common.errorcode.CommonErrorCode;
+import com.phonebid.app.jwt.JwtUtil;
+import com.phonebid.app.member.domain.Role;
+import com.phonebid.app.member.domain.User;
+import com.phonebid.app.member.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DbRefreshTokenService 테스트")
+class DbRefreshTokenServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private DbRefreshTokenService dbRefreshTokenService;
+
+    private User testUser;
+    private UUID testUserId;
+    private RefreshToken existingRefreshToken;
+    private String testToken;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = UUID.randomUUID();
+        testToken = "test.refresh.token";
+
+        testUser = User.builder()
+                .username("testuser")
+                .email("test@example.com")
+                .name("테스트 사용자")
+                .nickname("테스트닉네임")
+                .role(Role.CONSUMER)
+                .build();
+        
+        // Reflection을 사용하여 id 설정
+        try {
+            java.lang.reflect.Field idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(testUser, testUserId);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set user id", e);
+        }
+
+        existingRefreshToken = RefreshToken.builder()
+                .user(testUser)
+                .token("old.refresh.token")
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+    }
+
+    @Test
+    @DisplayName("RefreshToken 생성 및 저장 성공")
+    void createRefreshToken_ShouldCreateAndSaveToken() {
+        // given
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(jwtUtil.createRefreshToken(testUser.getUsername())).thenReturn(testToken);
+        when(refreshTokenRepository.save(any(RefreshToken.class))).thenAnswer(invocation -> {
+            RefreshToken token = invocation.getArgument(0);
+            return token;
+        });
+
+        // when
+        String result = dbRefreshTokenService.createRefreshToken(testUserId);
+
+        // then
+        assertThat(result).isEqualTo(testToken);
+        verify(refreshTokenRepository).deleteByUserId(testUserId);
+        verify(userRepository).findById(testUserId);
+        verify(jwtUtil).createRefreshToken(testUser.getUsername());
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("RefreshToken 생성 시 기존 토큰 삭제 확인")
+    void createRefreshToken_ShouldDeleteExistingToken() {
+        // given
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(jwtUtil.createRefreshToken(testUser.getUsername())).thenReturn(testToken);
+        when(refreshTokenRepository.save(any(RefreshToken.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        dbRefreshTokenService.createRefreshToken(testUserId);
+
+        // then
+        verify(refreshTokenRepository).deleteByUserId(testUserId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 RefreshToken 생성 시 예외 발생")
+    void createRefreshToken_WithNonExistentUser_ShouldThrowException() {
+        // given
+        when(userRepository.findById(testUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> dbRefreshTokenService.createRefreshToken(testUserId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.USER_NOT_FOUND);
+
+        verify(refreshTokenRepository).deleteByUserId(testUserId);
+        verify(userRepository).findById(testUserId);
+        verify(jwtUtil, never()).createRefreshToken(anyString());
+        verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("토큰으로 RefreshToken 조회 성공")
+    void findByToken_ShouldReturnRefreshToken() {
+        // given
+        when(refreshTokenRepository.findByToken(testToken))
+                .thenReturn(Optional.of(existingRefreshToken));
+
+        // when
+        Optional<RefreshToken> result = dbRefreshTokenService.findByToken(testToken);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getToken()).isEqualTo("old.refresh.token");
+        verify(refreshTokenRepository).findByToken(testToken);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 토큰으로 조회 시 Optional.empty() 반환")
+    void findByToken_WithNonExistentToken_ShouldReturnEmpty() {
+        // given
+        when(refreshTokenRepository.findByToken(testToken))
+                .thenReturn(Optional.empty());
+
+        // when
+        Optional<RefreshToken> result = dbRefreshTokenService.findByToken(testToken);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(refreshTokenRepository).findByToken(testToken);
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 RefreshToken 조회 성공")
+    void findByUserId_ShouldReturnRefreshToken() {
+        // given
+        when(refreshTokenRepository.findByUserId(testUserId))
+                .thenReturn(Optional.of(existingRefreshToken));
+
+        // when
+        Optional<RefreshToken> result = dbRefreshTokenService.findByUserId(testUserId);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getUser().getId()).isEqualTo(testUserId);
+        verify(refreshTokenRepository).findByUserId(testUserId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 ID로 조회 시 Optional.empty() 반환")
+    void findByUserId_WithNonExistentUserId_ShouldReturnEmpty() {
+        // given
+        when(refreshTokenRepository.findByUserId(testUserId))
+                .thenReturn(Optional.empty());
+
+        // when
+        Optional<RefreshToken> result = dbRefreshTokenService.findByUserId(testUserId);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(refreshTokenRepository).findByUserId(testUserId);
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 RefreshToken 삭제 성공")
+    void deleteByUserId_ShouldDeleteToken() {
+        // given
+        doNothing().when(refreshTokenRepository).deleteByUserId(testUserId);
+
+        // when
+        dbRefreshTokenService.deleteByUserId(testUserId);
+
+        // then
+        verify(refreshTokenRepository).deleteByUserId(testUserId);
+    }
+
+    @Test
+    @DisplayName("만료된 RefreshToken 삭제 성공")
+    void deleteExpiredTokens_ShouldDeleteExpiredTokens() {
+        // given
+        doNothing().when(refreshTokenRepository).deleteByExpiresAtBefore(any(LocalDateTime.class));
+
+        // when
+        dbRefreshTokenService.deleteExpiredTokens();
+
+        // then
+        verify(refreshTokenRepository).deleteByExpiresAtBefore(any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("유효한 RefreshToken 검증 성공")
+    void validateToken_WithValidToken_ShouldReturnTrue() {
+        // given
+        RefreshToken validToken = RefreshToken.builder()
+                .user(testUser)
+                .token(testToken)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+
+        when(jwtUtil.validateRefreshToken(testToken)).thenReturn(true);
+        when(refreshTokenRepository.findByToken(testToken))
+                .thenReturn(Optional.of(validToken));
+
+        // when
+        boolean result = dbRefreshTokenService.validateToken(testToken);
+
+        // then
+        assertThat(result).isTrue();
+        verify(jwtUtil).validateRefreshToken(testToken);
+        verify(refreshTokenRepository).findByToken(testToken);
+    }
+
+    @Test
+    @DisplayName("JWT 검증 실패 시 false 반환")
+    void validateToken_WithInvalidJwt_ShouldReturnFalse() {
+        // given
+        when(jwtUtil.validateRefreshToken(testToken)).thenReturn(false);
+
+        // when
+        boolean result = dbRefreshTokenService.validateToken(testToken);
+
+        // then
+        assertThat(result).isFalse();
+        verify(jwtUtil).validateRefreshToken(testToken);
+        verify(refreshTokenRepository, never()).findByToken(anyString());
+    }
+
+    @Test
+    @DisplayName("DB에 존재하지 않는 토큰 검증 시 false 반환")
+    void validateToken_WithNonExistentToken_ShouldReturnFalse() {
+        // given
+        when(jwtUtil.validateRefreshToken(testToken)).thenReturn(true);
+        when(refreshTokenRepository.findByToken(testToken))
+                .thenReturn(Optional.empty());
+
+        // when
+        boolean result = dbRefreshTokenService.validateToken(testToken);
+
+        // then
+        assertThat(result).isFalse();
+        verify(jwtUtil).validateRefreshToken(testToken);
+        verify(refreshTokenRepository).findByToken(testToken);
+    }
+
+    @Test
+    @DisplayName("만료된 RefreshToken 검증 시 false 반환")
+    void validateToken_WithExpiredToken_ShouldReturnFalse() {
+        // given
+        RefreshToken expiredToken = RefreshToken.builder()
+                .user(testUser)
+                .token(testToken)
+                .expiresAt(LocalDateTime.now().minusDays(1))
+                .build();
+
+        when(jwtUtil.validateRefreshToken(testToken)).thenReturn(true);
+        when(refreshTokenRepository.findByToken(testToken))
+                .thenReturn(Optional.of(expiredToken));
+
+        // when
+        boolean result = dbRefreshTokenService.validateToken(testToken);
+
+        // then
+        assertThat(result).isFalse();
+        verify(jwtUtil).validateRefreshToken(testToken);
+        verify(refreshTokenRepository).findByToken(testToken);
+    }
+}
+

--- a/backend/src/test/java/com/phonebid/app/jwt/JwtUtilTest.java
+++ b/backend/src/test/java/com/phonebid/app/jwt/JwtUtilTest.java
@@ -2,10 +2,8 @@ package com.phonebid.app.jwt;
 
 import com.phonebid.app.member.domain.Role;
 import io.jsonwebtoken.Claims;
-import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-@Disabled("잠시 비활성화")
 @TestPropertySource(properties = {
     "service.jwt.secret-key=testSecretKeyForJwtUtilTestingPurposesOnly123456789"
 })
@@ -177,5 +174,125 @@ class JwtUtilTest {
             assertThat(claims.get(JwtUtil.AUTHORIZATION_KEY)).isEqualTo(role.toString());
             assertThat(jwtUtil.validateToken(jwtToken)).isTrue();
         }
+    }
+
+    @Test
+    @DisplayName("Refresh Token 생성 테스트")
+    void createRefreshToken_ShouldCreateValidToken() {
+        // when
+        String refreshToken = jwtUtil.createRefreshToken(TEST_USERNAME);
+
+        // then
+        assertThat(refreshToken).isNotNull();
+        assertThat(refreshToken).doesNotStartWith("Bearer ");
+        assertThat(refreshToken.length()).isGreaterThan(50);
+    }
+
+    @Test
+    @DisplayName("유효한 Refresh Token 검증 테스트")
+    void validateRefreshToken_WithValidToken_ShouldReturnTrue() {
+        // given
+        String refreshToken = jwtUtil.createRefreshToken(TEST_USERNAME);
+
+        // when
+        boolean isValid = jwtUtil.validateRefreshToken(refreshToken);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 Refresh Token 검증 테스트")
+    void validateRefreshToken_WithInvalidToken_ShouldReturnFalse() {
+        // given
+        String invalidToken = "invalid.refresh.token";
+
+        // when
+        boolean isValid = jwtUtil.validateRefreshToken(invalidToken);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("Refresh Token에서 사용자 정보 추출 테스트")
+    void getUserInfoFromToken_WithRefreshToken_ShouldReturnClaims() {
+        // given
+        String refreshToken = jwtUtil.createRefreshToken(TEST_USERNAME);
+
+        // when
+        Claims claims = jwtUtil.getUserInfoFromToken(refreshToken);
+
+        // then
+        assertThat(claims).isNotNull();
+        assertThat(claims.getSubject()).isEqualTo(TEST_USERNAME);
+    }
+
+    @Test
+    @DisplayName("쿠키에서 Refresh Token 추출 테스트 - 정상 케이스")
+    void getRefreshTokenFromCookie_WithValidCookie_ShouldReturnToken() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String expectedToken = "test.refresh.token";
+        jakarta.servlet.http.Cookie cookie = new jakarta.servlet.http.Cookie(
+                com.phonebid.app.common.Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, 
+                expectedToken
+        );
+        request.setCookies(cookie);
+
+        // when
+        String extractedToken = jwtUtil.getRefreshTokenFromCookie(request);
+
+        // then
+        assertThat(extractedToken).isEqualTo(expectedToken);
+    }
+
+    @Test
+    @DisplayName("쿠키에서 Refresh Token 추출 테스트 - 쿠키 없음")
+    void getRefreshTokenFromCookie_WithoutCookie_ShouldReturnNull() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        String extractedToken = jwtUtil.getRefreshTokenFromCookie(request);
+
+        // then
+        assertThat(extractedToken).isNull();
+    }
+
+    @Test
+    @DisplayName("쿠키에서 Refresh Token 추출 테스트 - 다른 쿠키만 존재")
+    void getRefreshTokenFromCookie_WithOtherCookies_ShouldReturnNull() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        jakarta.servlet.http.Cookie cookie = new jakarta.servlet.http.Cookie(
+                "otherCookie", 
+                "otherValue"
+        );
+        request.setCookies(cookie);
+
+        // when
+        String extractedToken = jwtUtil.getRefreshTokenFromCookie(request);
+
+        // then
+        assertThat(extractedToken).isNull();
+    }
+
+    @Test
+    @DisplayName("쿠키에서 Refresh Token 추출 테스트 - 빈 값")
+    void getRefreshTokenFromCookie_WithEmptyValue_ShouldReturnNull() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        jakarta.servlet.http.Cookie cookie = new jakarta.servlet.http.Cookie(
+                com.phonebid.app.common.Constants.Jwt.REFRESH_TOKEN_COOKIE_NAME, 
+                ""
+        );
+        request.setCookies(cookie);
+
+        // when
+        String extractedToken = jwtUtil.getRefreshTokenFromCookie(request);
+
+        // then
+        assertThat(extractedToken).isNull();
     }
 } 

--- a/backend/src/test/java/com/phonebid/app/member/service/UserServiceLoginTest.java
+++ b/backend/src/test/java/com/phonebid/app/member/service/UserServiceLoginTest.java
@@ -3,10 +3,10 @@ package com.phonebid.app.member.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.phonebid.app.auth.service.RefreshTokenService;
 import com.phonebid.app.common.exception.CustomException;
 import com.phonebid.app.common.errorcode.CommonErrorCode;
 import com.phonebid.app.member.domain.Role;
@@ -38,6 +39,9 @@ class UserServiceLoginTest {
     @Mock
     private JwtUtil jwtUtil;
 
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
     @InjectMocks
     private UserService userService;
 
@@ -48,6 +52,7 @@ class UserServiceLoginTest {
 
     @BeforeEach
     void setUp() {
+        UUID userId = UUID.randomUUID();
         testUser = User.builder()
                 .username("testuser")
                 .password("encodedPassword")
@@ -56,6 +61,15 @@ class UserServiceLoginTest {
                 .nickname("테스트닉네임")
                 .role(Role.CONSUMER)
                 .build();
+        
+        // Reflection을 사용하여 id 설정 (Builder에 id 메서드가 없으므로)
+        try {
+            java.lang.reflect.Field idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(testUser, userId);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set user id", e);
+        }
 
         validLoginRequest = LoginRequestDto.builder()
                 .username("testuser")
@@ -78,9 +92,12 @@ class UserServiceLoginTest {
     void loginSuccess() {
         // given
         String expectedToken = "Bearer test.jwt.token";
+        String expectedRefreshToken = "test.refresh.token";
         when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(testUser));
         when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
-        when(jwtUtil.createToken("testuser", Role.CONSUMER)).thenReturn(expectedToken);
+        when(jwtUtil.createToken("testuser", Role.CONSUMER, false)).thenReturn(expectedToken);
+        doNothing().when(refreshTokenService).deleteByUserId(testUser.getId());
+        when(refreshTokenService.createRefreshToken(testUser.getId())).thenReturn(expectedRefreshToken);
 
         // when
         LoginResponseDto result = userService.login(validLoginRequest);
@@ -92,6 +109,10 @@ class UserServiceLoginTest {
         assertThat(result.getRole()).isEqualTo("CONSUMER");
         assertThat(result.getAccessToken()).isEqualTo(expectedToken);
         assertThat(result.getTokenType()).isEqualTo("Bearer");
+        
+        // RefreshToken 생성 확인
+        verify(refreshTokenService).deleteByUserId(testUser.getId());
+        verify(refreshTokenService).createRefreshToken(testUser.getId());
     }
 
     @Test
@@ -132,5 +153,46 @@ class UserServiceLoginTest {
         assertThatThrownBy(() -> userService.login(emptyUsernameRequest))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.INVALID_CREDENTIALS);
+        
+        // RefreshToken 생성되지 않아야 함
+        verify(refreshTokenService, never()).deleteByUserId(any());
+        verify(refreshTokenService, never()).createRefreshToken(any());
+    }
+
+    @Test
+    @DisplayName("로그인 시 기존 RefreshToken 삭제 확인")
+    void login_ShouldDeleteExistingRefreshToken() {
+        // given
+        String expectedToken = "Bearer test.jwt.token";
+        String expectedRefreshToken = "test.refresh.token";
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+        when(jwtUtil.createToken("testuser", Role.CONSUMER, false)).thenReturn(expectedToken);
+        doNothing().when(refreshTokenService).deleteByUserId(testUser.getId());
+        when(refreshTokenService.createRefreshToken(testUser.getId())).thenReturn(expectedRefreshToken);
+
+        // when
+        userService.login(validLoginRequest);
+
+        // then
+        verify(refreshTokenService).deleteByUserId(testUser.getId());
+        verify(refreshTokenService).createRefreshToken(testUser.getId());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 시 RefreshToken 생성되지 않음")
+    void login_WithInvalidCredentials_ShouldNotCreateRefreshToken() {
+        // given
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("wrongpassword", "encodedPassword")).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> userService.login(invalidPasswordRequest))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.INVALID_CREDENTIALS);
+        
+        // RefreshToken 생성되지 않아야 함
+        verify(refreshTokenService, never()).deleteByUserId(any());
+        verify(refreshTokenService, never()).createRefreshToken(any());
     }
 } 

--- a/backend/src/test/java/com/phonebid/app/member/service/UserServiceTest.java
+++ b/backend/src/test/java/com/phonebid/app/member/service/UserServiceTest.java
@@ -197,4 +197,59 @@ class UserServiceTest {
             user.getNickname().equals("테스트닉네임")
         ));
     }
+
+    @Test
+    @DisplayName("활성 사용자 조회 성공")
+    void findByUsername_WithActiveUser_ShouldReturnUser() {
+        // given
+        when(userRepository.findByUsername("testuser"))
+                .thenReturn(Optional.of(savedUser));
+
+        // when
+        User result = userService.findByUsername("testuser");
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo("testuser");
+        assertThat(result.getEmail()).isEqualTo("test@example.com");
+        verify(userRepository).findByUsername("testuser");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 조회 시 예외 발생")
+    void findByUsername_WithNonExistentUser_ShouldThrowException() {
+        // given
+        when(userRepository.findByUsername("nonexistent"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.findByUsername("nonexistent"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository).findByUsername("nonexistent");
+    }
+
+    @Test
+    @DisplayName("삭제된 사용자 조회 시 예외 발생")
+    void findByUsername_WithDeletedUser_ShouldThrowException() {
+        // given
+        User deletedUser = User.builder()
+                .username("deleteduser")
+                .email("deleted@example.com")
+                .name("삭제된 사용자")
+                .nickname("삭제닉네임")
+                .build();
+        deletedUser.softDelete("deleteduser");
+        
+        when(userRepository.findByUsername("deleteduser"))
+                .thenReturn(Optional.of(deletedUser));
+
+        // when & then
+        assertThatThrownBy(() -> userService.findByUsername("deleteduser"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository).findByUsername("deleteduser");
+    }
 } 

--- a/docs/ENTITY_DESIGN.md
+++ b/docs/ENTITY_DESIGN.md
@@ -6,15 +6,38 @@
 
 ## 🏗️ 공통 설계 원칙
 
-### BaseEntity
+### BaseEntity (일반 엔터티)
 
-모든 엔터티는 `BaseEntity`를 상속받아 공통 필드를 포함합니다:
+일반 엔터티(예: User, Product, Quote 등)는 `BaseEntity`를 상속받아 공통 필드를 포함합니다:
 
 - `createdAt`: 생성 시각 (`@CreatedDate`)
 - `updatedAt`: 수정 시각 (`@LastModifiedDate`)
 - `createdBy`: 생성자 (`@CreatedBy`)
 - `lastModifiedBy`: 최종 수정자 (`@LastModifiedBy`)
+- `deletedAt`: 삭제 시각 (소프트 삭제)
+- `deletedBy`: 삭제자
 - `isDelete`: 소프트 삭제 플래그
+
+### BaseTimeEntity (Immutable 엔터티 예외)
+
+**Immutable한 엔터티**(예: RefreshToken)는 `BaseTimeEntity`를 상속받을 수 있습니다:
+
+- `createdAt`: 생성 시각 (`@CreatedDate`)
+- `deletedAt`: 삭제 시각 (소프트 삭제)
+
+**설계 이유**:
+- 수정되지 않는 엔터티는 `updatedAt`, `updatedBy`, `createdBy`, `deletedBy`, `isDelete` 필드가 불필요합니다.
+- 최소한의 감사 정보만 제공하여 불필요한 컬럼을 제거합니다.
+- `BaseTimeEntity`는 `@SQLRestriction("deleted_at IS NULL")`로 소프트 삭제를 지원합니다.
+
+**사용 예시**:
+```java
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken extends BaseTimeEntity {
+    // created_at, deleted_at만 자동 관리됨
+}
+```
 
 ### 식별자 전략
 

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -17,6 +17,21 @@ last_modified_by VARCHAR(255),
 is_delete BOOLEAN NOT NULL DEFAULT FALSE
 );
 
+-- Refresh Token 테이블
+CREATE TABLE refresh_tokens (
+id UUID PRIMARY KEY, -- Refresh Token 고유 ID
+user_id UUID NOT NULL, -- 사용자 ID (users.id)
+token VARCHAR(500) NOT NULL UNIQUE, -- Refresh Token 값
+expires_at TIMESTAMP NOT NULL, -- 만료 시각
+created_at TIMESTAMP NOT NULL, -- BaseEntity
+updated_at TIMESTAMP NOT NULL,
+created_by VARCHAR(255),
+updated_by VARCHAR(255),
+deleted_at TIMESTAMP,
+deleted_by VARCHAR(255),
+is_delete BOOLEAN NOT NULL DEFAULT FALSE
+);
+
 -- 판매자 정보 테이블
 CREATE TABLE sellers (
 user_id UUID PRIMARY KEY, -- users.id 와 1:1 관계
@@ -113,6 +128,8 @@ is_delete BOOLEAN NOT NULL DEFAULT FALSE
 -- 인덱스 생성
 CREATE INDEX idx_users_email ON users(email);
 CREATE INDEX idx_users_provider ON users(provider, provider_id);
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_token ON refresh_tokens(token);
 CREATE INDEX idx_sellers_approval_status ON sellers(approval_status);
 CREATE INDEX idx_quotes_user_id ON quotes(user_id);
 CREATE INDEX idx_quotes_status ON quotes(status);
@@ -124,6 +141,7 @@ CREATE INDEX idx_seller_documents_seller_id ON seller_documents(seller_id);
 CREATE INDEX idx_seller_documents_type ON seller_documents(type);
 
 -- 외래 키 설정
+ALTER TABLE refresh_tokens ADD CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES users(id);
 ALTER TABLE sellers ADD CONSTRAINT fk_sellers_user FOREIGN KEY (user_id) REFERENCES users(id);
 ALTER TABLE seller_documents ADD CONSTRAINT fk_documents_seller FOREIGN KEY (seller_id) REFERENCES sellers(user_id);
 ALTER TABLE quotes ADD CONSTRAINT fk_quotes_user FOREIGN KEY (user_id) REFERENCES users(id);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,16 @@ import SWRProvider from "app/providers/SWRProvider";
 function App() {
   // 앱 시작 시 인증 상태 복원 (마운트 시 한 번만 실행)
   useEffect(() => {
-    useAuthStore.getState().initializeAuth();
+    const initialize = async () => {
+      try {
+        await useAuthStore.getState().initializeAuth();
+      } catch (error) {
+        // initializeAuth 내부에서 이미 에러 처리를 하므로 여기서는 로깅만
+        console.error("앱 초기화 중 인증 확인 실패:", error);
+      }
+    };
+    
+    initialize();
   }, []);
 
   return (

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 import Layout from "components/layout/Layout";
+import { ProtectedRoute } from "components/auth/ProtectedRoute";
 import LoginPage from "pages/LoginPage";
 import SignupPage from "pages/SignupPage";
 import AuthCallbackPage from "pages/AuthCallbackPage";
@@ -46,8 +47,22 @@ export const AppRouter: React.FC = () => {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/seller/login" element={<SellerLoginPage />} />
         <Route path="/seller/signup" element={<SellerSignupPage />} />
-        <Route path="/seller-center" element={<SellerDashboardPage />} />
-        <Route path="/seller-center/quotes/:quoteId/bid" element={<SellerBidCreatePage />} />
+        <Route
+          path="/seller-center"
+          element={
+            <ProtectedRoute requiredRole={["SELLER", "ADMIN"]} redirectTo="/seller/login">
+              <SellerDashboardPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/seller-center/quotes/:quoteId/bid"
+          element={
+            <ProtectedRoute requiredRole={["SELLER", "ADMIN"]} redirectTo="/seller/login">
+              <SellerBidCreatePage />
+            </ProtectedRoute>
+          }
+        />
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
         <Route path="/confetti" element={<ConfettiTestPage />} />

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -7,6 +7,8 @@ import SignupPage from "pages/SignupPage";
 import AuthCallbackPage from "pages/AuthCallbackPage";
 import SellerLoginPage from "pages/seller/SellerLoginPage";
 import SellerSignupPage from "pages/seller/SellerSignupPage";
+import SellerDashboardPage from "pages/seller/SellerDashboardPage";
+import SellerBidCreatePage from "pages/seller/SellerBidCreatePage";
 import ConfettiTestPage from "pages/ConfettiPage";
 import AuctionListPage from "pages/AuctionListPage";
 import WeeklyRankingPage from "pages/WeeklyRankingPage";
@@ -44,6 +46,8 @@ export const AppRouter: React.FC = () => {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/seller/login" element={<SellerLoginPage />} />
         <Route path="/seller/signup" element={<SellerSignupPage />} />
+        <Route path="/seller-center" element={<SellerDashboardPage />} />
+        <Route path="/seller-center/quotes/:quoteId/bid" element={<SellerBidCreatePage />} />
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
         <Route path="/confetti" element={<ConfettiTestPage />} />

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -19,17 +19,27 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   requiredRole,
   redirectTo = "/login",
 }) => {
-  const { isAuthenticated, user, checkAuth } = useAuthStore();
+  const { isAuthenticated, isInitializing, user, checkAuth } = useAuthStore();
   const location = useLocation();
-  const [isChecking, setIsChecking] = useState(true);
+  const [isChecking, setIsChecking] = useState(false);
 
   useEffect(() => {
     const verifyAuth = async () => {
+      // App.tsx의 initializeAuth가 진행 중이면 대기
+      if (isInitializing) {
+        return;
+      }
+
+      // 이미 인증되어 있으면 확인 불필요
+      if (isAuthenticated) {
+        setIsChecking(false);
+        return;
+      }
+
+      // 인증 상태가 없고 초기화가 완료된 경우에만 확인 시도
+      setIsChecking(true);
       try {
-        // 인증 상태가 없으면 확인 시도
-        if (!isAuthenticated) {
-          await checkAuth();
-        }
+        await checkAuth();
       } catch (error) {
         // 인증 확인 실패 시 로그인 페이지로 리다이렉트
         console.error("인증 확인 실패:", error);
@@ -39,10 +49,10 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     };
 
     verifyAuth();
-  }, [isAuthenticated, checkAuth]);
+  }, [isAuthenticated, isInitializing, checkAuth]);
 
-  // 인증 확인 중 로딩 상태
-  if (isChecking) {
+  // 인증 초기화 중이거나 확인 중 로딩 상태
+  if (isInitializing || isChecking) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-muted-foreground">인증 확인 중...</div>

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -56,14 +56,22 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   }
 
   // 역할이 필요한 경우 역할 체크
-  if (requiredRole && user?.role) {
+  if (requiredRole) {
     const allowedRoles = Array.isArray(requiredRole) ? requiredRole : [requiredRole];
+    
+    // user.role이 없으면 즉시 리다이렉트
+    if (!user?.role) {
+      const roleRedirectTo = allowedRoles.includes("SELLER") ? "/seller/login" : redirectTo;
+      return <Navigate to={roleRedirectTo} state={{ from: location }} replace />;
+    }
+    
+    // user.role이 있으면 기존 로직대로 체크
     const hasRequiredRole = allowedRoles.includes(user.role);
-
+    
     if (!hasRequiredRole) {
-      // 역할이 맞지 않으면 판매자 로그인 페이지 또는 홈으로 리다이렉트
-      const roleRedirectTo = allowedRoles.includes("SELLER") ? "/seller/login" : "/";
-      return <Navigate to={roleRedirectTo} replace />;
+      // 역할이 맞지 않으면 판매자 로그인 페이지 또는 기본 리다이렉트 경로로 이동
+      const roleRedirectTo = allowedRoles.includes("SELLER") ? "/seller/login" : redirectTo;
+      return <Navigate to={roleRedirectTo} state={{ from: location }} replace />;
     }
   }
 

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuthStore } from "store/authStore";
+
+interface ProtectedRouteProps {
+  children: React.ReactElement;
+  requiredRole?: string | string[];
+  redirectTo?: string;
+}
+
+/**
+ * 인증 및 역할 기반 라우트 보호 컴포넌트
+ * @param children - 보호할 컴포넌트
+ * @param requiredRole - 필요한 역할 (단일 문자열 또는 문자열 배열, 예: "SELLER", ["SELLER", "ADMIN"])
+ * @param redirectTo - 인증 실패 시 리다이렉트할 경로 (기본값: "/login")
+ */
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  children,
+  requiredRole,
+  redirectTo = "/login",
+}) => {
+  const { isAuthenticated, user, checkAuth } = useAuthStore();
+  const location = useLocation();
+  const [isChecking, setIsChecking] = useState(true);
+
+  useEffect(() => {
+    const verifyAuth = async () => {
+      try {
+        // 인증 상태가 없으면 확인 시도
+        if (!isAuthenticated) {
+          await checkAuth();
+        }
+      } catch (error) {
+        // 인증 확인 실패 시 로그인 페이지로 리다이렉트
+        console.error("인증 확인 실패:", error);
+      } finally {
+        setIsChecking(false);
+      }
+    };
+
+    verifyAuth();
+  }, [isAuthenticated, checkAuth]);
+
+  // 인증 확인 중 로딩 상태
+  if (isChecking) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-muted-foreground">인증 확인 중...</div>
+      </div>
+    );
+  }
+
+  // 인증되지 않은 경우 로그인 페이지로 리다이렉트
+  if (!isAuthenticated) {
+    return <Navigate to={redirectTo} state={{ from: location }} replace />;
+  }
+
+  // 역할이 필요한 경우 역할 체크
+  if (requiredRole && user?.role) {
+    const allowedRoles = Array.isArray(requiredRole) ? requiredRole : [requiredRole];
+    const hasRequiredRole = allowedRoles.includes(user.role);
+
+    if (!hasRequiredRole) {
+      // 역할이 맞지 않으면 판매자 로그인 페이지 또는 홈으로 리다이렉트
+      const roleRedirectTo = allowedRoles.includes("SELLER") ? "/seller/login" : "/";
+      return <Navigate to={roleRedirectTo} replace />;
+    }
+  }
+
+  // 인증 및 역할 확인 완료
+  return children;
+};
+

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -5,9 +5,9 @@ import { useState } from "react";
 const Header: React.FC = () => {
   const { isAuthenticated, user, logout } = useAuthStore();
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     try {
-      logout();
+      await logout();
     } catch (error) {
       console.error("로그아웃 실패:", error);
     }

--- a/frontend/src/components/seller/QuoteFilterBar.tsx
+++ b/frontend/src/components/seller/QuoteFilterBar.tsx
@@ -1,0 +1,100 @@
+import { Carrier } from "types/QuoteTypes";
+import { getCarrierDisplayName } from "utils/quoteUtils";
+import { Card, CardContent } from "components/ui/card";
+import { cn } from "utils/cn";
+
+interface QuoteFilterBarProps {
+  selectedCarrier: Carrier | "ALL";
+  selectedBrand: string | "ALL";
+  sortBy: "NEWEST" | "OLDEST" | "BID_COUNT";
+  onCarrierChange: (carrier: Carrier | "ALL") => void;
+  onBrandChange: (brand: string | "ALL") => void;
+  onSortChange: (sort: "NEWEST" | "OLDEST" | "BID_COUNT") => void;
+  className?: string;
+}
+
+const CARRIERS: (Carrier | "ALL")[] = ["ALL", "SKT", "KT", "LGU"];
+const BRANDS = ["ALL", "APPLE", "SAMSUNG"];
+const SORT_OPTIONS = [
+  { value: "NEWEST", label: "최신순" },
+  { value: "OLDEST", label: "오래된순" },
+  { value: "BID_COUNT", label: "입찰 많은순" },
+] as const;
+
+export const QuoteFilterBar: React.FC<QuoteFilterBarProps> = ({
+  selectedCarrier,
+  selectedBrand,
+  sortBy,
+  onCarrierChange,
+  onBrandChange,
+  onSortChange,
+  className,
+}) => {
+  return (
+    <Card className={cn("mb-4", className)}>
+      <CardContent className="py-2 px-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2">
+            <svg
+              className="w-4 h-4 text-foreground"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
+              />
+            </svg>
+            <span className="text-sm font-medium text-foreground">필터</span>
+          </div>
+          <select
+            value={selectedCarrier}
+            onChange={(e) =>
+              onCarrierChange(e.target.value as Carrier | "ALL")
+            }
+            className="border border-input rounded-md h-10 px-3 pr-8 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring appearance-none bg-[url('data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%3E%3Cpath%20fill%3D%22%23666%22%20d%3D%22M6%209l3%203%203-3H6z%22%2F%3E%3C%2Fsvg%3E')] bg-no-repeat bg-[length:12px_12px] bg-[right_8px_center]"
+          >
+            <option value="ALL">모든 통신사</option>
+            {CARRIERS.filter((c) => c !== "ALL").map((carrier) => (
+              <option key={carrier} value={carrier}>
+                {getCarrierDisplayName(carrier)}
+              </option>
+            ))}
+          </select>
+          <select
+            value={selectedBrand}
+            onChange={(e) => onBrandChange(e.target.value)}
+            className="border border-input rounded-md h-10 px-3 pr-8 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring appearance-none bg-[url('data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%3E%3Cpath%20fill%3D%22%23666%22%20d%3D%22M6%209l3%203%203-3H6z%22%2F%3E%3C%2Fsvg%3E')] bg-no-repeat bg-[length:12px_12px] bg-[right_8px_center]"
+          >
+            <option value="ALL">모든 기종</option>
+            {BRANDS.filter((b) => b !== "ALL").map((brand) => (
+              <option key={brand} value={brand}>
+                {brand === "APPLE" ? "애플" : brand === "SAMSUNG" ? "삼성" : brand}
+              </option>
+            ))}
+          </select>
+          <div className="flex items-center gap-2 ml-auto">
+            <label className="text-sm font-medium text-foreground">정렬:</label>
+            <select
+              value={sortBy}
+              onChange={(e) =>
+                onSortChange(e.target.value as "NEWEST" | "OLDEST" | "BID_COUNT")
+              }
+              className="border border-input rounded-md h-10 px-3 pr-8 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring appearance-none bg-[url('data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%3E%3Cpath%20fill%3D%22%23666%22%20d%3D%22M6%209l3%203%203-3H6z%22%2F%3E%3C%2Fsvg%3E')] bg-no-repeat bg-[length:12px_12px] bg-[right_8px_center]"
+            >
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+

--- a/frontend/src/components/seller/QuoteRequestCard.tsx
+++ b/frontend/src/components/seller/QuoteRequestCard.tsx
@@ -1,0 +1,154 @@
+import { QuoteListItem } from "types/QuoteTypes";
+import { getCarrierDisplayName, getPurchaseMethodDisplayName } from "utils/quoteUtils";
+import { formatRelativeTime } from "utils/formatters";
+import { Badge } from "components/ui/badge";
+import { cn } from "utils/cn";
+
+interface QuoteRequestCardProps {
+  quote: QuoteListItem;
+  onClick?: () => void;
+  className?: string;
+}
+
+const getBrandIcon = (brand: string) => {
+  if (brand === "APPLE") {
+    return (
+      <svg className="w-6 h-6 text-gray-900" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+      </svg>
+    );
+  }
+  if (brand === "SAMSUNG") {
+    return (
+      <div className="w-6 h-6 flex items-center justify-center font-bold text-xs bg-blue-100 text-blue-700 rounded">
+        SS
+      </div>
+    );
+  }
+  return null;
+};
+
+const getCarrierIcon = (carrier: string) => {
+  const carrierConfig: Record<string, { name: string; color: string; fillColor: string }> = {
+    SKT: { name: "SKT", color: "text-gray-700", fillColor: "#2563eb" },
+    KT: { name: "KT", color: "text-gray-700", fillColor: "#dc2626" },
+    LGU: { name: "LG U+", color: "text-gray-700", fillColor: "#9333ea" },
+  };
+  
+  const config = carrierConfig[carrier] || { name: carrier, color: "text-gray-700", fillColor: "#6b7280" };
+  
+  return (
+    <div className="flex items-center gap-1.5">
+      <svg 
+        className="w-5 h-5" 
+        viewBox="0 0 20 16" 
+        fill="none"
+      >
+        {/* SIM 카드 본체 - 모서리가 잘린 직사각형 */}
+        <path
+          d="M2 3C2 2.44772 2.44772 2 3 2H15C15.5523 2 16 2.44772 16 3V13C16 13.5523 15.5523 14 15 14H3C2.44772 14 2 13.5523 2 13V3Z"
+          fill={config.fillColor}
+          fillOpacity="0.15"
+          stroke={config.fillColor}
+          strokeWidth="1.2"
+        />
+        {/* SIM 카드 잘린 모서리 (왼쪽 상단) */}
+        <path
+          d="M2 3L5.5 2H3C2.44772 2 2 2.44772 2 3Z"
+          fill={config.fillColor}
+        />
+        {/* SIM 카드 내부 격자 패턴 (금속 접점) - 더 세밀하게 */}
+        <g fill={config.fillColor} fillOpacity="0.7">
+          <rect x="6" y="5" width="1.2" height="1.2" rx="0.2" />
+          <rect x="8" y="5" width="1.2" height="1.2" rx="0.2" />
+          <rect x="10" y="5" width="1.2" height="1.2" rx="0.2" />
+          <rect x="12" y="5" width="1.2" height="1.2" rx="0.2" />
+          <rect x="6" y="7" width="1.2" height="1.2" rx="0.2" />
+          <rect x="8" y="7" width="1.2" height="1.2" rx="0.2" />
+          <rect x="10" y="7" width="1.2" height="1.2" rx="0.2" />
+          <rect x="12" y="7" width="1.2" height="1.2" rx="0.2" />
+          <rect x="6" y="9" width="1.2" height="1.2" rx="0.2" />
+          <rect x="8" y="9" width="1.2" height="1.2" rx="0.2" />
+          <rect x="10" y="9" width="1.2" height="1.2" rx="0.2" />
+          <rect x="12" y="9" width="1.2" height="1.2" rx="0.2" />
+        </g>
+      </svg>
+      <span className={`text-sm font-medium ${config.color}`}>{config.name}</span>
+    </div>
+  );
+};
+
+const getStatusBadge = (status: string) => {
+  const statusMap = {
+    OPEN: { text: "진행중", className: "bg-gray-100 text-gray-700" },
+    CLOSED: { text: "마감", className: "bg-gray-100 text-gray-700" },
+    CONTRACTED: { text: "완료", className: "bg-gray-100 text-gray-700" },
+  };
+  return statusMap[status as keyof typeof statusMap] || statusMap.OPEN;
+};
+
+export const QuoteRequestCard: React.FC<QuoteRequestCardProps> = ({
+  quote,
+  onClick,
+  className,
+}) => {
+  const statusBadge = getStatusBadge(quote.status);
+  const brandIcon = getBrandIcon(quote.phoneModel.brand);
+
+  return (
+    <tr
+      className={cn(
+        "border-b hover:bg-muted/50 transition-colors cursor-pointer",
+        className
+      )}
+      onClick={onClick}
+    >
+      <td className="px-4 py-3">
+        <div className="flex items-center justify-center">{brandIcon}</div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="font-bold text-foreground">
+          {quote.phoneModel.model}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="text-sm text-muted-foreground">
+          {quote.storage?.displayLabel || "-"} /{" "}
+          {quote.color?.displayLabel || "-"}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        {getCarrierIcon(quote.carrier)}
+      </td>
+      <td className="px-4 py-3">
+        <div className="text-sm">
+          {getPurchaseMethodDisplayName(quote.purchaseMethod)}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="text-sm">
+          {quote.currentCarrier ? (
+            <div className="flex items-center gap-1">
+              <span className="text-gray-500">→</span>
+              {getCarrierIcon(quote.currentCarrier)}
+            </div>
+          ) : (
+            <span className="text-muted-foreground">-</span>
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="text-sm text-muted-foreground">
+          {formatRelativeTime(quote.createdAt)}
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="text-sm font-bold text-blue-600">{quote.bidCount || 0}</div>
+      </td>
+      <td className="px-4 py-3">
+        <Badge className={statusBadge.className}>{statusBadge.text}</Badge>
+      </td>
+    </tr>
+  );
+};
+

--- a/frontend/src/components/seller/QuoteRequestInfo.tsx
+++ b/frontend/src/components/seller/QuoteRequestInfo.tsx
@@ -1,0 +1,180 @@
+import { QuoteDetail } from "types/QuoteTypes";
+import { Card, CardContent, CardHeader, CardTitle } from "components/ui/card";
+import { getCarrierDisplayName, getPurchaseMethodDisplayName, getActivationMethodDisplayName } from "utils/quoteUtils";
+import { cn } from "utils/cn";
+
+interface QuoteRequestInfoProps {
+  quote: QuoteDetail;
+  className?: string;
+}
+
+const InfoItem: React.FC<{ icon: React.ReactNode; label: string; value: string }> = ({
+  icon,
+  label,
+  value,
+}) => {
+  return (
+    <div className="flex items-center gap-3 py-2">
+      <div className="flex-shrink-0">{icon}</div>
+      <div className="flex-1">
+        <div className="text-sm font-medium text-foreground">{label}</div>
+        <div className="text-sm font-bold text-foreground mt-1">{value}</div>
+      </div>
+    </div>
+  );
+};
+
+export const QuoteRequestInfo: React.FC<QuoteRequestInfoProps> = ({
+  quote,
+  className,
+}) => {
+  return (
+    <div className={cn("space-y-4", className)}>
+      <Card className="gap-0">
+        <CardHeader className="pb-1">
+          <CardTitle className="text-base">요청 정보</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 pt-0">
+          <InfoItem
+            icon={
+              <div className="w-10 h-10 rounded-lg bg-blue-100 flex items-center justify-center">
+                <svg
+                  className="w-5 h-5 text-blue-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+            }
+            label="기기"
+            value={quote.model}
+          />
+          <InfoItem
+            icon={
+              <div className="w-10 h-10 rounded-lg bg-purple-100 flex items-center justify-center">
+                <svg
+                  className="w-5 h-5 text-purple-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                  />
+                  <circle cx="7.5" cy="12" r="1.5" fill="currentColor" />
+                  <circle cx="16.5" cy="12" r="1.5" fill="currentColor" />
+                  <circle cx="12" cy="8" r="1.5" fill="currentColor" />
+                  <circle cx="12" cy="16" r="1.5" fill="currentColor" />
+                </svg>
+              </div>
+            }
+            label="색상"
+            value={quote.color || "상관없음"}
+          />
+          <InfoItem
+            icon={
+              <div className="w-10 h-10 rounded-lg bg-green-100 flex items-center justify-center">
+                <svg
+                  className="w-5 h-5 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
+                  />
+                </svg>
+              </div>
+            }
+            label="용량"
+            value={quote.storage || "상관없음"}
+          />
+          <InfoItem
+            icon={
+              <div className="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center">
+                <svg
+                  className="w-5 h-5 text-orange-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
+            }
+            label="통신사"
+            value={getCarrierDisplayName(quote.carrier)}
+          />
+          <InfoItem
+            icon={
+              <div className="w-10 h-10 rounded-lg bg-red-100 flex items-center justify-center">
+                <svg
+                  className="w-5 h-5 text-red-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                  />
+                </svg>
+              </div>
+            }
+            label="개통 조건"
+            value={getPurchaseMethodDisplayName(quote.purchaseMethod)}
+          />
+        </CardContent>
+      </Card>
+
+      <Card className="bg-blue-50 border-blue-200 gap-0">
+        <CardHeader className="pb-1">
+          <CardTitle className="text-base flex items-center gap-2">
+            <div className="w-8 h-8 rounded-lg bg-blue-100 flex items-center justify-center">
+              <svg
+                className="w-5 h-5 text-blue-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            구매자 요청사항
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <p className="text-sm text-muted-foreground">
+            최대한 저렴하게 구매하고 싶습니다. 요금제는 5만원대 이하로 희망하며, 할부 24개월 원합니다.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+

--- a/frontend/src/components/seller/SellerHeader.tsx
+++ b/frontend/src/components/seller/SellerHeader.tsx
@@ -9,9 +9,9 @@ export const SellerHeader: React.FC = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [sellerProfile, setSellerProfile] = useState<SellerProfileResponseDto | null>(null);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     try {
-      logout();
+      await logout();
     } catch (error) {
       console.error("로그아웃 실패:", error);
     }

--- a/frontend/src/components/seller/SellerHeader.tsx
+++ b/frontend/src/components/seller/SellerHeader.tsx
@@ -1,0 +1,213 @@
+import { Link } from "react-router-dom";
+import { useAuthStore } from "store/authStore";
+import { useState, useEffect } from "react";
+import { sellerService } from "services/sellerService";
+import type { SellerProfileResponseDto } from "types/SellerTypes";
+
+export const SellerHeader: React.FC = () => {
+  const { isAuthenticated, user, logout } = useAuthStore();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [sellerProfile, setSellerProfile] = useState<SellerProfileResponseDto | null>(null);
+
+  const handleLogout = () => {
+    try {
+      logout();
+    } catch (error) {
+      console.error("로그아웃 실패:", error);
+    }
+  };
+
+  const toggleMobileMenu = () => setIsMobileMenuOpen((prev) => !prev);
+
+  useEffect(() => {
+    if (isAuthenticated && user?.role === "SELLER") {
+      sellerService.getSellerProfile()
+        .then((profile) => {
+          setSellerProfile(profile);
+        })
+        .catch((error) => {
+          console.error("판매자 프로필 조회 실패:", error);
+        });
+    }
+  }, [isAuthenticated, user]);
+
+  return (
+    <header className="sticky top-0 z-40 bg-white border-b">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          {/* 로고 */}
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-primary-600 rounded flex items-center justify-center">
+              <svg
+                className="w-6 h-6 text-white"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+            <span className="text-lg font-semibold text-gray-900">
+              폰비드 판매자센터
+            </span>
+          </div>
+
+          {/* 네비게이션 */}
+          <nav className="hidden md:flex items-center space-x-6">
+            <Link
+              to="/seller-center"
+              className="text-gray-700 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium transition-colors"
+            >
+              서비스 소개
+            </Link>
+            <Link
+              to="/seller-center"
+              className="text-gray-700 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium transition-colors"
+            >
+              이용 가이드
+            </Link>
+            <Link
+              to="/seller-center"
+              className="text-gray-700 hover:text-primary-600 px-3 py-2 rounded-md text-sm font-medium transition-colors"
+            >
+              고객센터
+            </Link>
+          </nav>
+
+          {/* 사용자 메뉴 */}
+          <div className="hidden md:flex items-center space-x-4">
+            {isAuthenticated && user ? (
+              <div className="flex items-center space-x-3">
+                <div className="relative">
+                  <svg
+                    className="w-6 h-6 text-gray-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                    />
+                  </svg>
+                  <span className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full flex items-center justify-center">
+                    <span className="text-xs text-white font-bold">3</span>
+                  </span>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <div className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center">
+                    <span className="text-xs text-gray-600">
+                      {sellerProfile?.storeName?.[0] || user?.nickname?.[0] || "?"}
+                    </span>
+                  </div>
+                  <span className="text-sm text-gray-900 font-medium">
+                    {sellerProfile?.storeName || user?.nickname || "판매자"}
+                  </span>
+                  <svg
+                    className="w-4 h-4 text-gray-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center space-x-3">
+                <Link
+                  to="/seller/login"
+                  className="text-gray-700 hover:text-primary-600 text-sm font-medium"
+                >
+                  로그인
+                </Link>
+              </div>
+            )}
+          </div>
+
+          {/* 모바일 메뉴 버튼 */}
+          <div className="md:hidden">
+            <button
+              type="button"
+              onClick={toggleMobileMenu}
+              aria-label="모바일 메뉴 열기"
+              className="text-gray-700 hover:text-primary-600"
+            >
+              {isMobileMenuOpen ? (
+                <svg
+                  className="h-6 w-6"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  className="h-6 w-6"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* 모바일 드롭다운 메뉴 */}
+      {isMobileMenuOpen && (
+        <div className="md:hidden border-t bg-white">
+          <div className="px-4 py-3 space-y-2">
+            <Link
+              to="/seller-center"
+              className="block px-2 py-2 rounded-md text-gray-700 hover:bg-gray-100"
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              서비스 소개
+            </Link>
+            <Link
+              to="/seller-center"
+              className="block px-2 py-2 rounded-md text-gray-700 hover:bg-gray-100"
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              이용 가이드
+            </Link>
+            <Link
+              to="/seller-center"
+              className="block px-2 py-2 rounded-md text-gray-700 hover:bg-gray-100"
+              onClick={() => setIsMobileMenuOpen(false)}
+            >
+              고객센터
+            </Link>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+};
+

--- a/frontend/src/components/seller/StatCard.tsx
+++ b/frontend/src/components/seller/StatCard.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent } from "components/ui/card";
+import { cn } from "utils/cn";
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+  description: string;
+  icon?: React.ReactNode;
+  iconBgColor?: string;
+  className?: string;
+}
+
+export const StatCard: React.FC<StatCardProps> = ({
+  title,
+  value,
+  description,
+  icon,
+  iconBgColor = "bg-blue-100",
+  className,
+}) => {
+  return (
+    <Card className={cn("relative overflow-hidden", className)}>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <p className="text-sm font-medium text-muted-foreground">{title}</p>
+            <p className="mt-2 text-3xl font-bold text-foreground">{value}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+          </div>
+          {icon && (
+            <div className={cn("ml-4 flex-shrink-0 w-12 h-12 rounded-lg flex items-center justify-center", iconBgColor)}>
+              <div className="text-white">
+                {icon}
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+

--- a/frontend/src/hooks/useBidForm.ts
+++ b/frontend/src/hooks/useBidForm.ts
@@ -1,0 +1,162 @@
+import { useState, useMemo } from "react";
+import type { QuoteDetail } from "types/QuoteTypes";
+import type { BidCreateRequest, AdditionalServiceRequest } from "types/SellerTypes";
+import {
+  calculateInstallmentPrincipal,
+  calculateMonthlyInstallment,
+  calculateTotalMonthlyPayment,
+} from "utils/bidUtils";
+
+const DEFAULT_INSTALLMENT_MONTHS = 24;
+const DEFAULT_INSTALLMENT_INTEREST_RATE = 3.3;
+
+export interface BidFormData {
+  devicePrice: number;
+  publicSubsidy: number;
+  additionalSubsidy: number;
+  purchaseMethod: "NUMBER_TRANSFER" | "DEVICE_CHANGE" | "NEW_SUBSCRIPTION" | "LOWEST_PRICE" | "ANY";
+  carrier: "SKT" | "KT" | "LGU" | "SKT_ALD" | "KT_ALD" | "LGU_ALD" | "ANY";
+  currentCarrier?: "SKT" | "KT" | "LGU" | "SKT_ALD" | "KT_ALD" | "LGU_ALD" | "ANY";
+  activationMethod: "COMMON_SUBSIDY" | "SELECTIVE_SUBSIDY" | "ANY";
+  installmentMonths: number;
+  pricePlanName: string;
+  pricePlanPrice: number;
+  pricePlanMaintenanceMonths: number;
+  lineMaintenanceMonths: number;
+  additionalServices: AdditionalServiceRequest[];
+  additionalServicesMaintenanceMonths: number;
+  deliveryDays: number;
+}
+
+export interface BidFormErrors {
+  devicePrice?: string;
+  publicSubsidy?: string;
+  additionalSubsidy?: string;
+  pricePlanName?: string;
+  pricePlanPrice?: string;
+  deliveryDays?: string;
+}
+
+export const useBidForm = (quote: QuoteDetail | null) => {
+  const [formData, setFormData] = useState<BidFormData>({
+    devicePrice: 1231230,
+    publicSubsidy: 301000,
+    additionalSubsidy: 301000,
+    purchaseMethod: quote?.purchaseMethod || "DEVICE_CHANGE",
+    carrier: quote?.carrier || "SKT",
+    currentCarrier: quote?.currentCarrier,
+    activationMethod: quote?.activationMethod || "COMMON_SUBSIDY",
+    installmentMonths: DEFAULT_INSTALLMENT_MONTHS,
+    pricePlanName: "",
+    pricePlanPrice: 0,
+    pricePlanMaintenanceMonths: 24,
+    lineMaintenanceMonths: 24,
+    additionalServices: [],
+    additionalServicesMaintenanceMonths: 0,
+    deliveryDays: 3,
+  });
+
+  const [errors, setErrors] = useState<BidFormErrors>({});
+
+  const calculations = useMemo(() => {
+    const installmentPrincipal = calculateInstallmentPrincipal(
+      formData.devicePrice,
+      formData.publicSubsidy,
+      formData.additionalSubsidy
+    );
+
+    const monthlyInstallment = calculateMonthlyInstallment(
+      installmentPrincipal,
+      formData.installmentMonths,
+      DEFAULT_INSTALLMENT_INTEREST_RATE
+    );
+
+    const additionalServicesPrice = formData.additionalServices.reduce(
+      (sum, service) => sum + service.servicePrice,
+      0
+    );
+
+    const totalMonthlyPayment = calculateTotalMonthlyPayment(
+      monthlyInstallment,
+      formData.pricePlanPrice,
+      additionalServicesPrice
+    );
+
+    return {
+      installmentPrincipal,
+      monthlyInstallment,
+      totalMonthlyPayment,
+      additionalServicesPrice,
+    };
+  }, [formData]);
+
+  const updateField = <K extends keyof BidFormData>(
+    field: K,
+    value: BidFormData[K]
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (errors[field as keyof BidFormErrors]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  const validate = (): boolean => {
+    const newErrors: BidFormErrors = {};
+
+    if (formData.devicePrice <= 0) {
+      newErrors.devicePrice = "기기 가격을 입력해주세요.";
+    }
+
+    if (formData.publicSubsidy < 0) {
+      newErrors.publicSubsidy = "공시지원금은 0 이상이어야 합니다.";
+    }
+
+    if (formData.additionalSubsidy < 0) {
+      newErrors.additionalSubsidy = "추가지원금은 0 이상이어야 합니다.";
+    }
+
+    if (!formData.pricePlanName.trim()) {
+      newErrors.pricePlanName = "요금제를 선택해주세요.";
+    }
+
+    if (formData.pricePlanPrice <= 0) {
+      newErrors.pricePlanPrice = "요금제 가격을 입력해주세요.";
+    }
+
+    if (formData.deliveryDays < 1) {
+      newErrors.deliveryDays = "배송 예상일은 1일 이상이어야 합니다.";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const toBidCreateRequest = (): BidCreateRequest | null => {
+    if (!quote) return null;
+    return {
+      quoteId: quote.id,
+      price: formData.publicSubsidy + formData.additionalSubsidy,
+      deliveryDays: formData.deliveryDays,
+      purchaseMethod: formData.purchaseMethod,
+      carrier: formData.carrier,
+      currentCarrier: formData.currentCarrier,
+      activationMethod: formData.activationMethod,
+      additionalSubsidy: formData.additionalSubsidy > 0 ? formData.additionalSubsidy : undefined,
+      installmentPrincipal: calculations.installmentPrincipal,
+      contractMonths: formData.installmentMonths,
+      pricePlanName: formData.pricePlanName,
+      pricePlanPrice: formData.pricePlanPrice,
+      additionalServices: formData.additionalServices.length > 0 ? formData.additionalServices : undefined,
+    };
+  };
+
+  return {
+    formData,
+    errors,
+    calculations,
+    updateField,
+    validate,
+    toBidCreateRequest,
+  };
+};
+

--- a/frontend/src/hooks/useBidForm.ts
+++ b/frontend/src/hooks/useBidForm.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import type { QuoteDetail } from "types/QuoteTypes";
 import type { BidCreateRequest, AdditionalServiceRequest } from "types/SellerTypes";
 import {
@@ -6,6 +6,7 @@ import {
   calculateMonthlyInstallment,
   calculateTotalMonthlyPayment,
 } from "utils/bidUtils";
+import { BID_FORM_DEFAULTS } from "utils/constants";
 
 const DEFAULT_INSTALLMENT_MONTHS = 24;
 const DEFAULT_INSTALLMENT_INTEREST_RATE = 3.3;
@@ -39,9 +40,9 @@ export interface BidFormErrors {
 
 export const useBidForm = (quote: QuoteDetail | null) => {
   const [formData, setFormData] = useState<BidFormData>({
-    devicePrice: 1231230,
-    publicSubsidy: 301000,
-    additionalSubsidy: 301000,
+    devicePrice: BID_FORM_DEFAULTS.DEVICE_PRICE,
+    publicSubsidy: BID_FORM_DEFAULTS.PUBLIC_SUBSIDY,
+    additionalSubsidy: BID_FORM_DEFAULTS.ADDITIONAL_SUBSIDY,
     purchaseMethod: quote?.purchaseMethod || "DEVICE_CHANGE",
     carrier: quote?.carrier || "SKT",
     currentCarrier: quote?.currentCarrier,
@@ -49,14 +50,27 @@ export const useBidForm = (quote: QuoteDetail | null) => {
     installmentMonths: DEFAULT_INSTALLMENT_MONTHS,
     pricePlanName: "",
     pricePlanPrice: 0,
-    pricePlanMaintenanceMonths: 24,
-    lineMaintenanceMonths: 24,
+    pricePlanMaintenanceMonths: BID_FORM_DEFAULTS.PRICE_PLAN_MAINTENANCE_MONTHS,
+    lineMaintenanceMonths: BID_FORM_DEFAULTS.LINE_MAINTENANCE_MONTHS,
     additionalServices: [],
     additionalServicesMaintenanceMonths: 0,
-    deliveryDays: 3,
+    deliveryDays: BID_FORM_DEFAULTS.DELIVERY_DAYS,
   });
 
   const [errors, setErrors] = useState<BidFormErrors>({});
+
+  // quote 변경 시 formData 동기화
+  useEffect(() => {
+    if (quote) {
+      setFormData((prev) => ({
+        ...prev,
+        purchaseMethod: quote.purchaseMethod || prev.purchaseMethod,
+        carrier: quote.carrier || prev.carrier,
+        currentCarrier: quote.currentCarrier ?? prev.currentCarrier,
+        activationMethod: quote.activationMethod || prev.activationMethod,
+      }));
+    }
+  }, [quote]);
 
   const calculations = useMemo(() => {
     const installmentPrincipal = calculateInstallmentPrincipal(

--- a/frontend/src/hooks/useSellerDashboard.ts
+++ b/frontend/src/hooks/useSellerDashboard.ts
@@ -1,0 +1,87 @@
+import { useState, useMemo } from "react";
+import useSWR from "swr";
+import { sellerService } from "services/sellerService";
+import type { QuoteListItem } from "types/QuoteTypes";
+import type { Carrier } from "types/QuoteTypes";
+import { realtimeDataConfig } from "services/swrConfig";
+
+type FilterCarrier = Carrier | "ALL";
+type FilterBrand = "APPLE" | "SAMSUNG" | "ALL";
+type SortOption = "NEWEST" | "OLDEST" | "BID_COUNT";
+
+export const useSellerDashboard = () => {
+  const [selectedCarrier, setSelectedCarrier] = useState<FilterCarrier>("ALL");
+  const [selectedBrand, setSelectedBrand] = useState<FilterBrand>("ALL");
+  const [sortBy, setSortBy] = useState<SortOption>("NEWEST");
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
+
+  const { data: quotes, error, isLoading } = useSWR<QuoteListItem[]>(
+    "/auction/quotes",
+    async () => {
+      return await sellerService.getSellerQuotes();
+    },
+    realtimeDataConfig
+  );
+
+  const filteredAndSortedQuotes = useMemo(() => {
+    if (!quotes) return [];
+
+    let filtered = [...quotes];
+
+    if (selectedCarrier !== "ALL") {
+      filtered = filtered.filter((quote) => quote.carrier === selectedCarrier);
+    }
+
+    if (selectedBrand !== "ALL") {
+      filtered = filtered.filter(
+        (quote) => quote.phoneModel.brand === selectedBrand
+      );
+    }
+
+    filtered.sort((a, b) => {
+      switch (sortBy) {
+        case "NEWEST":
+          return (
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          );
+        case "OLDEST":
+          return (
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+          );
+        case "BID_COUNT":
+          return (b.bidCount || 0) - (a.bidCount || 0);
+        default:
+          return 0;
+      }
+    });
+
+    return filtered;
+  }, [quotes, selectedCarrier, selectedBrand, sortBy]);
+
+  const paginatedQuotes = useMemo(() => {
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+    return filteredAndSortedQuotes.slice(startIndex, endIndex);
+  }, [filteredAndSortedQuotes, currentPage]);
+
+  const totalPages = Math.ceil(filteredAndSortedQuotes.length / itemsPerPage);
+
+  return {
+    quotes: paginatedQuotes,
+    filteredQuotes: filteredAndSortedQuotes,
+    isLoading,
+    error,
+    selectedCarrier,
+    selectedBrand,
+    sortBy,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    setSelectedCarrier,
+    setSelectedBrand,
+    setSortBy,
+    setCurrentPage,
+  };
+};
+

--- a/frontend/src/pages/seller/SellerBidCreatePage.tsx
+++ b/frontend/src/pages/seller/SellerBidCreatePage.tsx
@@ -1,0 +1,459 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useBidForm } from "hooks/useBidForm";
+import { QuoteRequestInfo } from "components/seller/QuoteRequestInfo";
+import { getQuoteDetail } from "services/quoteService";
+import { sellerService } from "services/sellerService";
+import { Card, CardContent, CardHeader, CardTitle } from "components/ui/card";
+import { Button } from "components/ui/button";
+import { formatPrice } from "utils/quoteUtils";
+import { formatNumber } from "utils/formatters";
+import { logError } from "utils/errorUtils";
+import { toast } from "react-toastify";
+import type { QuoteDetail } from "types/QuoteTypes";
+
+const SellerBidCreatePage: React.FC = () => {
+  const navigate = useNavigate();
+  const { quoteId } = useParams<{ quoteId: string }>();
+  const [quote, setQuote] = useState<QuoteDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const bidForm = useBidForm(quote);
+
+  useEffect(() => {
+    if (!quoteId) {
+      navigate("/seller-center");
+      return;
+    }
+
+    const loadQuote = async () => {
+      try {
+        setIsLoading(true);
+        const quoteData = await getQuoteDetail(quoteId);
+        setQuote(quoteData);
+      } catch (error) {
+        logError("견적 조회 실패:", error);
+        toast.error("견적 정보를 불러오는데 실패했습니다.");
+        navigate("/seller-center");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadQuote();
+  }, [quoteId, navigate]);
+
+  const handleBack = () => {
+    navigate("/seller-center");
+  };
+
+  const handleSubmit = async () => {
+    if (!bidForm.validate()) {
+      toast.error("입력한 정보를 확인해주세요.");
+      return;
+    }
+
+    const bidRequest = bidForm.toBidCreateRequest();
+    if (!bidRequest) {
+      toast.error("견적 정보를 불러오지 못했습니다.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await sellerService.createBid(bidRequest);
+      toast.success("견적이 성공적으로 전송되었습니다.");
+      navigate("/seller-center");
+    } catch (error) {
+      logError("견적 전송 실패:", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading || !quote) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-muted-foreground">로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-6">
+          <Button
+            variant="ghost"
+            onClick={handleBack}
+            className="mb-4"
+          >
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            요청 목록으로 돌아가기
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-1">
+            <QuoteRequestInfo quote={quote} />
+          </div>
+
+          <div className="lg:col-span-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>견적 작성</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-4">
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      기기 가격 출고가
+                    </label>
+                    <div className="mt-1 text-lg font-semibold">
+                      {formatNumber(bidForm.formData.devicePrice)}원
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      공시지원금
+                    </label>
+                    <input
+                      type="number"
+                      value={bidForm.formData.publicSubsidy}
+                      onChange={(e) =>
+                        bidForm.updateField(
+                          "publicSubsidy",
+                          parseInt(e.target.value) || 0
+                        )
+                      }
+                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                    {bidForm.errors.publicSubsidy && (
+                      <p className="mt-1 text-sm text-red-500">
+                        {bidForm.errors.publicSubsidy}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      추가지원금
+                    </label>
+                    <input
+                      type="number"
+                      value={bidForm.formData.additionalSubsidy}
+                      onChange={(e) =>
+                        bidForm.updateField(
+                          "additionalSubsidy",
+                          parseInt(e.target.value) || 0
+                        )
+                      }
+                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                    {bidForm.errors.additionalSubsidy && (
+                      <p className="mt-1 text-sm text-red-500">
+                        {bidForm.errors.additionalSubsidy}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      할부원금
+                    </label>
+                    <div className="mt-1 text-lg font-semibold">
+                      {formatNumber(bidForm.calculations.installmentPrincipal)}원
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-4 pt-4 border-t">
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      개통 조건
+                    </label>
+                    <select
+                      value={bidForm.formData.purchaseMethod}
+                      onChange={(e) =>
+                        bidForm.updateField(
+                          "purchaseMethod",
+                          e.target.value as any
+                        )
+                      }
+                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value="DEVICE_CHANGE">기기변경</option>
+                      <option value="NUMBER_TRANSFER">번호이동</option>
+                      <option value="NEW_SUBSCRIPTION">신규가입</option>
+                    </select>
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      할부 조건
+                    </label>
+                    <select
+                      value={bidForm.formData.installmentMonths}
+                      onChange={(e) =>
+                        bidForm.updateField(
+                          "installmentMonths",
+                          parseInt(e.target.value) || 24
+                        )
+                      }
+                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value={24}>24개월</option>
+                      <option value={36}>36개월</option>
+                    </select>
+                  </div>
+                </div>
+
+                <Card className="bg-primary-50 border-primary-200">
+                  <CardContent className="p-4">
+                    <div className="text-sm text-muted-foreground mb-1">
+                      월 할부금
+                    </div>
+                    <div className="text-2xl font-bold text-primary-600">
+                      {formatNumber(bidForm.calculations.monthlyInstallment)}원
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1">
+                      3.3% 할부이자 포함
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <div className="space-y-4 pt-4 border-t">
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      요금제 선택
+                    </label>
+                    <input
+                      type="text"
+                      value={bidForm.formData.pricePlanName}
+                      onChange={(e) =>
+                        bidForm.updateField("pricePlanName", e.target.value)
+                      }
+                      placeholder="예: 5G 프리미어 에센셜"
+                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                    {bidForm.errors.pricePlanName && (
+                      <p className="mt-1 text-sm text-red-500">
+                        {bidForm.errors.pricePlanName}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      요금제 가격
+                    </label>
+                    <input
+                      type="number"
+                      value={bidForm.formData.pricePlanPrice}
+                      onChange={(e) =>
+                        bidForm.updateField(
+                          "pricePlanPrice",
+                          parseInt(e.target.value) || 0
+                        )
+                      }
+                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                    {bidForm.errors.pricePlanPrice && (
+                      <p className="mt-1 text-sm text-red-500">
+                        {bidForm.errors.pricePlanPrice}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      요금제 유지기간
+                    </label>
+                    <select
+                      value={bidForm.formData.pricePlanMaintenanceMonths}
+                      onChange={(e) =>
+                        bidForm.updateField(
+                          "pricePlanMaintenanceMonths",
+                          parseInt(e.target.value) || 24
+                        )
+                      }
+                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value={24}>24개월 이상</option>
+                      <option value={36}>36개월 이상</option>
+                    </select>
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-foreground">
+                      회선 유지기간
+                    </label>
+                    <select
+                      value={bidForm.formData.lineMaintenanceMonths}
+                      onChange={(e) =>
+                        bidForm.updateField(
+                          "lineMaintenanceMonths",
+                          parseInt(e.target.value) || 24
+                        )
+                      }
+                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value={24}>24개월 이상</option>
+                      <option value={36}>36개월 이상</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div className="space-y-4 pt-4 border-t">
+                  <div>
+                    <label className="text-sm font-medium text-foreground mb-2 block">
+                      부가서비스
+                    </label>
+                    <div className="space-y-2">
+                      <label className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="w-4 h-4"
+                          checked={bidForm.formData.additionalServices.some(
+                            (s) => s.serviceName === "T멤버십 VIP"
+                          )}
+                          onChange={(e) => {
+                            const services = [...bidForm.formData.additionalServices];
+                            if (e.target.checked) {
+                              services.push({
+                                serviceName: "T멤버십 VIP",
+                                servicePrice: 5000,
+                              });
+                            } else {
+                              const index = services.findIndex(
+                                (s) => s.serviceName === "T멤버십 VIP"
+                              );
+                              if (index > -1) services.splice(index, 1);
+                            }
+                            bidForm.updateField("additionalServices", services);
+                          }}
+                        />
+                        <span className="text-sm">
+                          T멤버십 VIP (월 5,000원)
+                        </span>
+                      </label>
+                      <label className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="w-4 h-4"
+                          checked={bidForm.formData.additionalServices.some(
+                            (s) => s.serviceName === "디바이스 케어"
+                          )}
+                          onChange={(e) => {
+                            const services = [...bidForm.formData.additionalServices];
+                            if (e.target.checked) {
+                              services.push({
+                                serviceName: "디바이스 케어",
+                                servicePrice: 11000,
+                              });
+                            } else {
+                              const index = services.findIndex(
+                                (s) => s.serviceName === "디바이스 케어"
+                              );
+                              if (index > -1) services.splice(index, 1);
+                            }
+                            bidForm.updateField("additionalServices", services);
+                          }}
+                        />
+                        <span className="text-sm">
+                          디바이스 케어 (월 11,000원)
+                        </span>
+                      </label>
+                      <label className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="w-4 h-4"
+                          checked={bidForm.formData.additionalServices.some(
+                            (s) => s.serviceName === "T우주 Pass"
+                          )}
+                          onChange={(e) => {
+                            const services = [...bidForm.formData.additionalServices];
+                            if (e.target.checked) {
+                              services.push({
+                                serviceName: "T우주 Pass",
+                                servicePrice: 13000,
+                              });
+                            } else {
+                              const index = services.findIndex(
+                                (s) => s.serviceName === "T우주 Pass"
+                              );
+                              if (index > -1) services.splice(index, 1);
+                            }
+                            bidForm.updateField("additionalServices", services);
+                          }}
+                        />
+                        <span className="text-sm">
+                          T우주 Pass (월 13,000원)
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+
+                <Card className="bg-purple-50 border-purple-200">
+                  <CardContent className="p-4">
+                    <div className="text-sm text-muted-foreground mb-1">
+                      (할부금 + 요금제)
+                    </div>
+                    <div className="text-2xl font-bold text-purple-600">
+                      {formatNumber(bidForm.calculations.totalMonthlyPayment)}원
+                    </div>
+                    <div className="text-sm font-medium text-foreground mt-1">
+                      월 예상 납부액
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <div className="pt-4">
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={isSubmitting}
+                    className="w-full bg-primary-600 hover:bg-primary-700 text-white"
+                    size="lg"
+                  >
+                    <svg
+                      className="w-5 h-5 mr-2"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
+                      />
+                    </svg>
+                    견적 보내기
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SellerBidCreatePage;
+

--- a/frontend/src/pages/seller/SellerBidCreatePage.tsx
+++ b/frontend/src/pages/seller/SellerBidCreatePage.tsx
@@ -6,7 +6,6 @@ import { getQuoteDetail } from "services/quoteService";
 import { sellerService } from "services/sellerService";
 import { Card, CardContent, CardHeader, CardTitle } from "components/ui/card";
 import { Button } from "components/ui/button";
-import { formatPrice } from "utils/quoteUtils";
 import { formatNumber } from "utils/formatters";
 import { logError } from "utils/errorUtils";
 import { toast } from "react-toastify";
@@ -84,13 +83,12 @@ const SellerBidCreatePage: React.FC = () => {
     <div className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="mb-6">
-          <Button
-            variant="ghost"
+          <button
             onClick={handleBack}
-            className="mb-4"
+            className="flex items-center gap-2 text-foreground hover:text-primary transition-colors mb-4 group"
           >
             <svg
-              className="w-5 h-5 mr-2"
+              className="w-5 h-5 transition-transform group-hover:-translate-x-1"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -102,8 +100,8 @@ const SellerBidCreatePage: React.FC = () => {
                 d="M15 19l-7-7 7-7"
               />
             </svg>
-            요청 목록으로 돌아가기
-          </Button>
+            <span className="text-sm font-medium">요청 목록으로 돌아가기</span>
+          </button>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -118,114 +116,160 @@ const SellerBidCreatePage: React.FC = () => {
               </CardHeader>
               <CardContent className="space-y-6">
                 <div className="space-y-4">
-                  <div>
+                  <div className="flex items-center gap-2">
                     <label className="text-sm font-medium text-foreground">
                       기기 가격 출고가
                     </label>
-                    <div className="mt-1 text-lg font-semibold">
+                    <div className="text-lg font-semibold">
                       {formatNumber(bidForm.formData.devicePrice)}원
                     </div>
                   </div>
 
-                  <div>
-                    <label className="text-sm font-medium text-foreground">
-                      공시지원금
-                    </label>
-                    <input
-                      type="number"
-                      value={bidForm.formData.publicSubsidy}
-                      onChange={(e) =>
-                        bidForm.updateField(
-                          "publicSubsidy",
-                          parseInt(e.target.value) || 0
-                        )
-                      }
-                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                    {bidForm.errors.publicSubsidy && (
-                      <p className="mt-1 text-sm text-red-500">
-                        {bidForm.errors.publicSubsidy}
-                      </p>
-                    )}
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="text-sm font-medium text-foreground">
+                        공시지원금
+                      </label>
+                      <div className="relative mt-1">
+                        <input
+                          type="text"
+                          value={
+                            bidForm.formData.publicSubsidy > 0
+                              ? formatNumber(bidForm.formData.publicSubsidy)
+                              : ""
+                          }
+                          onChange={(e) => {
+                            const numericValue = e.target.value.replace(/[^0-9]/g, "");
+                            bidForm.updateField(
+                              "publicSubsidy",
+                              parseInt(numericValue) || 0
+                            );
+                          }}
+                          className="w-full border border-input rounded-md h-10 px-3 pr-8 bg-background text-sm text-blue-600 font-medium text-right focus:outline-none focus:ring-2 focus:ring-ring"
+                          placeholder="0"
+                        />
+                        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-blue-600 font-medium pointer-events-none">
+                          원
+                        </span>
+                      </div>
+                      {bidForm.errors.publicSubsidy && (
+                        <p className="mt-1 text-sm text-red-500">
+                          {bidForm.errors.publicSubsidy}
+                        </p>
+                      )}
+                    </div>
+
+                    <div>
+                      <label className="text-sm font-medium text-foreground">
+                        추가지원금
+                      </label>
+                      <div className="relative mt-1">
+                        <input
+                          type="text"
+                          value={
+                            bidForm.formData.additionalSubsidy > 0
+                              ? formatNumber(bidForm.formData.additionalSubsidy)
+                              : ""
+                          }
+                          onChange={(e) => {
+                            const numericValue = e.target.value.replace(/[^0-9]/g, "");
+                            bidForm.updateField(
+                              "additionalSubsidy",
+                              parseInt(numericValue) || 0
+                            );
+                          }}
+                          className="w-full border border-input rounded-md h-10 px-3 pr-8 bg-background text-sm text-blue-600 font-medium text-right focus:outline-none focus:ring-2 focus:ring-ring"
+                          placeholder="0"
+                        />
+                        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-blue-600 font-medium pointer-events-none">
+                          원
+                        </span>
+                      </div>
+                      {bidForm.errors.additionalSubsidy && (
+                        <p className="mt-1 text-sm text-red-500">
+                          {bidForm.errors.additionalSubsidy}
+                        </p>
+                      )}
+                    </div>
                   </div>
 
-                  <div>
-                    <label className="text-sm font-medium text-foreground">
-                      추가지원금
-                    </label>
-                    <input
-                      type="number"
-                      value={bidForm.formData.additionalSubsidy}
-                      onChange={(e) =>
-                        bidForm.updateField(
-                          "additionalSubsidy",
-                          parseInt(e.target.value) || 0
-                        )
-                      }
-                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                    {bidForm.errors.additionalSubsidy && (
-                      <p className="mt-1 text-sm text-red-500">
-                        {bidForm.errors.additionalSubsidy}
-                      </p>
-                    )}
-                  </div>
-
-                  <div>
-                    <label className="text-sm font-medium text-foreground">
-                      할부원금
-                    </label>
-                    <div className="mt-1 text-lg font-semibold">
-                      {formatNumber(bidForm.calculations.installmentPrincipal)}원
+                  <div className="bg-gray-50 rounded-md p-4">
+                    <div className="flex items-center justify-between">
+                      <label className="text-sm font-medium text-foreground">
+                        할부원금
+                      </label>
+                      <div className="text-lg font-bold text-foreground">
+                        {formatNumber(bidForm.calculations.installmentPrincipal)}원
+                      </div>
                     </div>
                   </div>
                 </div>
 
-                <div className="space-y-4 pt-4 border-t">
-                  <div>
-                    <label className="text-sm font-medium text-foreground">
-                      개통 조건
-                    </label>
-                    <select
-                      value={bidForm.formData.purchaseMethod}
-                      onChange={(e) =>
-                        bidForm.updateField(
-                          "purchaseMethod",
-                          e.target.value as any
-                        )
-                      }
-                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                    >
-                      <option value="DEVICE_CHANGE">기기변경</option>
-                      <option value="NUMBER_TRANSFER">번호이동</option>
-                      <option value="NEW_SUBSCRIPTION">신규가입</option>
-                    </select>
-                  </div>
+                <div className="pt-4 border-t">
+                  <h3 className="text-base font-semibold text-foreground mb-4">
+                    개통 및 할부 조건
+                  </h3>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="text-sm font-medium text-foreground">
+                        개통 조건
+                      </label>
+                      <select
+                        value={bidForm.formData.purchaseMethod}
+                        onChange={(e) =>
+                          bidForm.updateField(
+                            "purchaseMethod",
+                            e.target.value as any
+                          )
+                        }
+                        className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        <option value="DEVICE_CHANGE">기기변경</option>
+                        <option value="NUMBER_TRANSFER">번호이동</option>
+                        <option value="NEW_SUBSCRIPTION">신규가입</option>
+                      </select>
+                    </div>
 
-                  <div>
-                    <label className="text-sm font-medium text-foreground">
-                      할부 조건
-                    </label>
-                    <select
-                      value={bidForm.formData.installmentMonths}
-                      onChange={(e) =>
-                        bidForm.updateField(
-                          "installmentMonths",
-                          parseInt(e.target.value) || 24
-                        )
-                      }
-                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                    >
-                      <option value={24}>24개월</option>
-                      <option value={36}>36개월</option>
-                    </select>
+                    <div>
+                      <label className="text-sm font-medium text-foreground">
+                        할부 조건
+                      </label>
+                      <select
+                        value={bidForm.formData.installmentMonths}
+                        onChange={(e) =>
+                          bidForm.updateField(
+                            "installmentMonths",
+                            parseInt(e.target.value) || 24
+                          )
+                        }
+                        className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        <option value={24}>24개월</option>
+                        <option value={36}>36개월</option>
+                      </select>
+                    </div>
                   </div>
                 </div>
 
                 <Card className="bg-primary-50 border-primary-200">
-                  <CardContent className="p-4">
-                    <div className="text-sm text-muted-foreground mb-1">
-                      월 할부금
+                  <CardContent className="py-2 px-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <svg
+                        className="w-5 h-5 text-primary-600"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"
+                        />
+                      </svg>
+                      <div className="text-sm font-medium text-foreground">
+                        월 할부금
+                      </div>
                     </div>
                     <div className="text-2xl font-bold text-primary-600">
                       {formatNumber(bidForm.calculations.monthlyInstallment)}원
@@ -262,14 +306,20 @@ const SellerBidCreatePage: React.FC = () => {
                       요금제 가격
                     </label>
                     <input
-                      type="number"
-                      value={bidForm.formData.pricePlanPrice}
-                      onChange={(e) =>
+                      type="text"
+                      value={
+                        bidForm.formData.pricePlanPrice > 0
+                          ? formatNumber(bidForm.formData.pricePlanPrice)
+                          : ""
+                      }
+                      onChange={(e) => {
+                        const numericValue = e.target.value.replace(/[^0-9]/g, "");
                         bidForm.updateField(
                           "pricePlanPrice",
-                          parseInt(e.target.value) || 0
-                        )
-                      }
+                          parseInt(numericValue) || 0
+                        );
+                      }}
+                      placeholder="0"
                       className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                     {bidForm.errors.pricePlanPrice && (
@@ -279,52 +329,54 @@ const SellerBidCreatePage: React.FC = () => {
                     )}
                   </div>
 
-                  <div>
-                    <label className="text-sm font-medium text-foreground">
-                      요금제 유지기간
-                    </label>
-                    <select
-                      value={bidForm.formData.pricePlanMaintenanceMonths}
-                      onChange={(e) =>
-                        bidForm.updateField(
-                          "pricePlanMaintenanceMonths",
-                          parseInt(e.target.value) || 24
-                        )
-                      }
-                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                    >
-                      <option value={24}>24개월 이상</option>
-                      <option value={36}>36개월 이상</option>
-                    </select>
-                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="text-sm font-medium text-foreground">
+                        요금제 유지기간
+                      </label>
+                      <select
+                        value={bidForm.formData.pricePlanMaintenanceMonths}
+                        onChange={(e) =>
+                          bidForm.updateField(
+                            "pricePlanMaintenanceMonths",
+                            parseInt(e.target.value) || 24
+                          )
+                        }
+                        className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        <option value={24}>24개월 이상</option>
+                        <option value={36}>36개월 이상</option>
+                      </select>
+                    </div>
 
-                  <div>
-                    <label className="text-sm font-medium text-foreground">
-                      회선 유지기간
-                    </label>
-                    <select
-                      value={bidForm.formData.lineMaintenanceMonths}
-                      onChange={(e) =>
-                        bidForm.updateField(
-                          "lineMaintenanceMonths",
-                          parseInt(e.target.value) || 24
-                        )
-                      }
-                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                    >
-                      <option value={24}>24개월 이상</option>
-                      <option value={36}>36개월 이상</option>
-                    </select>
+                    <div>
+                      <label className="text-sm font-medium text-foreground">
+                        회선 유지기간
+                      </label>
+                      <select
+                        value={bidForm.formData.lineMaintenanceMonths}
+                        onChange={(e) =>
+                          bidForm.updateField(
+                            "lineMaintenanceMonths",
+                            parseInt(e.target.value) || 24
+                          )
+                        }
+                        className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        <option value={24}>24개월 이상</option>
+                        <option value={36}>36개월 이상</option>
+                      </select>
+                    </div>
                   </div>
                 </div>
 
                 <div className="space-y-4 pt-4 border-t">
                   <div>
-                    <label className="text-sm font-medium text-foreground mb-2 block">
+                    <label className="text-sm font-bold text-foreground mb-4 block">
                       부가서비스
                     </label>
                     <div className="space-y-2">
-                      <label className="flex items-center gap-2">
+                      <label className="flex items-center gap-2 border border-gray-200 rounded-md p-3 cursor-pointer hover:bg-gray-50 transition-colors">
                         <input
                           type="checkbox"
                           className="w-4 h-4"
@@ -351,7 +403,7 @@ const SellerBidCreatePage: React.FC = () => {
                           T멤버십 VIP (월 5,000원)
                         </span>
                       </label>
-                      <label className="flex items-center gap-2">
+                      <label className="flex items-center gap-2 border border-gray-200 rounded-md p-3 cursor-pointer hover:bg-gray-50 transition-colors">
                         <input
                           type="checkbox"
                           className="w-4 h-4"
@@ -378,7 +430,7 @@ const SellerBidCreatePage: React.FC = () => {
                           디바이스 케어 (월 11,000원)
                         </span>
                       </label>
-                      <label className="flex items-center gap-2">
+                      <label className="flex items-center gap-2 border border-gray-200 rounded-md p-3 cursor-pointer hover:bg-gray-50 transition-colors">
                         <input
                           type="checkbox"
                           className="w-4 h-4"
@@ -406,29 +458,67 @@ const SellerBidCreatePage: React.FC = () => {
                         </span>
                       </label>
                     </div>
+                    <div className="mt-4">
+                      <label className="text-xs text-muted-foreground">
+                        부가서비스 유지기간
+                      </label>
+                      <select
+                        value={bidForm.formData.additionalServicesMaintenanceMonths}
+                        onChange={(e) =>
+                          bidForm.updateField(
+                            "additionalServicesMaintenanceMonths",
+                            parseInt(e.target.value) || 0
+                          )
+                        }
+                        className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        <option value={0}>선택 안함</option>
+                        <option value={24}>24개월 이상</option>
+                        <option value={36}>36개월 이상</option>
+                      </select>
+                    </div>
                   </div>
+                  <div className="border-t my-4"></div>
                 </div>
 
-                <Card className="bg-purple-50 border-purple-200">
-                  <CardContent className="p-4">
-                    <div className="text-sm text-muted-foreground mb-1">
-                      (할부금 + 요금제)
-                    </div>
-                    <div className="text-2xl font-bold text-purple-600">
-                      {formatNumber(bidForm.calculations.totalMonthlyPayment)}원
-                    </div>
-                    <div className="text-sm font-medium text-foreground mt-1">
-                      월 예상 납부액
-                    </div>
-                  </CardContent>
-                </Card>
+                <div>
+                  <Card className="border-pink-200 shadow-sm overflow-hidden" style={{ background: 'linear-gradient(to bottom right, #eff6ff, #e0f2fe, #fce7f3)' }}>
+                    <CardContent className="py-3 px-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="text-sm font-medium text-foreground">
+                          월 예상 납부액
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          (할부금 + 요금제)
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <div className="text-3xl font-bold text-foreground">
+                          {formatNumber(bidForm.calculations.totalMonthlyPayment)}
+                          <span className="text-xl font-normal ml-1">원</span>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </div>
 
-                <div className="pt-4">
+                <div className="pt-2">
                   <Button
                     onClick={handleSubmit}
                     disabled={isSubmitting}
-                    className="w-full bg-primary-600 hover:bg-primary-700 text-white"
+                    className="w-full text-white shadow-lg transition-all font-bold"
+                    style={{ background: 'linear-gradient(to right, #60a5fa, #3b82f6, #2563eb)' }}
                     size="lg"
+                    onMouseEnter={(e) => {
+                      if (!isSubmitting) {
+                        e.currentTarget.style.background = 'linear-gradient(to right, #3b82f6, #2563eb, #1d4ed8)';
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      if (!isSubmitting) {
+                        e.currentTarget.style.background = 'linear-gradient(to right, #60a5fa, #3b82f6, #2563eb)';
+                      }
+                    }}
                   >
                     <svg
                       className="w-5 h-5 mr-2"
@@ -440,7 +530,7 @@ const SellerBidCreatePage: React.FC = () => {
                         strokeLinecap="round"
                         strokeLinejoin="round"
                         strokeWidth={2}
-                        d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
+                        d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
                       />
                     </svg>
                     견적 보내기

--- a/frontend/src/pages/seller/SellerDashboardPage.tsx
+++ b/frontend/src/pages/seller/SellerDashboardPage.tsx
@@ -1,0 +1,307 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { SellerHeader } from "components/seller/SellerHeader";
+import { StatCard } from "components/seller/StatCard";
+import { QuoteFilterBar } from "components/seller/QuoteFilterBar";
+import { QuoteRequestCard } from "components/seller/QuoteRequestCard";
+import { useSellerDashboard } from "hooks/useSellerDashboard";
+import { Card, CardContent, CardHeader, CardTitle } from "components/ui/card";
+
+const SellerDashboardPage: React.FC = () => {
+  const navigate = useNavigate();
+  const {
+    quotes,
+    isLoading,
+    error,
+    selectedCarrier,
+    selectedBrand,
+    sortBy,
+    currentPage,
+    totalPages,
+    setSelectedCarrier,
+    setSelectedBrand,
+    setSortBy,
+    setCurrentPage,
+  } = useSellerDashboard();
+
+  useEffect(() => {
+    document.title = "판매자 대시보드 | PhoneBid";
+  }, []);
+
+  const handleQuoteClick = (quoteId: string) => {
+    navigate(`/seller-center/quotes/${quoteId}/bid`);
+  };
+
+  // 최근 24시간 내에 생성된 요청을 "새로운 요청"으로 카운트
+  const newRequestCount = quotes.filter((quote) => {
+    const createdAt = new Date(quote.createdAt);
+    const now = new Date();
+    const diffInHours = (now.getTime() - createdAt.getTime()) / (1000 * 60 * 60);
+    return diffInHours <= 24;
+  }).length;
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <SellerHeader />
+      <div className="flex-1 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            대시보드
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            실시간 견적 요청을 확인하고 관리하세요
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+          <StatCard
+            title="발송 수"
+            value={89}
+            description="기존에 발송한 총 견적"
+            iconBgColor="bg-blue-500"
+            icon={
+              <svg
+                className="w-6 h-6"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
+              </svg>
+            }
+          />
+          <StatCard
+            title="거래중"
+            value={34}
+            description="진행 중인 거래"
+            iconBgColor="bg-orange-500"
+            icon={
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M7 16.5V19m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11"
+                />
+              </svg>
+            }
+          />
+          <StatCard
+            title="거래완료"
+            value={124}
+            description="완료된 거래"
+            iconBgColor="bg-green-500"
+            icon={
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            }
+          />
+        </div>
+
+        <QuoteFilterBar
+          selectedCarrier={selectedCarrier}
+          selectedBrand={selectedBrand}
+          sortBy={sortBy}
+          onCarrierChange={setSelectedCarrier}
+          onBrandChange={(brand) => setSelectedBrand(brand as "APPLE" | "SAMSUNG" | "ALL")}
+          onSortChange={setSortBy}
+        />
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle>실시간 견적 요청</CardTitle>
+              <span className="text-sm text-foreground">
+                새로운 요청 <span className="text-blue-600">{newRequestCount}</span>개
+              </span>
+            </div>
+          </CardHeader>
+          <CardContent className="p-0">
+            {isLoading ? (
+              <div className="flex justify-center items-center py-12">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+                <span className="ml-2 text-muted-foreground">로딩 중...</span>
+              </div>
+            ) : error ? (
+              <div className="text-center py-12">
+                <div className="text-red-500 mb-2">
+                  ⚠️ 데이터를 불러오는데 실패했습니다
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  잠시 후 다시 시도해주세요.
+                </p>
+              </div>
+            ) : quotes.length === 0 ? (
+              <div className="text-center py-12">
+                <div className="text-muted-foreground mb-2">
+                  📱 등록된 견적이 없습니다
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  새로운 견적 요청을 기다려주세요.
+                </p>
+              </div>
+            ) : (
+              <>
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b bg-muted/50">
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          제조사
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          기종
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          용량/색상
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          통신사
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          개통유형
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          이동 통신사
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          요청 시간
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          입찰 건수
+                        </th>
+                        <th className="px-4 py-3 text-left text-sm font-medium text-muted-foreground">
+                          상태
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {quotes.map((quote) => (
+                        <QuoteRequestCard
+                          key={quote.id}
+                          quote={quote}
+                          onClick={() => handleQuoteClick(quote.id)}
+                        />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {totalPages > 1 && (
+                  <div className="flex items-center justify-center gap-2 px-4 py-4 border-t">
+                    <button
+                      onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                      disabled={currentPage === 1}
+                      className="flex items-center justify-center w-8 h-8 rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 19l-7-7 7-7"
+                        />
+                      </svg>
+                    </button>
+                    {Array.from({ length: totalPages }, (_, i) => i + 1).map(
+                      (page) => (
+                        <button
+                          key={page}
+                          onClick={() => setCurrentPage(page)}
+                          className={`flex items-center justify-center w-8 h-8 rounded text-sm font-medium transition-colors ${
+                            currentPage === page
+                              ? "bg-blue-600 text-white"
+                              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                          }`}
+                        >
+                          {page}
+                        </button>
+                      )
+                    )}
+                    <button
+                      onClick={() =>
+                        setCurrentPage((prev) => Math.min(totalPages, prev + 1))
+                      }
+                      disabled={currentPage === totalPages}
+                      className="flex items-center justify-center w-8 h-8 rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <footer className="border-t border-gray-200 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+            <p className="text-sm text-gray-600">
+              © 2026 PhoneQuote. All rights reserved.
+            </p>
+            <div className="flex items-center gap-6">
+              <a
+                href="/terms"
+                className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                이용약관
+              </a>
+              <a
+                href="/privacy"
+                className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                개인정보처리방침
+              </a>
+              <a
+                href="/customer-service"
+                className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                고객센터
+              </a>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default SellerDashboardPage;
+

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -1,12 +1,18 @@
-import axios, { AxiosInstance, AxiosResponse } from "axios";
+import axios, { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import { toast } from "react-toastify";
 import type { ApiResponse } from "types/ApiTypes";
 import { ApiErrorClass } from "types/ApiTypes";
 import { getApiBaseUrl, getApiTimeout, API_CONSTANTS } from "utils/apiUtils";
 import { useAuthStore } from "store/authStore";
+import { refreshAccessToken } from "services/authService";
 
 class ApiClient {
   private client: AxiosInstance;
+  private isRefreshing = false;
+  private failedQueue: Array<{
+    resolve: (value?: unknown) => void;
+    reject: (error?: unknown) => void;
+  }> = [];
 
   constructor() {
     const baseURL = getApiBaseUrl();
@@ -43,28 +49,85 @@ class ApiClient {
     // Response interceptor for error handling
     this.client.interceptors.response.use(
       (response: AxiosResponse<ApiResponse<unknown>>) => response,
-      (error) => {
+      async (error) => {
         const errorMessage =
           error.response?.data?.message || "알 수 없는 오류가 발생했습니다.";
         const errorCode = error.response?.status || 500;
         const requestUrl = error.config?.url || "";
+        const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
 
         console.error("API Error:", error);
 
-        // 토큰 관련 에러 처리 (401, 403)
-        if (errorCode === 401 || errorCode === 403) {
-          // 인증 확인용 요청(/mypage/profile)이거나 이미 로그인 페이지에 있으면 forceLogout 호출 안 함
+        // 401 에러 처리 (토큰 갱신 시도)
+        if (errorCode === 401 && originalRequest && !originalRequest._retry) {
+          // Refresh Token 갱신 요청은 인터셉터 제외
+          if (requestUrl.includes("/auth/refresh")) {
+            const { forceLogout } = useAuthStore.getState();
+            toast.error("세션이 만료되었습니다. 다시 로그인해주세요.");
+            forceLogout();
+            return Promise.reject(new ApiErrorClass(errorCode, "인증이 필요합니다."));
+          }
+
+          // 이미 갱신 중이면 대기
+          if (this.isRefreshing) {
+            return new Promise((resolve, reject) => {
+              this.failedQueue.push({ resolve, reject });
+            })
+              .then(() => {
+                return this.client(originalRequest);
+              })
+              .catch((err) => {
+                return Promise.reject(err);
+              });
+          }
+
+          originalRequest._retry = true;
+          this.isRefreshing = true;
+
+          try {
+            // Refresh Token으로 Access Token 갱신
+            await refreshAccessToken();
+            
+            // 대기 중인 요청들 재시도
+            this.processQueue(null);
+            
+            // 원래 요청 재시도
+            return this.client(originalRequest);
+          } catch (refreshError) {
+            // 갱신 실패 시 대기 중인 요청들 모두 실패 처리
+            this.processQueue(refreshError);
+            
+            // 인증 확인용 요청(/mypage/profile)이거나 이미 로그인 페이지에 있으면 forceLogout 호출 안 함
+            const isAuthCheckRequest = requestUrl.includes("/mypage/profile");
+            const isOnLoginPage = window.location.pathname === "/login";
+
+            if (!isAuthCheckRequest && !isOnLoginPage) {
+              const { forceLogout } = useAuthStore.getState();
+              toast.error("세션이 만료되었습니다. 다시 로그인해주세요.");
+              forceLogout();
+            }
+
+            return Promise.reject(
+              new ApiErrorClass(errorCode, "인증이 필요합니다.")
+            );
+          } finally {
+            this.isRefreshing = false;
+          }
+        }
+
+        // 403 에러 처리
+        if (errorCode === 403) {
           const isAuthCheckRequest = requestUrl.includes("/mypage/profile");
           const isOnLoginPage = window.location.pathname === "/login";
 
           if (!isAuthCheckRequest && !isOnLoginPage) {
             const { forceLogout } = useAuthStore.getState();
-            toast.error("세션이 만료되었습니다. 다시 로그인해주세요.");
+            toast.error("권한이 없습니다.");
             forceLogout();
           }
 
           return Promise.reject(
-            new ApiErrorClass(errorCode, "인증이 필요합니다.")
+            new ApiErrorClass(errorCode, "권한이 없습니다.")
           );
         }
 
@@ -72,6 +135,17 @@ class ApiClient {
         return Promise.reject(new ApiErrorClass(errorCode, errorMessage));
       }
     );
+  }
+
+  private processQueue(error: unknown) {
+    this.failedQueue.forEach((prom) => {
+      if (error) {
+        prom.reject(error);
+      } else {
+        prom.resolve(undefined);
+      }
+    });
+    this.failedQueue = [];
   }
 
   async get<T>(url: string): Promise<T> {

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -28,15 +28,10 @@ class ApiClient {
   }
 
   private setupInterceptors() {
-    // Request interceptor for auth token
-    // 쿠키 기반 인증 사용 시 헤더에 토큰을 명시적으로 설정하지 않아도 됨
-    // 하지만 하위 호환성을 위해 localStorage에 토큰이 있으면 헤더에 추가
+    // Request interceptor
+    // 쿠키 기반 인증 사용: 쿠키가 자동으로 전송되므로 헤더에 명시적으로 설정할 필요 없음
     this.client.interceptors.request.use(
       (config) => {
-        const token = localStorage.getItem("accessToken");
-        if (token) {
-          config.headers.Authorization = "Bearer " + token;
-        }
         // FormData인 경우 Content-Type 헤더를 삭제하여 브라우저가 자동으로 boundary를 포함한 올바른 Content-Type을 설정하도록 함
         if (config.data instanceof FormData) {
           delete config.headers["Content-Type"];
@@ -86,31 +81,14 @@ class ApiClient {
 
           try {
             // Refresh Token으로 Access Token 갱신
-            const newAccessToken = await refreshAccessToken();
-
-            // 토큰 갱신 반영 (헤더 우선 사용 환경 대응)
-            if (newAccessToken) {
-              // Bearer 접두사 제거 후 localStorage에 저장 (request interceptor에서 Bearer 추가)
-              const tokenWithoutBearer = newAccessToken.startsWith("Bearer ")
-                ? newAccessToken.substring(7)
-                : newAccessToken;
-              localStorage.setItem("accessToken", tokenWithoutBearer);
-              
-              // 헤더에 새 토큰 설정
-              this.client.defaults.headers.common.Authorization = `Bearer ${tokenWithoutBearer}`;
-              originalRequest.headers.Authorization = `Bearer ${tokenWithoutBearer}`;
-            } else {
-              // 토큰이 없으면 제거
-              localStorage.removeItem("accessToken");
-              delete this.client.defaults.headers.common.Authorization;
-              delete originalRequest.headers.Authorization;
-            }
+            // 쿠키 기반 인증: 백엔드에서 쿠키로 새 토큰을 설정하므로 클라이언트는 별도 처리 불필요
+            await refreshAccessToken();
 
             // 갱신 완료 후 큐 해제
             this.isRefreshing = false;
             this.processQueue(null);
 
-            // 원래 요청 재시도
+            // 원래 요청 재시도 (쿠키에 새 토큰이 자동으로 포함됨)
             return this.client(originalRequest);
           } catch (refreshError) {
             // 갱신 실패 시 즉시 플래그 해제
@@ -191,6 +169,9 @@ class ApiClient {
   /**
    * 인증 관련 헤더 및 설정 제거
    * 로그아웃 시 호출하여 토큰 재사용 방지
+   * 
+   * 주의: 쿠키 기반 인증을 사용하므로 Authorization 헤더를 기본적으로 사용하지 않습니다.
+   * 이 메서드는 혹시 모를 헤더 설정을 제거하기 위한 안전장치입니다.
    */
   clearAuth(): void {
     delete this.client.defaults.headers.common.Authorization;

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -187,6 +187,14 @@ class ApiClient {
     const response = await this.client.delete<ApiResponse<T>>(url);
     return response.data.data;
   }
+
+  /**
+   * 인증 관련 헤더 및 설정 제거
+   * 로그아웃 시 호출하여 토큰 재사용 방지
+   */
+  clearAuth(): void {
+    delete this.client.defaults.headers.common.Authorization;
+  }
 }
 
 export const apiClient = new ApiClient();

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -86,14 +86,36 @@ class ApiClient {
 
           try {
             // Refresh Token으로 Access Token 갱신
-            await refreshAccessToken();
-            
-            // 대기 중인 요청들 재시도
+            const newAccessToken = await refreshAccessToken();
+
+            // 토큰 갱신 반영 (헤더 우선 사용 환경 대응)
+            if (newAccessToken) {
+              // Bearer 접두사 제거 후 localStorage에 저장 (request interceptor에서 Bearer 추가)
+              const tokenWithoutBearer = newAccessToken.startsWith("Bearer ")
+                ? newAccessToken.substring(7)
+                : newAccessToken;
+              localStorage.setItem("accessToken", tokenWithoutBearer);
+              
+              // 헤더에 새 토큰 설정
+              this.client.defaults.headers.common.Authorization = `Bearer ${tokenWithoutBearer}`;
+              originalRequest.headers.Authorization = `Bearer ${tokenWithoutBearer}`;
+            } else {
+              // 토큰이 없으면 제거
+              localStorage.removeItem("accessToken");
+              delete this.client.defaults.headers.common.Authorization;
+              delete originalRequest.headers.Authorization;
+            }
+
+            // 갱신 완료 후 큐 해제
+            this.isRefreshing = false;
             this.processQueue(null);
-            
+
             // 원래 요청 재시도
             return this.client(originalRequest);
           } catch (refreshError) {
+            // 갱신 실패 시 즉시 플래그 해제
+            this.isRefreshing = false;
+            
             // 갱신 실패 시 대기 중인 요청들 모두 실패 처리
             this.processQueue(refreshError);
             
@@ -110,8 +132,6 @@ class ApiClient {
             return Promise.reject(
               new ApiErrorClass(errorCode, "인증이 필요합니다.")
             );
-          } finally {
-            this.isRefreshing = false;
           }
         }
 

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -102,8 +102,14 @@ class ApiClient {
             const isOnLoginPage = window.location.pathname === "/login";
 
             if (!isAuthCheckRequest && !isOnLoginPage) {
-              const { forceLogout } = useAuthStore.getState();
+              // 명시적 cleanup: Authorization 헤더 제거 (안전장치)
+              this.clearAuth();
+              
+              // toast 표시
               toast.error("세션이 만료되었습니다. 다시 로그인해주세요.");
+              
+              // forceLogout 호출 (내부에서 localStorage 정리 및 상태 초기화)
+              const { forceLogout } = useAuthStore.getState();
               forceLogout();
             }
 

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,6 +1,8 @@
 import { toast } from "react-toastify";
 import { createKakaoAuthURL, createNaverAuthURL } from "utils/constants";
+import { apiClient } from "services/apiClient";
 import type { User } from "types/UserTypes";
+import type { ApiResponse } from "types/ApiTypes";
 
 /**
  * 카카오 로그인 - URL 리다이렉트 방식
@@ -61,4 +63,31 @@ export const isLoggedIn = (): boolean => {
 export const getCurrentUser = (): User | null => {
   const userData = localStorage.getItem("userData");
   return userData ? JSON.parse(userData) : null;
+};
+
+/**
+ * Refresh Token으로 Access Token 갱신
+ * @returns 새로운 Access Token (Bearer 접두사 포함)
+ */
+export const refreshAccessToken = async (): Promise<string> => {
+  try {
+    // apiClient를 직접 사용하지 않고 axios를 직접 사용하여 인터셉터 제외
+    const axios = (await import("axios")).default;
+    const { getApiBaseUrl, API_CONSTANTS } = await import("utils/apiUtils");
+    
+    const baseURL = getApiBaseUrl();
+    const response = await axios.post<ApiResponse<string>>(
+      `${baseURL}${API_CONSTANTS.ENDPOINTS.API_V1}/auth/refresh`,
+      {},
+      {
+        withCredentials: true, // 쿠키 자동 전송
+      }
+    );
+    
+    // 응답에서 토큰 추출
+    return response.data.data || "";
+  } catch (error) {
+    console.error("토큰 갱신 실패:", error);
+    throw error;
+  }
 };

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,6 +1,7 @@
 import { toast } from "react-toastify";
 import { createKakaoAuthURL, createNaverAuthURL } from "utils/constants";
 import { apiClient } from "services/apiClient";
+import { useAuthStore } from "store/authStore";
 import type { User } from "types/UserTypes";
 import type { ApiResponse } from "types/ApiTypes";
 
@@ -34,6 +35,7 @@ export const loginWithNaver = (): void => {
 
 /**
  * 로그아웃
+ * authStore.logout에서 호출되는 중앙화된 로그아웃 로직
  */
 export const logout = async (): Promise<void> => {
   try {
@@ -45,17 +47,19 @@ export const logout = async (): Promise<void> => {
       console.error("로그아웃 API 호출 실패:", apiError);
     }
 
-    // 로컬 스토리지 정리
-    localStorage.removeItem("accessToken");
-    localStorage.removeItem("refreshToken");
+    // 로컬 스토리지 정리 (토큰은 쿠키에만 저장되므로 제거 불필요)
     localStorage.removeItem("userData");
+    
+    // apiClient의 Authorization 헤더 제거 (혹시 모를 헤더 설정 제거)
+    apiClient.clearAuth();
+    // axios 기본 Authorization 헤더도 제거 (다른 axios 인스턴스에서 사용할 수 있음)
+    const axios = (await import("axios")).default;
+    delete axios.defaults.headers.common.Authorization;
 
     toast.success("로그아웃되었습니다.");
   } catch (error) {
     console.error("로그아웃 중 오류:", error);
     // 에러가 발생해도 로컬 스토리지는 정리
-    localStorage.removeItem("accessToken");
-    localStorage.removeItem("refreshToken");
     localStorage.removeItem("userData");
     toast.error("로그아웃 중 오류가 발생했습니다.");
   }
@@ -63,10 +67,12 @@ export const logout = async (): Promise<void> => {
 
 /**
  * 현재 로그인 상태 확인
+ * 쿠키 기반 인증: localStorage 대신 authStore의 인증 상태 확인
  */
 export const isLoggedIn = (): boolean => {
-  const accessToken = localStorage.getItem("accessToken");
-  return !!accessToken;
+  // authStore를 사용하여 인증 상태 확인
+  // 주의: 이 함수는 동기적으로 동작하므로, 실제 인증 상태는 authStore.checkAuth()로 확인해야 함
+  return useAuthStore.getState().isAuthenticated;
 };
 
 /**
@@ -79,16 +85,16 @@ export const getCurrentUser = (): User | null => {
 
 /**
  * Refresh Token으로 Access Token 갱신
- * @returns 새로운 Access Token (Bearer 접두사 포함)
+ * RTR(Refresh Token Rotation) 방식: 백엔드에서 쿠키로 새 토큰을 설정하므로 반환값 불필요
  */
-export const refreshAccessToken = async (): Promise<string> => {
+export const refreshAccessToken = async (): Promise<void> => {
   try {
     // apiClient를 직접 사용하지 않고 axios를 직접 사용하여 인터셉터 제외
     const axios = (await import("axios")).default;
     const { getApiBaseUrl, API_CONSTANTS } = await import("utils/apiUtils");
     
     const baseURL = getApiBaseUrl();
-    const response = await axios.post<ApiResponse<string>>(
+    await axios.post<ApiResponse<void>>(
       `${baseURL}${API_CONSTANTS.ENDPOINTS.API_V1}/auth/refresh`,
       {},
       {
@@ -96,8 +102,7 @@ export const refreshAccessToken = async (): Promise<string> => {
       }
     );
     
-    // 응답에서 토큰 추출
-    return response.data.data || "";
+    // 백엔드에서 쿠키로 새 토큰을 설정하므로 별도 처리 불필요
   } catch (error) {
     console.error("토큰 갱신 실패:", error);
     throw error;

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -37,6 +37,14 @@ export const loginWithNaver = (): void => {
  */
 export const logout = async (): Promise<void> => {
   try {
+    // 백엔드 로그아웃 API 호출 (DB에서 RefreshToken 삭제 및 쿠키 삭제)
+    try {
+      await apiClient.post<ApiResponse<void>>("/users/logout");
+    } catch (apiError) {
+      // API 호출 실패해도 로컬 스토리지는 정리
+      console.error("로그아웃 API 호출 실패:", apiError);
+    }
+
     // 로컬 스토리지 정리
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
@@ -45,6 +53,10 @@ export const logout = async (): Promise<void> => {
     toast.success("로그아웃되었습니다.");
   } catch (error) {
     console.error("로그아웃 중 오류:", error);
+    // 에러가 발생해도 로컬 스토리지는 정리
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+    localStorage.removeItem("userData");
     toast.error("로그아웃 중 오류가 발생했습니다.");
   }
 };

--- a/frontend/src/services/sellerService.ts
+++ b/frontend/src/services/sellerService.ts
@@ -1,6 +1,7 @@
 import { apiClient } from "./apiClient";
 import { toast } from "react-toastify";
-import type { SellerRegisterRequestDto } from "types/SellerTypes";
+import type { SellerRegisterRequestDto, SellerDashboardStats, BidCreateRequest, SellerProfileResponseDto } from "types/SellerTypes";
+import type { QuoteListItem } from "types/QuoteTypes";
 import { logError } from "utils/errorUtils";
 
 export const sellerService = {
@@ -32,6 +33,54 @@ export const sellerService = {
     } catch (error: unknown) {
       logError("문서 업로드 실패:", error);
       toast.error("문서 업로드에 실패했습니다.");
+      throw error;
+    }
+  },
+
+  getDashboardStats: async (): Promise<SellerDashboardStats> => {
+    try {
+      // TODO: 실제 API 엔드포인트로 교체 필요
+      // 현재는 플레이스홀더 데이터 반환
+      return {
+        totalBidsSent: 89,
+        inProgressTransactions: 34,
+        completedTransactions: 124,
+      };
+    } catch (error: unknown) {
+      logError("대시보드 통계 조회 실패:", error);
+      toast.error("대시보드 통계를 불러오는데 실패했습니다.");
+      throw error;
+    }
+  },
+
+  getSellerQuotes: async (): Promise<QuoteListItem[]> => {
+    try {
+      const response = await apiClient.get<QuoteListItem[]>("/auction/quotes");
+      return response;
+    } catch (error: unknown) {
+      logError("견적 목록 조회 실패:", error);
+      toast.error("견적 목록을 불러오는데 실패했습니다.");
+      throw error;
+    }
+  },
+
+  createBid: async (data: BidCreateRequest): Promise<void> => {
+    try {
+      await apiClient.post<void>("/auction/bids", data);
+      toast.success("견적이 성공적으로 전송되었습니다.");
+    } catch (error: unknown) {
+      logError("견적 생성 실패:", error);
+      toast.error("견적 전송에 실패했습니다.");
+      throw error;
+    }
+  },
+
+  getSellerProfile: async (): Promise<SellerProfileResponseDto> => {
+    try {
+      const response = await apiClient.get<SellerProfileResponseDto>("/sellers/profile");
+      return response;
+    } catch (error: unknown) {
+      logError("판매자 프로필 조회 실패:", error);
       throw error;
     }
   },

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -59,7 +59,11 @@ export const useAuthStore = create<AuthStore>()(
         },
 
         forceLogout: () => {
+          // 로컬 스토리지 정리
           localStorage.removeItem("userData");
+          
+          // apiClient의 Authorization 헤더 제거 (혹시 모를 헤더 설정 제거)
+          apiClient.clearAuth();
 
           set(
             {

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,12 +1,13 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import type { AuthState, User, ProfileResponseDto } from "types/UserTypes";
+import type { ApiResponse } from "types/ApiTypes";
 import { apiClient } from "services/apiClient";
 
 interface AuthStore extends AuthState {
   // Actions
   login: (user: User) => void;
-  logout: () => void;
+  logout: () => Promise<void>;
   forceLogout: () => void;
   initializeAuth: () => Promise<void>;
   checkAuth: () => Promise<void>;
@@ -37,11 +38,19 @@ export const useAuthStore = create<AuthStore>()(
           );
         },
 
-        logout: () => {
+        logout: async () => {
+          try {
+            // 백엔드 로그아웃 API 호출 (DB에서 RefreshToken 삭제 및 쿠키 삭제)
+            await apiClient.post<ApiResponse<void>>("/users/logout");
+          } catch (error) {
+            // API 호출 실패해도 로컬 스토리지는 정리
+            console.error("로그아웃 API 호출 실패:", error);
+          }
+
           localStorage.removeItem("userData");
           // persist 스토리지도 정리
           localStorage.removeItem("auth-storage");
-          // 쿠키는 백엔드에서 삭제해야 함 (프론트엔드에서는 HttpOnly 쿠키 접근 불가)
+          // 쿠키는 백엔드에서 삭제됨 (HttpOnly 쿠키는 프론트엔드에서 접근 불가)
 
           set(
             {

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -20,6 +20,7 @@ export const useAuthStore = create<AuthStore>()(
       (set, get) => ({
         // Initial state
         isAuthenticated: false,
+        isInitializing: true, // 초기 인증 확인 중 상태
         user: null,
         accessToken: null,
 
@@ -40,38 +41,21 @@ export const useAuthStore = create<AuthStore>()(
         },
 
         logout: async () => {
-          try {
-            // 백엔드 로그아웃 API 호출 (DB에서 RefreshToken 삭제 및 쿠키 삭제)
-            await apiClient.post<ApiResponse<void>>("/users/logout");
-          } catch (error) {
-            // API 호출 실패해도 로컬 스토리지는 정리
-            console.error("로그아웃 API 호출 실패:", error);
-          } finally {
-            // API 호출 성공/실패 여부와 관계없이 항상 정리
-            // localStorage에서 토큰 제거
-            localStorage.removeItem("accessToken");
-            localStorage.removeItem("refreshToken");
-            localStorage.removeItem("userData");
-            // persist 스토리지도 정리
-            localStorage.removeItem("auth-storage");
-            
-            // apiClient의 Authorization 헤더 제거
-            apiClient.clearAuth();
-            // axios 기본 Authorization 헤더도 제거 (다른 axios 인스턴스에서 사용할 수 있음)
-            delete axios.defaults.headers.common.Authorization;
-            
-            // 쿠키는 백엔드에서 삭제됨 (HttpOnly 쿠키는 프론트엔드에서 접근 불가)
-
-            set(
-              {
-                isAuthenticated: false,
-                user: null,
-                accessToken: null,
-              },
-              false,
-              "auth/logout"
-            );
-          }
+          // authService.logout을 호출하여 중복 제거
+          const { logout: authServiceLogout } = await import("services/authService");
+          await authServiceLogout();
+          
+          // 상태 업데이트
+          localStorage.removeItem("auth-storage");
+          set(
+            {
+              isAuthenticated: false,
+              user: null,
+              accessToken: null,
+            },
+            false,
+            "auth/logout"
+          );
         },
 
         forceLogout: () => {
@@ -97,6 +81,8 @@ export const useAuthStore = create<AuthStore>()(
         initializeAuth: async () => {
           // 쿠키 기반 인증이므로 항상 API 호출로 인증 상태 확인
           // localStorage에 userData가 없어도 쿠키에 토큰이 있을 수 있음 (예: 카카오 로그인 직후)
+          set({ isInitializing: true }, false, "auth/initialize/start");
+          
           try {
             // 쿠키에 토큰이 있는지 확인하기 위해 프로필 API 호출
             await get().checkAuth();
@@ -111,8 +97,10 @@ export const useAuthStore = create<AuthStore>()(
                 accessToken: null,
               },
               false,
-              "auth/initialize"
+              "auth/initialize/fail"
             );
+          } finally {
+            set({ isInitializing: false }, false, "auth/initialize/complete");
           }
         },
 
@@ -159,6 +147,7 @@ export const useAuthStore = create<AuthStore>()(
         name: "auth-storage",
         partialize: (state) => {
           // 로그아웃 상태일 때는 저장하지 않음
+          // isInitializing은 저장하지 않음 (항상 false로 시작)
           if (!state.isAuthenticated) {
             return {};
           }
@@ -166,6 +155,7 @@ export const useAuthStore = create<AuthStore>()(
             isAuthenticated: state.isAuthenticated,
             user: state.user,
             accessToken: state.accessToken,
+            // isInitializing은 저장하지 않음 (초기화 시 항상 true로 시작)
           };
         },
       }

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
+import axios from "axios";
 import type { AuthState, User, ProfileResponseDto } from "types/UserTypes";
 import type { ApiResponse } from "types/ApiTypes";
 import { apiClient } from "services/apiClient";
@@ -45,22 +46,32 @@ export const useAuthStore = create<AuthStore>()(
           } catch (error) {
             // API 호출 실패해도 로컬 스토리지는 정리
             console.error("로그아웃 API 호출 실패:", error);
+          } finally {
+            // API 호출 성공/실패 여부와 관계없이 항상 정리
+            // localStorage에서 토큰 제거
+            localStorage.removeItem("accessToken");
+            localStorage.removeItem("refreshToken");
+            localStorage.removeItem("userData");
+            // persist 스토리지도 정리
+            localStorage.removeItem("auth-storage");
+            
+            // apiClient의 Authorization 헤더 제거
+            apiClient.clearAuth();
+            // axios 기본 Authorization 헤더도 제거 (다른 axios 인스턴스에서 사용할 수 있음)
+            delete axios.defaults.headers.common.Authorization;
+            
+            // 쿠키는 백엔드에서 삭제됨 (HttpOnly 쿠키는 프론트엔드에서 접근 불가)
+
+            set(
+              {
+                isAuthenticated: false,
+                user: null,
+                accessToken: null,
+              },
+              false,
+              "auth/logout"
+            );
           }
-
-          localStorage.removeItem("userData");
-          // persist 스토리지도 정리
-          localStorage.removeItem("auth-storage");
-          // 쿠키는 백엔드에서 삭제됨 (HttpOnly 쿠키는 프론트엔드에서 접근 불가)
-
-          set(
-            {
-              isAuthenticated: false,
-              user: null,
-              accessToken: null,
-            },
-            false,
-            "auth/logout"
-          );
         },
 
         forceLogout: () => {

--- a/frontend/src/types/SellerTypes.ts
+++ b/frontend/src/types/SellerTypes.ts
@@ -61,3 +61,45 @@ export const BANK_LIST = [
 
 export type BankName = typeof BANK_LIST[number];
 
+export interface SellerDashboardStats {
+  totalBidsSent: number;
+  inProgressTransactions: number;
+  completedTransactions: number;
+}
+
+export interface AdditionalServiceRequest {
+  serviceName: string;
+  servicePrice: number;
+  description?: string;
+  mandatory?: boolean;
+  cancellableAfterMonths?: number;
+}
+
+export interface BidCreateRequest {
+  quoteId: string;
+  price: number;
+  deliveryDays: number;
+  purchaseMethod: "NUMBER_TRANSFER" | "DEVICE_CHANGE" | "NEW_SUBSCRIPTION" | "LOWEST_PRICE" | "ANY";
+  carrier: "SKT" | "KT" | "LGU" | "SKT_ALD" | "KT_ALD" | "LGU_ALD" | "ANY";
+  currentCarrier?: "SKT" | "KT" | "LGU" | "SKT_ALD" | "KT_ALD" | "LGU_ALD" | "ANY";
+  activationMethod: "COMMON_SUBSIDY" | "SELECTIVE_SUBSIDY" | "ANY";
+  additionalSubsidy?: number;
+  installmentPrincipal: number;
+  contractMonths?: number;
+  pricePlanName: string;
+  pricePlanPrice: number;
+  additionalServices?: AdditionalServiceRequest[];
+}
+
+export interface SellerProfileResponseDto {
+  username: string;
+  businessNumber: string;
+  storeName: string;
+  representativeName: string;
+  phoneNumber: string;
+  email: string;
+  fullAddress: string;
+  approvalStatus: "PENDING" | "APPROVED" | "REJECTED";
+  approvalStatusDisplayName: string;
+}
+

--- a/frontend/src/types/UserTypes.ts
+++ b/frontend/src/types/UserTypes.ts
@@ -20,6 +20,7 @@ export interface LoginResponse {
 
 export interface AuthState {
   isAuthenticated: boolean;
+  isInitializing: boolean;
   user: User | null;
   accessToken: string | null;
 }

--- a/frontend/src/utils/bidUtils.ts
+++ b/frontend/src/utils/bidUtils.ts
@@ -4,6 +4,8 @@ export interface BidCalculationInput {
   additionalSubsidy: number;
   installmentMonths: number;
   installmentInterestRate: number;
+  pricePlanPrice?: number;
+  additionalServicesPrice?: number;
 }
 
 export interface BidCalculationResult {
@@ -63,10 +65,16 @@ export const calculateBidAmounts = (
     input.installmentInterestRate
   );
 
+  const totalMonthlyPayment = calculateTotalMonthlyPayment(
+    monthlyInstallment,
+    input.pricePlanPrice ?? 0,
+    input.additionalServicesPrice ?? 0
+  );
+
   return {
     installmentPrincipal,
     monthlyInstallment,
-    totalMonthlyPayment: monthlyInstallment,
+    totalMonthlyPayment,
   };
 };
 

--- a/frontend/src/utils/bidUtils.ts
+++ b/frontend/src/utils/bidUtils.ts
@@ -28,6 +28,12 @@ export const calculateMonthlyInstallment = (
   if (months === 0) return principal;
   
   const monthlyRate = interestRate / 100 / 12;
+  
+  // 이자율이 0인 경우 원금을 개월수로 균등 분할
+  if (interestRate === 0 || monthlyRate === 0) {
+    return Math.round(principal / months);
+  }
+  
   const numerator = principal * monthlyRate * Math.pow(1 + monthlyRate, months);
   const denominator = Math.pow(1 + monthlyRate, months) - 1;
   

--- a/frontend/src/utils/bidUtils.ts
+++ b/frontend/src/utils/bidUtils.ts
@@ -1,0 +1,66 @@
+export interface BidCalculationInput {
+  devicePrice: number;
+  publicSubsidy: number;
+  additionalSubsidy: number;
+  installmentMonths: number;
+  installmentInterestRate: number;
+}
+
+export interface BidCalculationResult {
+  installmentPrincipal: number;
+  monthlyInstallment: number;
+  totalMonthlyPayment: number;
+}
+
+export const calculateInstallmentPrincipal = (
+  devicePrice: number,
+  publicSubsidy: number,
+  additionalSubsidy: number
+): number => {
+  return devicePrice - publicSubsidy - additionalSubsidy;
+};
+
+export const calculateMonthlyInstallment = (
+  principal: number,
+  months: number,
+  interestRate: number
+): number => {
+  if (months === 0) return principal;
+  
+  const monthlyRate = interestRate / 100 / 12;
+  const numerator = principal * monthlyRate * Math.pow(1 + monthlyRate, months);
+  const denominator = Math.pow(1 + monthlyRate, months) - 1;
+  
+  return Math.round(numerator / denominator);
+};
+
+export const calculateTotalMonthlyPayment = (
+  monthlyInstallment: number,
+  pricePlanPrice: number,
+  additionalServicesPrice: number = 0
+): number => {
+  return monthlyInstallment + pricePlanPrice + additionalServicesPrice;
+};
+
+export const calculateBidAmounts = (
+  input: BidCalculationInput
+): BidCalculationResult => {
+  const installmentPrincipal = calculateInstallmentPrincipal(
+    input.devicePrice,
+    input.publicSubsidy,
+    input.additionalSubsidy
+  );
+
+  const monthlyInstallment = calculateMonthlyInstallment(
+    installmentPrincipal,
+    input.installmentMonths,
+    input.installmentInterestRate
+  );
+
+  return {
+    installmentPrincipal,
+    monthlyInstallment,
+    totalMonthlyPayment: monthlyInstallment,
+  };
+};
+

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -101,3 +101,13 @@ export const STORAGE_KEYS = {
   ACCESS_TOKEN: "accessToken",
   USER_DATA: "userData",
 } as const;
+
+// 입찰 폼 기본값
+export const BID_FORM_DEFAULTS = {
+  DEVICE_PRICE: 1231230,
+  PUBLIC_SUBSIDY: 301000,
+  ADDITIONAL_SUBSIDY: 301000,
+  DELIVERY_DAYS: 3,
+  PRICE_PLAN_MAINTENANCE_MONTHS: 24,
+  LINE_MAINTENANCE_MONTHS: 24,
+} as const;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #94, #88

## 📝 작업 내용

> Refresh Token 인증 시스템과 판매자 기능을 구현했습니다. 다만 판매자 기능 쪽은 디자인 수정 중으로, 확정된 디자인이 아니며 추후 변경 가능성이 있습니다.

## 🔐 Refresh Token 인증 시스템 (#94)

### 백엔드

#### RefreshToken 엔티티 및 리포지토리 추가
- 사용자별 Refresh Token을 DB에 저장하여 관리
- 인덱스 최적화 (user_id, token)
- 만료 시간 자동 관리

#### RefreshTokenService 인터페이스 및 구현체
- `DbRefreshTokenService`: PostgreSQL 기반 구현
- 향후 Redis 등 다른 저장소로 교체 가능한 추상화 설계
- 토큰 생성, 검증, 삭제 기능 제공

#### AuthController에 토큰 갱신 엔드포인트 추가
- `POST /api/v1/auth/refresh`: Refresh Token으로 Access Token 갱신
- 쿠키 기반 Refresh Token 추출 및 검증
- 새로운 Access Token을 쿠키에 저장 (프로덕션 환경 고려)
- **RTR(Refresh Token Rotation) 방식 적용**: 토큰 갱신 시 새로운 Refresh Token 발급

#### JWT 유틸리티 확장
- `createRefreshToken()`: 14일 만료 Refresh Token 생성
- `validateRefreshToken()`: Refresh Token 유효성 검증
- `getRefreshTokenFromCookie()`: 쿠키에서 토큰 추출

#### 만료 토큰 자동 정리 스케줄러
- `RefreshTokenCleanupScheduler`: 매일 자정에 만료된 토큰 삭제
- DB 부하 최소화를 위한 배치 처리

#### 테스트 코드
- `AuthFlowIntegrationTest`: 전체 인증 플로우 통합 테스트
- `DbRefreshTokenServiceTest`: Refresh Token 서비스 단위 테스트
- `AuthControllerTest`: 토큰 갱신 API 테스트

### 프론트엔드

#### 쿠키 기반 인증 시스템 완전 전환
- **모든 토큰을 쿠키로 관리**: Access Token과 Refresh Token 모두 HttpOnly 쿠키에 저장
- **localStorage에서 토큰 저장 완전 제거**: 보안 강화 및 데이터 단일 출처 원칙 준수
- `withCredentials: true` 설정으로 모든 API 요청에 쿠키 자동 전송

#### 인증 상태 관리 개선
- `authStore`: 쿠키 기반 인증에 맞게 상태 관리 로직 수정
  - `accessToken`은 항상 `null`로 설정 (쿠키에 저장되므로)
  - `isInitializing` 상태 추가로 초기 인증 확인 중 상태 관리
  - `initializeAuth()`: 앱 시작 시 쿠키에 토큰이 있는지 확인
  - `checkAuth()`: 프로필 API 호출로 인증 상태 확인

#### 앱 초기화 로직 개선
- `App.tsx`: `initializeAuth()` 호출을 async/await로 감싸 에러 처리 추가
- 앱 마운트 시 인증 상태 복원 로직 안정화

#### 라우트 보호 로직 개선
- `ProtectedRoute`: 중복 호출 방지 로직 추가
  - `isInitializing` 상태 체크로 App.tsx의 초기화 완료 전 중복 호출 방지
  - 인증 초기화 중 로딩 상태 표시로 UX 개선

#### API 클라이언트 개선
- `apiClient`: 쿠키 기반 인증에 맞게 인터셉터 수정
  - 401 에러 시 자동 토큰 갱신 (RTR 방식)
  - 토큰 갱신 실패 시 자동 로그아웃 처리
  - 인증 확인용 요청(`/mypage/profile`)과 일반 요청 구분 처리

#### 인증 서비스 업데이트
- `authService`: 쿠키 기반 인증에 맞게 로직 수정
  - `refreshAccessToken()`: RTR 방식으로 토큰 갱신 (반환값 없음)
  - `logout()`: 쿠키 기반 로그아웃 처리
  - `clearAuth()`: Authorization 헤더 제거 (안전장치)

## 🏪 판매자 기능 (#88)

### 백엔드

#### 판매자 도메인 및 엔티티
- `Seller` 엔티티: 사업자 정보, 승인 상태, 주소 정보 관리
- `SellerDocument` 엔티티: 사업자등록증, 사전승낙서 등 문서 관리
- `ApprovalStatus` enum: PENDING, APPROVED, REJECTED 상태 관리

#### 판매자 회원가입 기능
- `SellerController.registerSeller()`: 판매자 신청 및 회원가입
- 사업자등록번호, 상호명, 대표자명 등 필수 정보 검증
- 중복 검사 (사업자등록번호, 아이디, 이메일, 닉네임)
- User와 Seller 엔티티 동시 생성

#### 판매자 문서 업로드
- `SellerDocumentController`: 사업자등록증, 사전승낙서 업로드
- S3 임시 저장소 활용 (회원가입 단계)
- 문서 타입별 관리 (BUSINESS_LICENSE, CONSENT_FORM)

#### 판매자 프로필 관리
- `SellerController.getSellerProfile()`: 판매자 프로필 조회
- `SellerController.updateSellerProfile()`: 판매자 프로필 수정
- 정산 계좌 정보 관리

#### 입찰 생성 기능
- `BidService.createBid()`: 판매자가 견적에 입찰
- 요금제(PricePlan) 및 부가서비스 관리
- 판매자 승인 상태 검증 (승인된 판매자만 입찰 가능)

### 프론트엔드

#### 판매자 회원가입 페이지
- `SellerSignupPage`: 2단계 회원가입 프로세스
  - Step 1: 사업자 정보 및 주소 입력
  - Step 2: 계정 정보 입력
- 문서 업로드 (사업자등록증, 사전승낙서)
- 실시간 유효성 검증

#### 판매자 대시보드
- `SellerDashboardPage`: 판매자 전용 대시보드
- 통계 정보 표시 (총 입찰 수, 진행 중 거래, 완료된 거래)
- 견적 목록 조회 및 필터링
- 입찰 가능한 견적 확인

#### 입찰 생성 페이지
- `SellerBidCreatePage`: 견적 상세 정보 확인 및 입찰
- 요금제 선택 (약정/선택약정/기기변경)
- 부가서비스 선택 (보험, 케이스 등)
- 입찰 가격 입력 및 검증

#### 판매자 관련 컴포넌트
- `SellerSignupStep1`, `SellerSignupStep2`: 회원가입 단계별 컴포넌트
- `SellerHeader`: 판매자 센터 헤더
- `QuoteRequestCard`: 견적 요청 카드
- `QuoteFilterBar`: 견적 필터링 바

#### 판매자 서비스 및 훅
- `sellerService`: 판매자 관련 API 호출
- `useSellerSignup`: 회원가입 로직 관리
- `useBidForm`: 입찰 폼 상태 관리
- `useSellerDashboard`: 대시보드 데이터 관리

## 🔧 기술적 개선사항

### 보안 강화
- **Refresh Token을 DB에 저장하여 토큰 무효화 가능**
- **쿠키 기반 토큰 관리로 XSS 공격 방어**
- **HttpOnly 쿠키 사용**: JavaScript로 접근 불가능한 쿠키로 보안 향상
- **프로덕션 환경에서 Secure, HttpOnly 쿠키 설정**
- **RTR(Refresh Token Rotation) 방식**: 토큰 갱신 시 새로운 Refresh Token 발급으로 보안 강화
- **localStorage에서 토큰 저장 완전 제거**: XSS 공격 위험 감소
- **access token 만료시간**은 `30분`, **refresh token 만료시간**은 `2주`로 단축하여 설정

### 확장성 고려
- `RefreshTokenService` 인터페이스로 저장소 교체 용이
- 향후 Redis 등 캐시 저장소로 마이그레이션 가능

### 코드 품질
- 도메인 중심 설계로 비즈니스 로직 명확화
- 단위 테스트 및 통합 테스트 작성
- 에러 처리 및 로깅 강화
- 인증 초기화 로직 개선으로 중복 호출 방지

### 데이터 일관성
- **단일 출처 원칙 준수**: 모든 인증 정보를 쿠키로 통일
- **localStorage와 쿠키 혼용 제거**: 데이터 일관성 확보

## ✔️ 주요 변경 사항

### 쿠키 기반 인증 완전 전환 (1/28일 추가 작업)

#### 문제점
- Refresh Token을 HttpOnly 쿠키에 저장했지만, Access Token은 localStorage와 쿠키 모두에 보관되고 있었음
- 이로 인해 보안 취약점(XSS 공격)과 데이터 단일 출처 원칙 위반 발생

#### 해결 방안
1. **프론트엔드에서 localStorage 토큰 저장 완전 제거**
   - `authStore`에서 `accessToken`을 항상 `null`로 설정
   - 로그인 응답의 `accessToken`을 무시하고 사용자 정보만 저장
   - 모든 인증 상태는 쿠키 기반으로 확인

2. **인증 초기화 로직 개선**
   - `App.tsx`: `initializeAuth()` 호출을 async/await로 감싸 에러 처리 추가
   - `ProtectedRoute`: `isInitializing` 상태 체크로 중복 호출 방지
   - 초기화 완료 전까지 로딩 상태 표시로 UX 개선

3. **API 클라이언트 개선**
   - 모든 요청에 `withCredentials: true` 설정
   - 401 에러 시 자동 토큰 갱신 (RTR 방식)
   - 토큰 갱신 실패 시 적절한 에러 처리

#### 개선 효과
- ✅ **보안 강화**: localStorage에 토큰을 저장하지 않아 XSS 공격 위험 감소
- ✅ **일관성**: 모든 인증이 쿠키 기반으로 통일
- ✅ **단순화**: 토큰 관리 로직 단순화, 유지보수성 증가
- ✅ **HttpOnly 쿠키 활용**: JavaScript로 접근 불가능한 쿠키 사용으로 보안 향상
- ✅ **데이터 일관성**: 단일 출처 원칙 준수로 데이터 일관성 확보
- ✅ **UX 개선**: 인증 초기화 중 로딩 상태 표시로 사용자 경험 향상

## 📋 테스트

### 백엔드 테스트
- ✅ `AuthFlowIntegrationTest`: 전체 인증 플로우 통합 테스트
- ✅ `DbRefreshTokenServiceTest`: Refresh Token 서비스 단위 테스트
- ✅ `AuthControllerTest`: 토큰 갱신 API 테스트

### 프론트엔드 테스트
- ✅ 쿠키 기반 인증 플로우 테스트
- ✅ 토큰 자동 갱신 테스트
- ✅ 인증 실패 시 로그아웃 처리 테스트
- ✅ ProtectedRoute 인증 확인 테스트

## 🔍 검증 사항

- ✅ Access Token을 localStorage에 저장하지 않음 확인
- ✅ Refresh Token을 HttpOnly 쿠키에 저장 확인
- ✅ 모든 API 요청에 쿠키 자동 전송 확인
- ✅ 토큰 갱신 시 RTR 방식 적용 확인
- ✅ 인증 초기화 로직 중복 호출 방지 확인
- ✅ 로그인 응답의 accessToken을 사용하지 않음 확인

