### PR TITLE
feat: Add plan enable/disable and selection flow update

### DIFF
--- a/backend/src/main/java/com/phonebid/app/auction/controller/PricePlanController.java
+++ b/backend/src/main/java/com/phonebid/app/auction/controller/PricePlanController.java
@@ -1,0 +1,44 @@
+package com.phonebid.app.auction.controller;
+
+import com.phonebid.app.auction.domain.Carrier;
+import com.phonebid.app.auction.domain.PricePlanCategory;
+import com.phonebid.app.auction.dto.response.PricePlanResponseDto;
+import com.phonebid.app.auction.service.PricePlanService;
+import com.phonebid.app.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auction/price-plans")
+public class PricePlanController {
+
+    private final PricePlanService pricePlanService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PricePlanResponseDto>>> getActivePricePlans(
+            @RequestParam(required = false) Carrier carrier,
+            @RequestParam(required = false) PricePlanCategory category) {
+
+        List<PricePlanResponseDto> response = pricePlanService.getActivePricePlans(carrier, category);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "활성 요금제 목록 조회가 완료되었습니다.", response));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<PricePlanResponseDto>> getPricePlanById(@PathVariable UUID id) {
+
+        PricePlanResponseDto response = pricePlanService.getPricePlanById(id);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "요금제 상세 조회가 완료되었습니다.", response));
+    }
+}

--- a/backend/src/main/java/com/phonebid/app/auction/controller/PricePlanController.java
+++ b/backend/src/main/java/com/phonebid/app/auction/controller/PricePlanController.java
@@ -38,6 +38,7 @@ public class PricePlanController {
 
         PricePlanResponseDto response = pricePlanService.getPricePlanById(id);
 
+
         return ResponseEntity.ok()
                 .body(ApiResponse.success(HttpStatus.OK, "요금제 상세 조회가 완료되었습니다.", response));
     }

--- a/backend/src/main/java/com/phonebid/app/auction/controller/admin/AdminPricePlanController.java
+++ b/backend/src/main/java/com/phonebid/app/auction/controller/admin/AdminPricePlanController.java
@@ -6,6 +6,7 @@ import com.phonebid.app.auction.dto.response.PricePlanResponseDto;
 import com.phonebid.app.auction.service.PricePlanService;
 import com.phonebid.app.common.dto.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -66,7 +67,7 @@ public class AdminPricePlanController {
     @PutMapping("/{id}/display-order")
     public ResponseEntity<ApiResponse<Void>> updateDisplayOrder(
             @PathVariable UUID id,
-            @RequestParam Integer displayOrder) {
+            @RequestParam @Min(value = 0, message = "노출 순서는 0 이상이어야 합니다.") Integer displayOrder) {
 
         pricePlanService.updateDisplayOrder(id, displayOrder);
 

--- a/backend/src/main/java/com/phonebid/app/auction/controller/admin/AdminPricePlanController.java
+++ b/backend/src/main/java/com/phonebid/app/auction/controller/admin/AdminPricePlanController.java
@@ -1,0 +1,76 @@
+package com.phonebid.app.auction.controller.admin;
+
+import com.phonebid.app.auction.domain.Carrier;
+import com.phonebid.app.auction.dto.request.PricePlanCreateRequestDto;
+import com.phonebid.app.auction.dto.response.PricePlanResponseDto;
+import com.phonebid.app.auction.service.PricePlanService;
+import com.phonebid.app.common.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/auction/price-plans")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminPricePlanController {
+
+    private final PricePlanService pricePlanService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PricePlanResponseDto>>> getAllPricePlans(
+            @RequestParam(required = false) Carrier carrier) {
+
+        List<PricePlanResponseDto> response = pricePlanService.getAllPricePlansForAdmin(carrier);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "요금제 전체 목록 조회가 완료되었습니다.", response));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<PricePlanResponseDto>> createPricePlan(
+            @Valid @RequestBody PricePlanCreateRequestDto requestDto) {
+
+        PricePlanResponseDto response = pricePlanService.createPricePlan(requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, "요금제가 성공적으로 등록되었습니다.", response));
+    }
+
+    @PutMapping("/{id}/deactivate")
+    public ResponseEntity<ApiResponse<Void>> deactivatePricePlan(@PathVariable UUID id) {
+
+        pricePlanService.deactivatePricePlan(id);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "요금제가 비활성화되었습니다.", null));
+    }
+
+    @PutMapping("/{id}/activate")
+    public ResponseEntity<ApiResponse<Void>> activatePricePlan(@PathVariable UUID id) {
+
+        pricePlanService.activatePricePlan(id);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "요금제가 활성화되었습니다.", null));
+    }
+
+    @PutMapping("/{id}/display-order")
+    public ResponseEntity<ApiResponse<Void>> updateDisplayOrder(
+            @PathVariable UUID id,
+            @RequestParam Integer displayOrder) {
+
+        pricePlanService.updateDisplayOrder(id, displayOrder);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(HttpStatus.OK, "요금제 노출 순서가 변경되었습니다.", null));
+    }
+}

--- a/backend/src/main/java/com/phonebid/app/auction/domain/PricePlan.java
+++ b/backend/src/main/java/com/phonebid/app/auction/domain/PricePlan.java
@@ -1,6 +1,5 @@
 package com.phonebid.app.auction.domain;
 
-
 import com.phonebid.app.common.domain.BaseEntity;
 
 import jakarta.persistence.*;
@@ -14,10 +13,13 @@ import java.util.UUID;
 import org.hibernate.annotations.Comment;
 
 @Entity
-@Table(name = "price_plans")
+@Table(name = "price_plans", indexes = {
+    @Index(name = "idx_price_plans_carrier_active", columnList = "carrier, is_active"),
+    @Index(name = "idx_price_plans_category_active", columnList = "category, is_active")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PricePlan extends BaseEntity{
+public class PricePlan extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -26,66 +28,103 @@ public class PricePlan extends BaseEntity{
     private UUID id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "carrier")
-    @Comment("통신사")
+    @Column(name = "carrier", nullable = false)
+    @Comment("통신사 (SKT, KT, LGU)")
     private Carrier carrier;
-    
-    @Column(name = "plan_name")
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, columnDefinition = "varchar(255) default 'FIVE_G'")
+    @Comment("요금제 구분 (5G, LTE)")
+    private PricePlanCategory category;
+
+    @Column(name = "plan_name", nullable = false)
     @Comment("요금제 이름")
     private String planName;
 
-    @Column(name = "plan_price")
-    @Comment("요금제 가격")
-    private Integer planPrice;
+    @Column(name = "monthly_fee", nullable = false)
+    @Comment("월정액 (VAT 포함, 원)")
+    private Integer monthlyFee;
+
+    @Column(name = "data_allowance_text")
+    @Comment("데이터 제공량 (예: 무제한, 110GB)")
+    private String dataAllowanceText;
+
+    @Column(name = "throttle_speed_text")
+    @Comment("소진 시 속도 (예: 5Mbps, 1Mbps, -)")
+    private String throttleSpeedText;
+
+    @Column(name = "voice_sms_text")
+    @Comment("음성/문자 (예: 집/이동전화 무제한)")
+    private String voiceSmsText;
+
+    @Column(name = "is_active", nullable = false)
+    @Comment("사용 여부 (true: 활성, false: 비활성)")
+    private Boolean isActive;
+
+    @Column(name = "display_order")
+    @Comment("노출 순서 (낮을수록 상위)")
+    private Integer displayOrder;
 
     @Builder
-    private PricePlan(Carrier carrier, String planName, Integer planPrice) {
+    private PricePlan(Carrier carrier, PricePlanCategory category, String planName, 
+                      Integer monthlyFee, String dataAllowanceText, String throttleSpeedText,
+                      String voiceSmsText, Boolean isActive, Integer displayOrder) {
         this.carrier = carrier;
+        this.category = category;
         this.planName = planName;
-        this.planPrice = planPrice;
+        this.monthlyFee = monthlyFee;
+        this.dataAllowanceText = dataAllowanceText;
+        this.throttleSpeedText = throttleSpeedText;
+        this.voiceSmsText = voiceSmsText;
+        this.isActive = isActive != null ? isActive : true;
+        this.displayOrder = displayOrder;
     }
 
-    // 비즈니스 메서드
     public String getPlanSummary() {
-        if (planName == null || planPrice == null) {
+        if (planName == null || monthlyFee == null) {
             return "요금제 정보 없음";
         }
-        return String.format("%s (%,d원)", planName, planPrice);
+        return String.format("%s (%,d원)", planName, monthlyFee);
     }
 
     public boolean isComplete() {
         return planName != null && !planName.trim().isEmpty() && 
-               planPrice != null && planPrice > 0;
+               monthlyFee != null && monthlyFee > 0;
     }
 
     public boolean isEmpty() {
         return (planName == null || planName.trim().isEmpty()) && 
-               (planPrice == null || planPrice == 0);
+               (monthlyFee == null || monthlyFee == 0);
     }
 
     public boolean isAffordable(Integer budget) {
-        if (budget == null || planPrice == null) {
+        if (budget == null || monthlyFee == null) {
             return false;
         }
-        return budget >= planPrice;
+        return budget >= monthlyFee;
     }
 
-    public boolean isUnlimited() {
-        if (planName == null) {
+    public boolean isUnlimitedData() {
+        if (dataAllowanceText == null) {
             return false;
         }
-        String lowerPlanName = planName.toLowerCase();
-        return lowerPlanName.contains("무제한") || lowerPlanName.contains("unlimited");
+        return dataAllowanceText.contains("무제한");
     }
 
-    // 요금제 정보 업데이트
-    public void update(String planName, Integer planPrice) {
-        if (planName != null) {
-            this.planName = planName;
-        }
-        if (planPrice != null) {
-            this.planPrice = planPrice;
-        }
+    public void deactivate() {
+        this.isActive = false;
     }
 
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void updateDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    @Deprecated
+    public Integer getPlanPrice() {
+        return this.monthlyFee;
+    }
 } 

--- a/backend/src/main/java/com/phonebid/app/auction/domain/PricePlanCategory.java
+++ b/backend/src/main/java/com/phonebid/app/auction/domain/PricePlanCategory.java
@@ -1,0 +1,16 @@
+package com.phonebid.app.auction.domain;
+
+public enum PricePlanCategory {
+    FIVE_G("5G"),
+    LTE("LTE");
+
+    private final String displayName;
+
+    PricePlanCategory(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/backend/src/main/java/com/phonebid/app/auction/dto/request/BidCreateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/auction/dto/request/BidCreateRequestDto.java
@@ -47,12 +47,8 @@ public class BidCreateRequestDto {
 
     private Integer contractMonths;
 
-    @NotNull(message = "요금제 이름은 필수입니다.")
-    private String pricePlanName;
-
-    @NotNull(message = "요금제 가격은 필수입니다.")
-    @Min(value = 0, message = "요금제 가격은 0 이상이어야 합니다.")
-    private Integer pricePlanPrice;
+    @NotNull(message = "요금제 ID는 필수입니다.")
+    private UUID pricePlanId;
 
     @Valid
     private List<AdditionalServiceRequestDto> additionalServices = new ArrayList<>();
@@ -62,7 +58,7 @@ public class BidCreateRequestDto {
                                 PurchaseMethod purchaseMethod, Carrier carrier, Carrier currentCarrier,
                                 ActivationMethod activationMethod, Integer additionalSubsidy,
                                 Integer installmentPrincipal, Integer contractMonths,
-                                String pricePlanName, Integer pricePlanPrice,
+                                UUID pricePlanId,
                                 List<AdditionalServiceRequestDto> additionalServices) {
         this.quoteId = quoteId;
         this.price = price;
@@ -74,17 +70,8 @@ public class BidCreateRequestDto {
         this.additionalSubsidy = additionalSubsidy;
         this.installmentPrincipal = installmentPrincipal;
         this.contractMonths = contractMonths;
-        this.pricePlanName = pricePlanName;
-        this.pricePlanPrice = pricePlanPrice;
+        this.pricePlanId = pricePlanId;
         this.additionalServices = additionalServices != null ? additionalServices : new ArrayList<>();
-    }
-
-    public PricePlan toPricePlanEntity() {
-        return PricePlan.builder()
-                .carrier(carrier)
-                .planName(pricePlanName)
-                .planPrice(pricePlanPrice)
-                .build();
     }
 
     public Bid toBidEntity(Quote quote, Seller seller, PricePlan pricePlan, Double ratingSnapshot) {

--- a/backend/src/main/java/com/phonebid/app/auction/dto/request/BidUpdateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/auction/dto/request/BidUpdateRequestDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
@@ -28,10 +29,7 @@ public class BidUpdateRequestDto {
     @Min(value = 1, message = "약정개월은 1개월 이상이어야 합니다.")
     private Integer contractMonths;
 
-    private String pricePlanName;
-
-    @Min(value = 0, message = "요금제 가격은 0 이상이어야 합니다.")
-    private Integer pricePlanPrice;
+    private UUID pricePlanId;
 
     @Valid
     private List<AdditionalServiceRequestDto> additionalServices;
@@ -39,15 +37,14 @@ public class BidUpdateRequestDto {
     @Builder
     public BidUpdateRequestDto(Integer price, Integer deliveryDays, Integer additionalSubsidy,
                                 Integer installmentPrincipal, Integer contractMonths,
-                                String pricePlanName, Integer pricePlanPrice,
+                                UUID pricePlanId,
                                 List<AdditionalServiceRequestDto> additionalServices) {
         this.price = price;
         this.deliveryDays = deliveryDays;
         this.additionalSubsidy = additionalSubsidy;
         this.installmentPrincipal = installmentPrincipal;
         this.contractMonths = contractMonths;
-        this.pricePlanName = pricePlanName;
-        this.pricePlanPrice = pricePlanPrice;
+        this.pricePlanId = pricePlanId;
         this.additionalServices = additionalServices != null ? additionalServices : new ArrayList<>();
     }
 }

--- a/backend/src/main/java/com/phonebid/app/auction/dto/request/PricePlanCreateRequestDto.java
+++ b/backend/src/main/java/com/phonebid/app/auction/dto/request/PricePlanCreateRequestDto.java
@@ -1,0 +1,62 @@
+package com.phonebid.app.auction.dto.request;
+
+import com.phonebid.app.auction.domain.Carrier;
+import com.phonebid.app.auction.domain.PricePlan;
+import com.phonebid.app.auction.domain.PricePlanCategory;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PricePlanCreateRequestDto {
+
+    @NotNull(message = "통신사는 필수입니다.")
+    private Carrier carrier;
+
+    @NotNull(message = "요금제 구분은 필수입니다.")
+    private PricePlanCategory category;
+
+    @NotBlank(message = "요금제 이름은 필수입니다.")
+    private String planName;
+
+    @NotNull(message = "월정액은 필수입니다.")
+    @Min(value = 0, message = "월정액은 0 이상이어야 합니다.")
+    private Integer monthlyFee;
+
+    private String dataAllowanceText;
+    private String throttleSpeedText;
+    private String voiceSmsText;
+    private Integer displayOrder;
+
+    @Builder
+    public PricePlanCreateRequestDto(Carrier carrier, PricePlanCategory category, String planName,
+                                      Integer monthlyFee, String dataAllowanceText, String throttleSpeedText,
+                                      String voiceSmsText, Integer displayOrder) {
+        this.carrier = carrier;
+        this.category = category;
+        this.planName = planName;
+        this.monthlyFee = monthlyFee;
+        this.dataAllowanceText = dataAllowanceText;
+        this.throttleSpeedText = throttleSpeedText;
+        this.voiceSmsText = voiceSmsText;
+        this.displayOrder = displayOrder;
+    }
+
+    public PricePlan toEntity() {
+        return PricePlan.builder()
+                .carrier(carrier)
+                .category(category)
+                .planName(planName)
+                .monthlyFee(monthlyFee)
+                .dataAllowanceText(dataAllowanceText)
+                .throttleSpeedText(throttleSpeedText)
+                .voiceSmsText(voiceSmsText)
+                .isActive(true)
+                .displayOrder(displayOrder)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/phonebid/app/auction/dto/response/BidListResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/auction/dto/response/BidListResponseDto.java
@@ -2,6 +2,8 @@ package com.phonebid.app.auction.dto.response;
 
 import com.phonebid.app.auction.domain.Bid;
 import com.phonebid.app.auction.domain.BidStatus;
+import com.phonebid.app.auction.domain.PricePlan;
+import com.phonebid.app.auction.domain.PricePlanCategory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,13 +20,16 @@ public class BidListResponseDto {
     private Double sellerRating;
     private Integer installmentPrincipal;
     private Integer totalMaintenanceCost;
+    private UUID pricePlanId;
     private String pricePlanName;
     private Integer pricePlanPrice;
+    private PricePlanCategory pricePlanCategory;
     private BidStatus status;
     private LocalDateTime createdAt;
 
     public static BidListResponseDto from(Bid bid) {
         Integer totalMaintenanceCost = calculateTotalMaintenanceCost(bid);
+        PricePlan pricePlan = bid.getPricePlan();
         
         return BidListResponseDto.builder()
                 .id(bid.getId())
@@ -33,8 +38,10 @@ public class BidListResponseDto {
                 .sellerRating(bid.getRatingSnapshot())
                 .installmentPrincipal(bid.getInstallmentPrincipal())
                 .totalMaintenanceCost(totalMaintenanceCost)
-                .pricePlanName(bid.getPricePlan() != null ? bid.getPricePlan().getPlanName() : null)
-                .pricePlanPrice(bid.getPricePlan() != null ? bid.getPricePlan().getPlanPrice() : null)
+                .pricePlanId(pricePlan != null ? pricePlan.getId() : null)
+                .pricePlanName(pricePlan != null ? pricePlan.getPlanName() : null)
+                .pricePlanPrice(pricePlan != null ? pricePlan.getMonthlyFee() : null)
+                .pricePlanCategory(pricePlan != null ? pricePlan.getCategory() : null)
                 .status(bid.getStatus())
                 .createdAt(bid.getCreatedAt())
                 .build();
@@ -42,7 +49,7 @@ public class BidListResponseDto {
 
     private static Integer calculateTotalMaintenanceCost(Bid bid) {
         Integer months = bid.getContractMonths() != null ? bid.getContractMonths() : 24;
-        Integer planPrice = bid.getPricePlan() != null ? bid.getPricePlan().getPlanPrice() : 0;
+        Integer planPrice = bid.getPricePlan() != null ? bid.getPricePlan().getMonthlyFee() : 0;
         Integer additionalServiceTotal = bid.getAdditionalServiceList().stream()
                 .mapToInt(service -> service.getServicePrice() != null ? service.getServicePrice() : 0)
                 .sum();

--- a/backend/src/main/java/com/phonebid/app/auction/dto/response/BidResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/auction/dto/response/BidResponseDto.java
@@ -16,37 +16,35 @@ public class BidResponseDto {
     private UUID id;
     private UUID quoteId;
     
-    // 판매자 정보
     private UUID sellerId;
     private String sellerStoreName;
     private Double sellerRating;
     
-    // 가격 정보
     private Integer price;
     private Integer installmentPrincipal;
     private Integer additionalSubsidy;
     private Integer totalMaintenanceCost;
     
-    // 요금제 정보
+    private UUID pricePlanId;
     private String pricePlanName;
     private Integer pricePlanPrice;
+    private PricePlanCategory pricePlanCategory;
+    private String pricePlanDataAllowance;
+    private String pricePlanThrottleSpeed;
+    private String pricePlanVoiceSms;
     
-    // 부가서비스 정보
     private List<AdditionalServiceResponseDto> additionalServices;
     private Integer additionalServicesCount;
     private Integer additionalServicesTotalPrice;
     
-    // 개통 정보
     private PurchaseMethod purchaseMethod;
     private Carrier carrier;
     private Carrier currentCarrier;
     private ActivationMethod activationMethod;
     private Integer contractMonths;
     
-    // 배송 정보
     private Integer deliveryDays;
     
-    // 상태 정보
     private BidStatus status;
     private LocalDateTime createdAt;
 
@@ -60,6 +58,7 @@ public class BidResponseDto {
                 .sum();
         
         Integer totalMaintenanceCost = calculateTotalMaintenanceCost(bid, additionalServicesTotalPrice);
+        PricePlan pricePlan = bid.getPricePlan();
         
         return BidResponseDto.builder()
                 .id(bid.getId())
@@ -71,8 +70,13 @@ public class BidResponseDto {
                 .installmentPrincipal(bid.getInstallmentPrincipal())
                 .additionalSubsidy(bid.getAdditionalSubsidy())
                 .totalMaintenanceCost(totalMaintenanceCost)
-                .pricePlanName(bid.getPricePlan() != null ? bid.getPricePlan().getPlanName() : null)
-                .pricePlanPrice(bid.getPricePlan() != null ? bid.getPricePlan().getPlanPrice() : null)
+                .pricePlanId(pricePlan != null ? pricePlan.getId() : null)
+                .pricePlanName(pricePlan != null ? pricePlan.getPlanName() : null)
+                .pricePlanPrice(pricePlan != null ? pricePlan.getMonthlyFee() : null)
+                .pricePlanCategory(pricePlan != null ? pricePlan.getCategory() : null)
+                .pricePlanDataAllowance(pricePlan != null ? pricePlan.getDataAllowanceText() : null)
+                .pricePlanThrottleSpeed(pricePlan != null ? pricePlan.getThrottleSpeedText() : null)
+                .pricePlanVoiceSms(pricePlan != null ? pricePlan.getVoiceSmsText() : null)
                 .additionalServices(additionalServiceDtos)
                 .additionalServicesCount(additionalServiceDtos.size())
                 .additionalServicesTotalPrice(additionalServicesTotalPrice)
@@ -89,7 +93,7 @@ public class BidResponseDto {
 
     private static Integer calculateTotalMaintenanceCost(Bid bid, Integer additionalServicesTotalPrice) {
         Integer months = bid.getContractMonths() != null ? bid.getContractMonths() : 24;
-        Integer planPrice = bid.getPricePlan() != null ? bid.getPricePlan().getPlanPrice() : 0;
+        Integer planPrice = bid.getPricePlan() != null ? bid.getPricePlan().getMonthlyFee() : 0;
         
         return (planPrice + additionalServicesTotalPrice) * months;
     }

--- a/backend/src/main/java/com/phonebid/app/auction/dto/response/PricePlanResponseDto.java
+++ b/backend/src/main/java/com/phonebid/app/auction/dto/response/PricePlanResponseDto.java
@@ -1,0 +1,40 @@
+package com.phonebid.app.auction.dto.response;
+
+import com.phonebid.app.auction.domain.Carrier;
+import com.phonebid.app.auction.domain.PricePlan;
+import com.phonebid.app.auction.domain.PricePlanCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class PricePlanResponseDto {
+
+    private UUID id;
+    private Carrier carrier;
+    private PricePlanCategory category;
+    private String planName;
+    private Integer monthlyFee;
+    private String dataAllowanceText;
+    private String throttleSpeedText;
+    private String voiceSmsText;
+    private Boolean isActive;
+    private Integer displayOrder;
+
+    public static PricePlanResponseDto from(PricePlan pricePlan) {
+        return PricePlanResponseDto.builder()
+                .id(pricePlan.getId())
+                .carrier(pricePlan.getCarrier())
+                .category(pricePlan.getCategory())
+                .planName(pricePlan.getPlanName())
+                .monthlyFee(pricePlan.getMonthlyFee())
+                .dataAllowanceText(pricePlan.getDataAllowanceText())
+                .throttleSpeedText(pricePlan.getThrottleSpeedText())
+                .voiceSmsText(pricePlan.getVoiceSmsText())
+                .isActive(pricePlan.getIsActive())
+                .displayOrder(pricePlan.getDisplayOrder())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/phonebid/app/auction/repository/PricePlanRepository.java
+++ b/backend/src/main/java/com/phonebid/app/auction/repository/PricePlanRepository.java
@@ -2,26 +2,41 @@ package com.phonebid.app.auction.repository;
 
 import com.phonebid.app.auction.domain.Carrier;
 import com.phonebid.app.auction.domain.PricePlan;
+import com.phonebid.app.auction.domain.PricePlanCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-// 요금제 Repository
 public interface PricePlanRepository extends JpaRepository<PricePlan, UUID> {
 
-    /**
-     * 통신사별 요금제 목록 조회
-     */
-    @Query("SELECT pp FROM PricePlan pp WHERE pp.carrier = :carrier AND (pp.isDelete = false OR pp.isDelete IS NULL)")
-    List<PricePlan> findByCarrier(@Param("carrier") Carrier carrier);
+    @Query("SELECT pp FROM PricePlan pp WHERE pp.id = :id AND pp.isActive = true AND (pp.isDelete = false OR pp.isDelete IS NULL)")
+    Optional<PricePlan> findByIdAndIsActiveTrue(@Param("id") UUID id);
 
-    /**
-     * 통신사 및 최대 가격 조건으로 요금제 목록 조회
-     */
-    @Query("SELECT pp FROM PricePlan pp WHERE pp.carrier = :carrier AND pp.planPrice <= :maxPrice AND (pp.isDelete = false OR pp.isDelete IS NULL)")
-    List<PricePlan> findByCarrierAndMaxPrice(@Param("carrier") Carrier carrier, @Param("maxPrice") Integer maxPrice);
+    @Query("SELECT pp FROM PricePlan pp WHERE pp.isActive = true AND (pp.isDelete = false OR pp.isDelete IS NULL) ORDER BY pp.carrier, pp.displayOrder, pp.monthlyFee DESC")
+    List<PricePlan> findAllActiveOrderByCarrierAndDisplayOrder();
+
+    @Query("SELECT pp FROM PricePlan pp WHERE pp.carrier = :carrier AND pp.isActive = true AND (pp.isDelete = false OR pp.isDelete IS NULL) ORDER BY pp.displayOrder, pp.monthlyFee DESC")
+    List<PricePlan> findByCarrierAndIsActiveTrue(@Param("carrier") Carrier carrier);
+
+    @Query("SELECT pp FROM PricePlan pp WHERE pp.category = :category AND pp.isActive = true AND (pp.isDelete = false OR pp.isDelete IS NULL) ORDER BY pp.carrier, pp.displayOrder, pp.monthlyFee DESC")
+    List<PricePlan> findByCategoryAndIsActiveTrue(@Param("category") PricePlanCategory category);
+
+    @Query("SELECT pp FROM PricePlan pp WHERE pp.carrier = :carrier AND pp.category = :category AND pp.isActive = true AND (pp.isDelete = false OR pp.isDelete IS NULL) ORDER BY pp.displayOrder, pp.monthlyFee DESC")
+    List<PricePlan> findByCarrierAndCategoryAndIsActiveTrue(@Param("carrier") Carrier carrier, @Param("category") PricePlanCategory category);
+
+    @Query("SELECT pp FROM PricePlan pp WHERE (pp.isDelete = false OR pp.isDelete IS NULL) ORDER BY pp.carrier, pp.category, pp.displayOrder, pp.monthlyFee DESC")
+    List<PricePlan> findAllForAdmin();
+
+    @Query("SELECT pp FROM PricePlan pp WHERE pp.carrier = :carrier AND (pp.isDelete = false OR pp.isDelete IS NULL) ORDER BY pp.category, pp.displayOrder, pp.monthlyFee DESC")
+    List<PricePlan> findByCarrierForAdmin(@Param("carrier") Carrier carrier);
+
+    @Query("SELECT pp FROM PricePlan pp WHERE pp.carrier = :carrier AND pp.monthlyFee <= :maxPrice AND pp.isActive = true AND (pp.isDelete = false OR pp.isDelete IS NULL) ORDER BY pp.displayOrder, pp.monthlyFee DESC")
+    List<PricePlan> findByCarrierAndMaxPriceAndIsActiveTrue(@Param("carrier") Carrier carrier, @Param("maxPrice") Integer maxPrice);
+
+    boolean existsByCarrierAndPlanNameAndIsActiveTrue(Carrier carrier, String planName);
 }
 

--- a/backend/src/main/java/com/phonebid/app/auction/repository/PricePlanRepository.java
+++ b/backend/src/main/java/com/phonebid/app/auction/repository/PricePlanRepository.java
@@ -37,6 +37,6 @@ public interface PricePlanRepository extends JpaRepository<PricePlan, UUID> {
     @Query("SELECT pp FROM PricePlan pp WHERE pp.carrier = :carrier AND pp.monthlyFee <= :maxPrice AND pp.isActive = true AND (pp.isDelete = false OR pp.isDelete IS NULL) ORDER BY pp.displayOrder, pp.monthlyFee DESC")
     List<PricePlan> findByCarrierAndMaxPriceAndIsActiveTrue(@Param("carrier") Carrier carrier, @Param("maxPrice") Integer maxPrice);
 
-    boolean existsByCarrierAndPlanNameAndIsActiveTrue(Carrier carrier, String planName);
+    boolean existsByCarrierAndPlanName(Carrier carrier, String planName);
 }
 

--- a/backend/src/main/java/com/phonebid/app/auction/service/BidService.java
+++ b/backend/src/main/java/com/phonebid/app/auction/service/BidService.java
@@ -57,8 +57,8 @@ public class BidService {
         // 3. 최저가 갱신 여부 확인을 위해 입찰 저장 전에 기존 최저 할부원금 조회
         Integer previousLowestInstallmentPrincipal = bidRepository.findMinInstallmentPrincipalByQuoteId(quote.getId(), BidStatus.ACTIVE);
 
-        // 4. 요금제 생성 및 저장
-        PricePlan pricePlan = createAndSavePricePlan(requestDto);
+        // 4. 요금제 조회 및 검증
+        PricePlan pricePlan = validateAndGetPricePlan(requestDto);
 
         // 5. 입찰 생성
         Bid bid = createAndSaveBid(requestDto, quote, seller, pricePlan);
@@ -105,10 +105,9 @@ public class BidService {
         return quote;
     }
 
-    // 요금제 생성 및 저장
-    private PricePlan createAndSavePricePlan(BidCreateRequestDto requestDto) {
-        PricePlan pricePlan = requestDto.toPricePlanEntity();
-        return pricePlanRepository.save(pricePlan);
+    private PricePlan validateAndGetPricePlan(BidCreateRequestDto requestDto) {
+        return pricePlanRepository.findByIdAndIsActiveTrue(requestDto.getPricePlanId())
+                .orElseThrow(() -> new CustomException(AuctionErrorCode.PRICE_PLAN_NOT_ACTIVE));
     }
 
     // 입찰 생성 및 저장
@@ -156,24 +155,11 @@ public class BidService {
             throw new CustomException(AuctionErrorCode.BID_MODIFICATION_NOT_ALLOWED);
         }
 
-        // 5. 요금제 업데이트 (요금제 정보가 제공된 경우)
-        if (requestDto.getPricePlanName() != null || requestDto.getPricePlanPrice() != null) {
-            PricePlan existingPricePlan = bid.getPricePlan();
-            
-            if (existingPricePlan != null) {
-                // 기존 PricePlan이 있는 경우 필드 업데이트
-                existingPricePlan.update(requestDto.getPricePlanName(), requestDto.getPricePlanPrice());
-                pricePlanRepository.save(existingPricePlan);
-            } else {
-                // 기존 PricePlan이 없는 경우 새로 생성
-                PricePlan newPricePlan = PricePlan.builder()
-                        .carrier(bid.getCarrier())
-                        .planName(requestDto.getPricePlanName())
-                        .planPrice(requestDto.getPricePlanPrice())
-                        .build();
-                pricePlanRepository.save(newPricePlan);
-                bid.updatePricePlan(newPricePlan);
-            }
+        // 5. 요금제 업데이트 (요금제 ID가 제공된 경우)
+        if (requestDto.getPricePlanId() != null) {
+            PricePlan newPricePlan = pricePlanRepository.findByIdAndIsActiveTrue(requestDto.getPricePlanId())
+                    .orElseThrow(() -> new CustomException(AuctionErrorCode.PRICE_PLAN_NOT_ACTIVE));
+            bid.updatePricePlan(newPricePlan);
         }
 
         // 6. 부가서비스 업데이트 (부가서비스 목록이 제공된 경우)

--- a/backend/src/main/java/com/phonebid/app/auction/service/PricePlanService.java
+++ b/backend/src/main/java/com/phonebid/app/auction/service/PricePlanService.java
@@ -1,0 +1,113 @@
+package com.phonebid.app.auction.service;
+
+import com.phonebid.app.auction.domain.Carrier;
+import com.phonebid.app.auction.domain.PricePlan;
+import com.phonebid.app.auction.domain.PricePlanCategory;
+import com.phonebid.app.auction.dto.request.PricePlanCreateRequestDto;
+import com.phonebid.app.auction.dto.response.PricePlanResponseDto;
+import com.phonebid.app.auction.repository.PricePlanRepository;
+import com.phonebid.app.common.errorcode.AuctionErrorCode;
+import com.phonebid.app.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PricePlanService {
+
+    private final PricePlanRepository pricePlanRepository;
+
+    @Transactional(readOnly = true)
+    public List<PricePlanResponseDto> getActivePricePlans(Carrier carrier, PricePlanCategory category) {
+        List<PricePlan> pricePlans;
+
+        if (carrier != null && category != null) {
+            pricePlans = pricePlanRepository.findByCarrierAndCategoryAndIsActiveTrue(carrier, category);
+        } else if (carrier != null) {
+            pricePlans = pricePlanRepository.findByCarrierAndIsActiveTrue(carrier);
+        } else if (category != null) {
+            pricePlans = pricePlanRepository.findByCategoryAndIsActiveTrue(category);
+        } else {
+            pricePlans = pricePlanRepository.findAllActiveOrderByCarrierAndDisplayOrder();
+        }
+
+        return pricePlans.stream()
+                .map(PricePlanResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public PricePlanResponseDto getPricePlanById(UUID id) {
+        PricePlan pricePlan = pricePlanRepository.findById(id)
+                .orElseThrow(() -> new CustomException(AuctionErrorCode.PRICE_PLAN_NOT_FOUND));
+        return PricePlanResponseDto.from(pricePlan);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PricePlanResponseDto> getAllPricePlansForAdmin(Carrier carrier) {
+        List<PricePlan> pricePlans;
+
+        if (carrier != null) {
+            pricePlans = pricePlanRepository.findByCarrierForAdmin(carrier);
+        } else {
+            pricePlans = pricePlanRepository.findAllForAdmin();
+        }
+
+        return pricePlans.stream()
+                .map(PricePlanResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public PricePlanResponseDto createPricePlan(PricePlanCreateRequestDto requestDto) {
+        if (pricePlanRepository.existsByCarrierAndPlanNameAndIsActiveTrue(
+                requestDto.getCarrier(), requestDto.getPlanName())) {
+            throw new CustomException(AuctionErrorCode.PRICE_PLAN_ALREADY_EXISTS);
+        }
+
+        PricePlan pricePlan = requestDto.toEntity();
+        PricePlan savedPricePlan = pricePlanRepository.save(pricePlan);
+
+        log.info("요금제 생성 완료 - id: {}, carrier: {}, planName: {}", 
+                savedPricePlan.getId(), savedPricePlan.getCarrier(), savedPricePlan.getPlanName());
+
+        return PricePlanResponseDto.from(savedPricePlan);
+    }
+
+    @Transactional
+    public void deactivatePricePlan(UUID id) {
+        PricePlan pricePlan = pricePlanRepository.findById(id)
+                .orElseThrow(() -> new CustomException(AuctionErrorCode.PRICE_PLAN_NOT_FOUND));
+
+        pricePlan.deactivate();
+
+        log.info("요금제 비활성화 완료 - id: {}, planName: {}", id, pricePlan.getPlanName());
+    }
+
+    @Transactional
+    public void activatePricePlan(UUID id) {
+        PricePlan pricePlan = pricePlanRepository.findById(id)
+                .orElseThrow(() -> new CustomException(AuctionErrorCode.PRICE_PLAN_NOT_FOUND));
+
+        pricePlan.activate();
+
+        log.info("요금제 활성화 완료 - id: {}, planName: {}", id, pricePlan.getPlanName());
+    }
+
+    @Transactional
+    public void updateDisplayOrder(UUID id, Integer displayOrder) {
+        PricePlan pricePlan = pricePlanRepository.findById(id)
+                .orElseThrow(() -> new CustomException(AuctionErrorCode.PRICE_PLAN_NOT_FOUND));
+
+        pricePlan.updateDisplayOrder(displayOrder);
+
+        log.info("요금제 순서 변경 완료 - id: {}, displayOrder: {}", id, displayOrder);
+    }
+}

--- a/backend/src/main/java/com/phonebid/app/auction/service/PricePlanService.java
+++ b/backend/src/main/java/com/phonebid/app/auction/service/PricePlanService.java
@@ -67,7 +67,7 @@ public class PricePlanService {
 
     @Transactional
     public PricePlanResponseDto createPricePlan(PricePlanCreateRequestDto requestDto) {
-        if (pricePlanRepository.existsByCarrierAndPlanNameAndIsActiveTrue(
+        if (pricePlanRepository.existsByCarrierAndPlanName(
                 requestDto.getCarrier(), requestDto.getPlanName())) {
             throw new CustomException(AuctionErrorCode.PRICE_PLAN_ALREADY_EXISTS);
         }

--- a/backend/src/main/java/com/phonebid/app/common/errorcode/AuctionErrorCode.java
+++ b/backend/src/main/java/com/phonebid/app/common/errorcode/AuctionErrorCode.java
@@ -31,7 +31,14 @@ public enum AuctionErrorCode implements ErrorCode {
     QUOTE_NOT_OWNED_BY_USER(HttpStatus.FORBIDDEN, "해당 유저가 올린 견적이 아닙니다."),
     BID_NOT_EXISTS_FOR_SELLER(HttpStatus.NOT_FOUND, "해당 견적에 입찰한 이력이 없습니다."),
     BID_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 입찰에 대한 접근 권한이 없습니다."),
-    INVALID_ADDITIONAL_SERVICE(HttpStatus.BAD_REQUEST, "부가서비스가 올바른 입찰에 연결되지 않았습니다.");
+    INVALID_ADDITIONAL_SERVICE(HttpStatus.BAD_REQUEST, "부가서비스가 올바른 입찰에 연결되지 않았습니다."),
+    IDENTITY_VERIFICATION_REQUIRED(HttpStatus.FORBIDDEN, "본인인증이 필요합니다."),
+    MVNO_DEVICE_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "알뜰폰 사용자는 기기변경이 불가합니다. 번호이동을 이용해주세요."),
+    INVALID_DEVICE_CHANGE_CARRIER(HttpStatus.BAD_REQUEST, "기기변경 시 현재 통신사와 동일한 통신사만 선택 가능합니다."),
+    INVALID_NUMBER_TRANSFER_CARRIER(HttpStatus.BAD_REQUEST, "번호이동 시 현재 통신사를 제외한 주요 통신사만 선택 가능합니다."),
+    PRICE_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "요금제를 찾을 수 없습니다."),
+    PRICE_PLAN_ALREADY_EXISTS(HttpStatus.CONFLICT, "동일한 이름의 활성 요금제가 이미 존재합니다."),
+    PRICE_PLAN_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "비활성화된 요금제는 선택할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,14 +25,10 @@ spring:
       max-file-size: 500MB
       max-request-size: 500MB
 
-  sql:
-    init:
-      mode: always
 
   jpa:
     hibernate:
       ddl-auto: update
-    defer-datasource-initialization: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -243,6 +243,10 @@ INSERT INTO users (id, username, password, email, name, nickname, phone, role, p
 VALUES ('f0f0a444-4444-4444-8444-444444444444', 'seed_seller_b_20260308', '$2a$10$7eqJtq98hPqEX7fNZaFWoO.HVQ5fD4QnQeNf5f7dI4A4A4A4A4A4O', 'seed.seller.b.20260308@phonebid.local', '이판매', '판매자B', '01045678901', 'SELLER', NULL, NULL, NULL, 'LGU', TRUE, '2026-03-08 10:00:00', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
 ON CONFLICT (id) DO NOTHING;
 
+INSERT INTO users (id, username, password, email, name, nickname, phone, role, provider, provider_id, profile_image_url, carrier, is_identity_verified, verified_at, created_at, updated_at, is_delete)
+VALUES ('f0f0a555-5555-4555-8555-555555555555', 'seller1', '$2b$10$.Jm8hl1MzLyeKg0R7LbscOBgvRxR7t310WSR0NQSTX40den2J5L.S', 'seller1@phonebid.local', '테스트판매자', '판매자1', '01055555555', 'SELLER', NULL, NULL, NULL, 'SKT', TRUE, '2026-03-08 10:00:00', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO UPDATE SET password = '$2b$10$.Jm8hl1MzLyeKg0R7LbscOBgvRxR7t310WSR0NQSTX40den2J5L.S';
+
 -- Sellers
 INSERT INTO sellers (seller_id, user_id, business_number, store_name, approval_status, postal_code, address, detail_address, is_agent, representative_name, business_postal_code, business_address, business_detail_address, consent_number, customer_service_phone, created_at, updated_at, is_delete)
 VALUES ('a1b2c311-1111-4111-8111-111111111111', 'f0f0a333-3333-4333-8333-333333333333', '123-45-67890', '폰비드 강남점', 'APPROVED', '06234', '서울 강남구 테헤란로 1', '101호', TRUE, '박판매', '06234', '서울 강남구 테헤란로 1', '101호', 'CN-2026-SELLER-A', '0212345678', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
@@ -250,6 +254,10 @@ ON CONFLICT (seller_id) DO NOTHING;
 
 INSERT INTO sellers (seller_id, user_id, business_number, store_name, approval_status, postal_code, address, detail_address, is_agent, representative_name, business_postal_code, business_address, business_detail_address, consent_number, customer_service_phone, created_at, updated_at, is_delete)
 VALUES ('a1b2c322-2222-4222-8222-222222222222', 'f0f0a444-4444-4444-8444-444444444444', '234-56-78901', '폰비드 마포점', 'APPROVED', '04123', '서울 마포구 월드컵북로 2', '202호', FALSE, '이판매', '04123', '서울 마포구 월드컵북로 2', '202호', 'CN-2026-SELLER-B', '0298765432', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (seller_id) DO NOTHING;
+
+INSERT INTO sellers (seller_id, user_id, business_number, store_name, approval_status, postal_code, address, detail_address, is_agent, representative_name, business_postal_code, business_address, business_detail_address, consent_number, customer_service_phone, created_at, updated_at, is_delete)
+VALUES ('a1b2c333-3333-4333-8333-333333333333', 'f0f0a555-5555-4555-8555-555555555555', '345-67-89012', '테스트 판매점', 'APPROVED', '12345', '서울 종로구 종로 1', '301호', TRUE, '테스트판매자', '12345', '서울 종로구 종로 1', '301호', 'CN-2026-SELLER-TEST', '0211112222', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
 ON CONFLICT (seller_id) DO NOTHING;
 
 -- Quotes (consumer requests)

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -222,3 +222,189 @@ INSERT INTO phone_options (id, model_id, option_type, option_value, display_labe
 INSERT INTO phone_options (id, model_id, option_type, option_value, display_label, created_at, updated_at, is_delete) VALUES ('b443b32b-bcd5-4f1f-9fe4-5fe59e5e280c', 'c614c39f-eabc-489f-a4db-8f3051621904', 'STORAGE', '512GB', '512GB', '2026-02-23 22:48:49', '2026-02-23 22:48:49', FALSE) ON CONFLICT (id) DO NOTHING;
 INSERT INTO phone_options (id, model_id, option_type, option_value, display_label, created_at, updated_at, is_delete) VALUES ('717a1f98-929c-42a2-b457-1993c5848a97', 'c614c39f-eabc-489f-a4db-8f3051621904', 'STORAGE', '1TB', '1TB', '2026-02-23 22:48:49', '2026-02-23 22:48:49', FALSE) ON CONFLICT (id) DO NOTHING;
 
+-- ========================================================================
+-- Dummy data for local development (user/admin/seller + quote/bid)
+-- ========================================================================
+
+-- Users
+INSERT INTO users (id, username, password, email, name, nickname, phone, role, provider, provider_id, profile_image_url, carrier, is_identity_verified, verified_at, created_at, updated_at, is_delete)
+VALUES ('f0f0a111-1111-4111-8111-111111111111', 'seed_user_20260308', '$2a$10$7eqJtq98hPqEX7fNZaFWoO.HVQ5fD4QnQeNf5f7dI4A4A4A4A4A4O', 'seed.user.20260308@phonebid.local', '홍소비', '소비자샘플', '01012345678', 'CONSUMER', NULL, NULL, NULL, 'KT', TRUE, '2026-03-08 10:00:00', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO users (id, username, password, email, name, nickname, phone, role, provider, provider_id, profile_image_url, carrier, is_identity_verified, verified_at, created_at, updated_at, is_delete)
+VALUES ('f0f0a222-2222-4222-8222-222222222222', 'seed_admin_20260308', '$2a$10$7eqJtq98hPqEX7fNZaFWoO.HVQ5fD4QnQeNf5f7dI4A4A4A4A4A4O', 'seed.admin.20260308@phonebid.local', '김관리', '관리자샘플', '01023456789', 'ADMIN', NULL, NULL, NULL, 'SKT', TRUE, '2026-03-08 10:00:00', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO users (id, username, password, email, name, nickname, phone, role, provider, provider_id, profile_image_url, carrier, is_identity_verified, verified_at, created_at, updated_at, is_delete)
+VALUES ('f0f0a333-3333-4333-8333-333333333333', 'seed_seller_a_20260308', '$2a$10$7eqJtq98hPqEX7fNZaFWoO.HVQ5fD4QnQeNf5f7dI4A4A4A4A4A4O', 'seed.seller.a.20260308@phonebid.local', '박판매', '판매자A', '01034567890', 'SELLER', NULL, NULL, NULL, 'SKT', TRUE, '2026-03-08 10:00:00', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO users (id, username, password, email, name, nickname, phone, role, provider, provider_id, profile_image_url, carrier, is_identity_verified, verified_at, created_at, updated_at, is_delete)
+VALUES ('f0f0a444-4444-4444-8444-444444444444', 'seed_seller_b_20260308', '$2a$10$7eqJtq98hPqEX7fNZaFWoO.HVQ5fD4QnQeNf5f7dI4A4A4A4A4A4O', 'seed.seller.b.20260308@phonebid.local', '이판매', '판매자B', '01045678901', 'SELLER', NULL, NULL, NULL, 'LGU', TRUE, '2026-03-08 10:00:00', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+-- Sellers
+INSERT INTO sellers (seller_id, user_id, business_number, store_name, approval_status, postal_code, address, detail_address, is_agent, representative_name, business_postal_code, business_address, business_detail_address, consent_number, customer_service_phone, created_at, updated_at, is_delete)
+VALUES ('a1b2c311-1111-4111-8111-111111111111', 'f0f0a333-3333-4333-8333-333333333333', '123-45-67890', '폰비드 강남점', 'APPROVED', '06234', '서울 강남구 테헤란로 1', '101호', TRUE, '박판매', '06234', '서울 강남구 테헤란로 1', '101호', 'CN-2026-SELLER-A', '0212345678', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (seller_id) DO NOTHING;
+
+INSERT INTO sellers (seller_id, user_id, business_number, store_name, approval_status, postal_code, address, detail_address, is_agent, representative_name, business_postal_code, business_address, business_detail_address, consent_number, customer_service_phone, created_at, updated_at, is_delete)
+VALUES ('a1b2c322-2222-4222-8222-222222222222', 'f0f0a444-4444-4444-8444-444444444444', '234-56-78901', '폰비드 마포점', 'APPROVED', '04123', '서울 마포구 월드컵북로 2', '202호', FALSE, '이판매', '04123', '서울 마포구 월드컵북로 2', '202호', 'CN-2026-SELLER-B', '0298765432', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (seller_id) DO NOTHING;
+
+-- Quotes (consumer requests)
+INSERT INTO quotes (id, user_id, phone_model_id, storage, color, carrier, status, expired_at, purchase_method, current_carrier, activation_method, created_at, updated_at, is_delete)
+VALUES ('b1c2d311-1111-4111-8111-111111111111', 'f0f0a111-1111-4111-8111-111111111111', '91bfa9bc-97f8-4093-acd9-749356415499', '667ac51a-e969-4c82-b0c3-13dc3d4d0de6', 'e61714f3-6200-4631-ab9c-bb429f5b9cc9', 'SKT', 'OPEN', '2030-12-31 23:59:59', 'NUMBER_TRANSFER', 'KT', 'SELECTIVE_SUBSIDY', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO quotes (id, user_id, phone_model_id, storage, color, carrier, status, expired_at, purchase_method, current_carrier, activation_method, created_at, updated_at, is_delete)
+VALUES ('b1c2d322-2222-4222-8222-222222222222', 'f0f0a111-1111-4111-8111-111111111111', 'cb4b0a30-3107-4435-b5da-6b07246bc7d4', '33344cdd-eab8-4368-b5b8-b3b801b93fda', '79957f79-1fcd-4e14-a551-83d4308f9c90', 'ANY', 'OPEN', '2030-12-31 23:59:59', 'ANY', NULL, 'ANY', '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+-- ========================================================================
+-- Price Plans Master Data (신규 스키마 기반)
+-- ========================================================================
+
+-- SKT 5G 요금제
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000001-0001-5001-8000-000000000001', 'SKT', 'FIVE_G', '5GX 플래티넘', 125000, '무제한', '-', '집/이동전화 무제한', TRUE, 1, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000002-0001-5001-8000-000000000002', 'SKT', 'FIVE_G', '0 청년 109', 109000, '무제한', '-', '집/이동전화 무제한', TRUE, 2, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000003-0001-5001-8000-000000000003', 'SKT', 'FIVE_G', '5GX 프리미엄', 109000, '무제한', '-', '집/이동전화 무제한', TRUE, 3, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000004-0001-5001-8000-000000000004', 'SKT', 'FIVE_G', '0 청년 99', 99000, '무제한', '-', '집/이동전화 무제한', TRUE, 4, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000005-0001-5001-8000-000000000005', 'SKT', 'FIVE_G', '5GX 프라임플러스', 99000, '무제한', '-', '집/이동전화 무제한', TRUE, 5, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000006-0001-5001-8000-000000000006', 'SKT', 'FIVE_G', '0 청년 89', 89000, '무제한', '-', '집/이동전화 무제한', TRUE, 6, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000007-0001-5001-8000-000000000007', 'SKT', 'FIVE_G', '5GX 프라임', 89000, '무제한', '-', '집/이동전화 무제한', TRUE, 7, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000008-0001-5001-8000-000000000008', 'SKT', 'FIVE_G', '0 청년 79', 79000, '300GB', '5Mbps', '집/이동전화 무제한', TRUE, 8, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000009-0001-5001-8000-000000000009', 'SKT', 'FIVE_G', '5GX 레귤러플러스', 79000, '250GB', '5Mbps', '집/이동전화 무제한', TRUE, 9, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000010-0001-5001-8000-000000000010', 'SKT', 'FIVE_G', '다이렉트5G 76', 76000, '무제한', '-', '집/이동전화 무제한', TRUE, 10, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000011-0001-5001-8000-000000000011', 'SKT', 'FIVE_G', '0 청년 다이렉트 69', 69000, '무제한', '-', '집/이동전화 무제한', TRUE, 11, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000012-0001-5001-8000-000000000012', 'SKT', 'FIVE_G', '다이렉트5G 69', 69000, '무제한', '-', '집/이동전화 무제한', TRUE, 12, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000013-0001-5001-8000-000000000013', 'SKT', 'FIVE_G', '5G 행복누리 레귤러', 69000, '110GB', '5Mbps', '집/이동전화 무제한', TRUE, 13, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000014-0001-5001-8000-000000000014', 'SKT', 'FIVE_G', '0 청년 69', 69000, '160GB', '5Mbps', '집/이동전화 무제한', TRUE, 14, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000015-0001-5001-8000-000000000015', 'SKT', 'FIVE_G', '5GX 레귤러', 69000, '110GB', '5Mbps', '집/이동전화 무제한', TRUE, 15, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('a1000016-0001-5001-8000-000000000016', 'SKT', 'FIVE_G', '슬림', 55000, '15GB', '1Mbps', '집/이동전화 무제한', TRUE, 16, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+
+-- KT 5G 요금제
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000001-0002-5001-8000-000000000001', 'KT', 'FIVE_G', '5G 초이스 프리미엄', 130000, '무제한', '-', '집/이동전화 무제한', TRUE, 1, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000002-0002-5001-8000-000000000002', 'KT', 'FIVE_G', '5G 초이스 스페셜', 110000, '무제한', '-', '집/이동전화 무제한', TRUE, 2, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000003-0002-5001-8000-000000000003', 'KT', 'FIVE_G', '5G 초이스 베이직', 90000, '무제한', '-', '집/이동전화 무제한', TRUE, 3, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000004-0002-5001-8000-000000000004', 'KT', 'FIVE_G', '5G 스페셜', 100000, '무제한', '-', '집/이동전화 무제한', TRUE, 4, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000005-0002-5001-8000-000000000005', 'KT', 'FIVE_G', '5G 스페셜 Y', 100000, '무제한', '-', '집/이동전화 무제한', TRUE, 5, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000006-0002-5001-8000-000000000006', 'KT', 'FIVE_G', '5G 베이직', 80000, '무제한', '-', '집/이동전화 무제한', TRUE, 6, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000007-0002-5001-8000-000000000007', 'KT', 'FIVE_G', '5G 베이직 Y', 80000, '무제한', '-', '집/이동전화 무제한', TRUE, 7, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000008-0002-5001-8000-000000000008', 'KT', 'FIVE_G', '5G 심플 110GB', 69000, '110GB', '5Mbps', '집/이동전화 무제한', TRUE, 8, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000009-0002-5001-8000-000000000009', 'KT', 'FIVE_G', '5G 심플 90GB', 67000, '90GB', '1Mbps', '집/이동전화 무제한', TRUE, 9, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000010-0002-5001-8000-000000000010', 'KT', 'FIVE_G', '5G 심플 70GB', 65000, '70GB', '1Mbps', '집/이동전화 무제한', TRUE, 10, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000011-0002-5001-8000-000000000011', 'KT', 'FIVE_G', '5G 심플 50GB', 63000, '50GB', '1Mbps', '집/이동전화 무제한', TRUE, 11, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000012-0002-5001-8000-000000000012', 'KT', 'FIVE_G', '5G 심플 30GB', 61000, '30GB', '1Mbps', '집/이동전화 무제한', TRUE, 12, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000013-0002-5001-8000-000000000013', 'KT', 'FIVE_G', '5G 슬림 21GB', 58000, '21GB', '1Mbps', '집/이동전화 무제한', TRUE, 13, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000014-0002-5001-8000-000000000014', 'KT', 'FIVE_G', '5G 슬림 14GB', 55000, '14GB', '1Mbps', '집/이동전화 무제한', TRUE, 14, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000015-0002-5001-8000-000000000015', 'KT', 'FIVE_G', '5G 슬림 Y', 55000, '14GB', '1Mbps', '집/이동전화 무제한', TRUE, 15, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000016-0002-5001-8000-000000000016', 'KT', 'FIVE_G', '5G 슬림 10GB', 50000, '10GB', '400Kbps', '집/이동전화 무제한', TRUE, 16, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000017-0002-5001-8000-000000000017', 'KT', 'FIVE_G', '5G 슬림 4GB', 45000, '4GB', '400Kbps', '집/이동전화 무제한', TRUE, 17, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('b1000018-0002-5001-8000-000000000018', 'KT', 'FIVE_G', '5G 슬림 라이트', 37000, '10GB', '1Mbps', '집/이동전화 무제한', TRUE, 18, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+
+-- LGU+ 5G 요금제
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000001-0003-5001-8000-000000000001', 'LGU', 'FIVE_G', '5G 시그니처', 130000, '무제한', '-', '집/이동전화 무제한', TRUE, 1, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000002-0003-5001-8000-000000000002', 'LGU', 'FIVE_G', '5G 프리미어 슈퍼', 115000, '무제한', '-', '집/이동전화 무제한', TRUE, 2, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000003-0003-5001-8000-000000000003', 'LGU', 'FIVE_G', '5G 프리미어 플러스', 105000, '무제한', '-', '집/이동전화 무제한', TRUE, 3, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000004-0003-5001-8000-000000000004', 'LGU', 'FIVE_G', '5G 프리미어 레귤러', 95000, '무제한', '-', '집/이동전화 무제한', TRUE, 4, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000005-0003-5001-8000-000000000005', 'LGU', 'FIVE_G', '5G 프리미어 에센셜', 85000, '무제한', '-', '집/이동전화 무제한', TRUE, 5, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000006-0003-5001-8000-000000000006', 'LGU', 'FIVE_G', '5G 스탠다드', 75000, '150GB', '5Mbps', '집/이동전화 무제한', TRUE, 6, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000007-0003-5001-8000-000000000007', 'LGU', 'FIVE_G', '5G 스탠다드 에센셜', 70000, '125GB', '5Mbps', '집/이동전화 무제한', TRUE, 7, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000008-0003-5001-8000-000000000008', 'LGU', 'FIVE_G', '5G 데이터 레귤러', 63000, '50GB', '1Mbps', '집/이동전화 무제한', TRUE, 8, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1000009-0003-5001-8000-000000000009', 'LGU', 'FIVE_G', '5G 라이트+', 55000, '14GB', '1Mbps', '집/이동전화 무제한', TRUE, 9, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+
+-- LGU+ LTE 요금제
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('d1000001-0004-5001-8000-000000000001', 'LGU', 'LTE', 'LTE 프리미어 플러스', 105000, '무제한', '-', '집/이동전화 무제한', TRUE, 1, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('d1000002-0004-5001-8000-000000000002', 'LGU', 'LTE', '추가요금 걱정없는 69', 69000, '매일 5GB', '5Mbps', '집/이동전화 무제한', TRUE, 2, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('d1000003-0004-5001-8000-000000000003', 'LGU', 'LTE', '추가요금 걱정없는 59', 59000, '6.6GB', '1Mbps', '집/이동전화 무제한', TRUE, 3, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('d1000004-0004-5001-8000-000000000004', 'LGU', 'LTE', '추가요금 걱정없는 49', 49000, '3GB', '1Mbps', '집/이동전화 무제한', TRUE, 4, NOW(), NOW(), FALSE) ON CONFLICT (id) DO NOTHING;
+
+-- ========================================================================
+-- Legacy Price Plans (기존 테스트용 - 신규 스키마 컬럼 기본값 적용)
+-- ========================================================================
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1d2e311-1111-4111-8111-111111111111', 'SKT', 'FIVE_G', '5GX 프라임 110GB', 89000, '110GB', '5Mbps', '집/이동전화 무제한', TRUE, 100, '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1d2e322-2222-4222-8222-222222222222', 'SKT', 'FIVE_G', '5GX 스탠다드', 69000, '110GB', '5Mbps', '집/이동전화 무제한', TRUE, 101, '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO price_plans (id, carrier, category, plan_name, monthly_fee, data_allowance_text, throttle_speed_text, voice_sms_text, is_active, display_order, created_at, updated_at, is_delete)
+VALUES ('c1d2e333-3333-4333-8333-333333333333', 'LGU', 'FIVE_G', '5G 프리미어 에센셜', 85000, '무제한', '-', '집/이동전화 무제한', TRUE, 102, '2026-03-08 10:00:00', '2026-03-08 10:00:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+-- Bids from sellers
+INSERT INTO bids (id, quote_id, seller_id, price_plan_id, price, delivery_days, rating_snapshot, purchase_method, carrier, current_carrier, activation_method, additional_subsidy, installment_principal, contract_months, status, created_at, updated_at, is_delete)
+VALUES ('d1e2f311-1111-4111-8111-111111111111', 'b1c2d311-1111-4111-8111-111111111111', 'a1b2c311-1111-4111-8111-111111111111', 'c1d2e311-1111-4111-8111-111111111111', 980000, 1, 4.8, 'NUMBER_TRANSFER', 'SKT', 'KT', 'SELECTIVE_SUBSIDY', 120000, 350000, 24, 'ACTIVE', '2026-03-08 10:10:00', '2026-03-08 10:10:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bids (id, quote_id, seller_id, price_plan_id, price, delivery_days, rating_snapshot, purchase_method, carrier, current_carrier, activation_method, additional_subsidy, installment_principal, contract_months, status, created_at, updated_at, is_delete)
+VALUES ('d1e2f322-2222-4222-8222-222222222222', 'b1c2d311-1111-4111-8111-111111111111', 'a1b2c322-2222-4222-8222-222222222222', 'c1d2e322-2222-4222-8222-222222222222', 965000, 2, 4.6, 'NUMBER_TRANSFER', 'SKT', 'KT', 'COMMON_SUBSIDY', 100000, 330000, 24, 'ACTIVE', '2026-03-08 10:12:00', '2026-03-08 10:12:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bids (id, quote_id, seller_id, price_plan_id, price, delivery_days, rating_snapshot, purchase_method, carrier, current_carrier, activation_method, additional_subsidy, installment_principal, contract_months, status, created_at, updated_at, is_delete)
+VALUES ('d1e2f333-3333-4333-8333-333333333333', 'b1c2d322-2222-4222-8222-222222222222', 'a1b2c322-2222-4222-8222-222222222222', 'c1d2e333-3333-4333-8333-333333333333', 1050000, 3, 4.7, 'NEW_SUBSCRIPTION', 'LGU', NULL, 'COMMON_SUBSIDY', 80000, 420000, 24, 'ACTIVE', '2026-03-08 10:20:00', '2026-03-08 10:20:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+-- Additional services attached to bids
+INSERT INTO bid_additional_services (id, bid_id, service_name, service_price, description, mandatory, cancellable_after_months, created_at, updated_at, is_delete)
+VALUES ('e1f2a311-1111-4111-8111-111111111111', 'd1e2f311-1111-4111-8111-111111111111', '통화안심보험', 4900, '파손/분실 보장 보험', TRUE, 3, '2026-03-08 10:10:00', '2026-03-08 10:10:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bid_additional_services (id, bid_id, service_name, service_price, description, mandatory, cancellable_after_months, created_at, updated_at, is_delete)
+VALUES ('e1f2a322-2222-4222-8222-222222222222', 'd1e2f322-2222-4222-8222-222222222222', '데이터쉐어링', 5500, '태블릿/워치 데이터 공유', FALSE, 1, '2026-03-08 10:12:00', '2026-03-08 10:12:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bid_additional_services (id, bid_id, service_name, service_price, description, mandatory, cancellable_after_months, created_at, updated_at, is_delete)
+VALUES ('e1f2a333-3333-4333-8333-333333333333', 'd1e2f333-3333-4333-8333-333333333333', '유심보호서비스', 0, '유심 교체/보호 부가서비스', FALSE, NULL, '2026-03-08 10:20:00', '2026-03-08 10:20:00', FALSE)
+ON CONFLICT (id) DO NOTHING;
+

--- a/frontend/src/hooks/useBidForm.ts
+++ b/frontend/src/hooks/useBidForm.ts
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from "react";
 import type { QuoteDetail } from "types/QuoteTypes";
-import type { BidCreateRequest, AdditionalServiceRequest } from "types/SellerTypes";
+import type { BidCreateRequest, AdditionalServiceRequest, PricePlan } from "types/SellerTypes";
 import {
   calculateInstallmentPrincipal,
   calculateMonthlyInstallment,
@@ -20,8 +20,8 @@ export interface BidFormData {
   currentCarrier?: "SKT" | "KT" | "LGU" | "SKT_ALD" | "KT_ALD" | "LGU_ALD" | "ANY";
   activationMethod: "COMMON_SUBSIDY" | "SELECTIVE_SUBSIDY" | "ANY";
   installmentMonths: number;
-  pricePlanName: string;
-  pricePlanPrice: number;
+  pricePlanId: string;
+  selectedPricePlan: PricePlan | null;
   pricePlanMaintenanceMonths: number;
   lineMaintenanceMonths: number;
   additionalServices: AdditionalServiceRequest[];
@@ -33,8 +33,7 @@ export interface BidFormErrors {
   devicePrice?: string;
   publicSubsidy?: string;
   additionalSubsidy?: string;
-  pricePlanName?: string;
-  pricePlanPrice?: string;
+  pricePlanId?: string;
   deliveryDays?: string;
 }
 
@@ -48,8 +47,8 @@ export const useBidForm = (quote: QuoteDetail | null) => {
     currentCarrier: quote?.currentCarrier,
     activationMethod: quote?.activationMethod || "COMMON_SUBSIDY",
     installmentMonths: DEFAULT_INSTALLMENT_MONTHS,
-    pricePlanName: "",
-    pricePlanPrice: 0,
+    pricePlanId: "",
+    selectedPricePlan: null,
     pricePlanMaintenanceMonths: BID_FORM_DEFAULTS.PRICE_PLAN_MAINTENANCE_MONTHS,
     lineMaintenanceMonths: BID_FORM_DEFAULTS.LINE_MAINTENANCE_MONTHS,
     additionalServices: [],
@@ -90,9 +89,11 @@ export const useBidForm = (quote: QuoteDetail | null) => {
       0
     );
 
+    const pricePlanPrice = formData.selectedPricePlan?.monthlyFee ?? 0;
+
     const totalMonthlyPayment = calculateTotalMonthlyPayment(
       monthlyInstallment,
-      formData.pricePlanPrice,
+      pricePlanPrice,
       additionalServicesPrice
     );
 
@@ -101,6 +102,7 @@ export const useBidForm = (quote: QuoteDetail | null) => {
       monthlyInstallment,
       totalMonthlyPayment,
       additionalServicesPrice,
+      pricePlanPrice,
     };
   }, [formData]);
 
@@ -129,12 +131,8 @@ export const useBidForm = (quote: QuoteDetail | null) => {
       newErrors.additionalSubsidy = "추가지원금은 0 이상이어야 합니다.";
     }
 
-    if (!formData.pricePlanName.trim()) {
-      newErrors.pricePlanName = "요금제를 선택해주세요.";
-    }
-
-    if (formData.pricePlanPrice <= 0) {
-      newErrors.pricePlanPrice = "요금제 가격을 입력해주세요.";
+    if (!formData.pricePlanId || !formData.selectedPricePlan) {
+      newErrors.pricePlanId = "요금제를 선택해주세요.";
     }
 
     if (formData.deliveryDays < 1) {
@@ -146,7 +144,7 @@ export const useBidForm = (quote: QuoteDetail | null) => {
   };
 
   const toBidCreateRequest = (): BidCreateRequest | null => {
-    if (!quote) return null;
+    if (!quote || !formData.pricePlanId) return null;
     return {
       quoteId: quote.id,
       price: formData.publicSubsidy + formData.additionalSubsidy,
@@ -158,10 +156,20 @@ export const useBidForm = (quote: QuoteDetail | null) => {
       additionalSubsidy: formData.additionalSubsidy > 0 ? formData.additionalSubsidy : undefined,
       installmentPrincipal: calculations.installmentPrincipal,
       contractMonths: formData.installmentMonths,
-      pricePlanName: formData.pricePlanName,
-      pricePlanPrice: formData.pricePlanPrice,
+      pricePlanId: formData.pricePlanId,
       additionalServices: formData.additionalServices.length > 0 ? formData.additionalServices : undefined,
     };
+  };
+
+  const selectPricePlan = (pricePlan: PricePlan) => {
+    setFormData((prev) => ({
+      ...prev,
+      pricePlanId: pricePlan.id,
+      selectedPricePlan: pricePlan,
+    }));
+    if (errors.pricePlanId) {
+      setErrors((prev) => ({ ...prev, pricePlanId: undefined }));
+    }
   };
 
   return {
@@ -171,6 +179,7 @@ export const useBidForm = (quote: QuoteDetail | null) => {
     updateField,
     validate,
     toBidCreateRequest,
+    selectPricePlan,
   };
 };
 

--- a/frontend/src/pages/BidDetailPage.tsx
+++ b/frontend/src/pages/BidDetailPage.tsx
@@ -152,6 +152,21 @@ const BidDetailPage = () => {
                   {formatPrice(bid.pricePlanPrice)}
                 </span>
               </div>
+              {(bid.pricePlanDataAllowance || bid.pricePlanVoiceSms) && (
+                <div className="text-xs text-gray-500 space-y-0.5 mt-1">
+                  {bid.pricePlanCategory && (
+                    <span className="inline-block px-1.5 py-0.5 bg-gray-100 rounded text-gray-600 mr-1">
+                      {bid.pricePlanCategory === "FIVE_G" ? "5G" : "LTE"}
+                    </span>
+                  )}
+                  {bid.pricePlanDataAllowance && (
+                    <span>데이터 {bid.pricePlanDataAllowance}</span>
+                  )}
+                  {bid.pricePlanThrottleSpeed && bid.pricePlanThrottleSpeed !== "-" && (
+                    <span className="ml-1">(소진 시 {bid.pricePlanThrottleSpeed})</span>
+                  )}
+                </div>
+              )}
               {bid.pricePlanPrice && bid.pricePlanPrice >= 10000 && (
                 <p className="text-xs text-gray-500 mt-2">
                   3개월 후 10,000원 이상 요금제로 변경할 수 있습니다.

--- a/frontend/src/pages/BidDetailPage.tsx
+++ b/frontend/src/pages/BidDetailPage.tsx
@@ -165,6 +165,19 @@ const BidDetailPage = () => {
                   {bid.pricePlanThrottleSpeed && bid.pricePlanThrottleSpeed !== "-" && (
                     <span className="ml-1">(소진 시 {bid.pricePlanThrottleSpeed})</span>
                   )}
+                  {bid.pricePlanVoiceSms && (
+                    <span
+                      className={
+                        bid.pricePlanDataAllowance ||
+                        (bid.pricePlanThrottleSpeed &&
+                          bid.pricePlanThrottleSpeed !== "-")
+                          ? "ml-1"
+                          : ""
+                      }
+                    >
+                      음성/문자 {bid.pricePlanVoiceSms}
+                    </span>
+                  )}
                 </div>
               )}
               {bid.pricePlanPrice && bid.pricePlanPrice >= 10000 && (

--- a/frontend/src/pages/seller/SellerBidCreatePage.tsx
+++ b/frontend/src/pages/seller/SellerBidCreatePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useBidForm } from "hooks/useBidForm";
 import { QuoteRequestInfo } from "components/seller/QuoteRequestInfo";
@@ -23,6 +23,10 @@ const SellerBidCreatePage: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<PricePlanCategory>("FIVE_G");
 
   const bidForm = useBidForm(quote);
+  const bidFormRef = useRef(bidForm);
+  bidFormRef.current = bidForm;
+
+  const pricePlansRequestIdRef = useRef(0);
 
   useEffect(() => {
     if (!quoteId) {
@@ -50,6 +54,9 @@ const SellerBidCreatePage: React.FC = () => {
   useEffect(() => {
     const loadPricePlans = async () => {
       if (!quote) return;
+
+      const requestId = ++pricePlansRequestIdRef.current;
+
       const carrierForPlans = quote.carrier === "ANY" ? undefined : 
         (quote.carrier === "SKT_ALD" ? "SKT" : 
          quote.carrier === "KT_ALD" ? "KT" : 
@@ -61,8 +68,21 @@ const SellerBidCreatePage: React.FC = () => {
           carrier: carrierForPlans, 
           category: selectedCategory 
         });
+        if (requestId !== pricePlansRequestIdRef.current) {
+          return;
+        }
         setPricePlans(plans);
+
+        const { pricePlanId, selectedPricePlan } = bidFormRef.current.formData;
+        const selectedId = pricePlanId || selectedPricePlan?.id || "";
+        if (selectedId && !plans.some((p) => p.id === selectedId)) {
+          bidFormRef.current.updateField("pricePlanId", "");
+          bidFormRef.current.updateField("selectedPricePlan", null);
+        }
       } catch (error) {
+        if (requestId !== pricePlansRequestIdRef.current) {
+          return;
+        }
         logError("요금제 목록 조회 실패:", error);
       }
     };

--- a/frontend/src/pages/seller/SellerBidCreatePage.tsx
+++ b/frontend/src/pages/seller/SellerBidCreatePage.tsx
@@ -329,12 +329,16 @@ const SellerBidCreatePage: React.FC = () => {
 
                 <div className="space-y-4 pt-4 border-t">
                   <div>
-                    <label className="text-sm font-medium text-foreground mb-2 block">
+                    <label
+                      htmlFor="seller-bid-price-plan-select"
+                      className="text-sm font-medium text-foreground mb-2 block"
+                    >
                       요금제 선택
                     </label>
                     <div className="flex gap-2 mb-3">
                       <button
                         type="button"
+                        aria-pressed={selectedCategory === "FIVE_G"}
                         onClick={() => setSelectedCategory("FIVE_G")}
                         className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                           selectedCategory === "FIVE_G"
@@ -346,6 +350,7 @@ const SellerBidCreatePage: React.FC = () => {
                       </button>
                       <button
                         type="button"
+                        aria-pressed={selectedCategory === "LTE"}
                         onClick={() => setSelectedCategory("LTE")}
                         className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                           selectedCategory === "LTE"
@@ -357,6 +362,7 @@ const SellerBidCreatePage: React.FC = () => {
                       </button>
                     </div>
                     <select
+                      id="seller-bid-price-plan-select"
                       value={bidForm.formData.pricePlanId}
                       onChange={(e) => {
                         const plan = pricePlans.find(p => p.id === e.target.value);

--- a/frontend/src/pages/seller/SellerBidCreatePage.tsx
+++ b/frontend/src/pages/seller/SellerBidCreatePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useBidForm } from "hooks/useBidForm";
 import { QuoteRequestInfo } from "components/seller/QuoteRequestInfo";
 import { getQuoteDetail } from "services/quoteService";
+import { getActivePricePlans } from "services/pricePlanService";
 import { sellerService } from "services/sellerService";
 import { Card, CardContent, CardHeader, CardTitle } from "components/ui/card";
 import { Button } from "components/ui/button";
@@ -10,6 +11,7 @@ import { formatNumber } from "utils/formatters";
 import { logError } from "utils/errorUtils";
 import { toast } from "react-toastify";
 import type { QuoteDetail } from "types/QuoteTypes";
+import type { PricePlan, PricePlanCategory } from "types/SellerTypes";
 
 const SellerBidCreatePage: React.FC = () => {
   const navigate = useNavigate();
@@ -17,6 +19,8 @@ const SellerBidCreatePage: React.FC = () => {
   const [quote, setQuote] = useState<QuoteDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [pricePlans, setPricePlans] = useState<PricePlan[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<PricePlanCategory>("FIVE_G");
 
   const bidForm = useBidForm(quote);
 
@@ -42,6 +46,29 @@ const SellerBidCreatePage: React.FC = () => {
 
     loadQuote();
   }, [quoteId, navigate]);
+
+  useEffect(() => {
+    const loadPricePlans = async () => {
+      if (!quote) return;
+      const carrierForPlans = quote.carrier === "ANY" ? undefined : 
+        (quote.carrier === "SKT_ALD" ? "SKT" : 
+         quote.carrier === "KT_ALD" ? "KT" : 
+         quote.carrier === "LGU_ALD" ? "LGU" : 
+         quote.carrier as "SKT" | "KT" | "LGU");
+      
+      try {
+        const plans = await getActivePricePlans({ 
+          carrier: carrierForPlans, 
+          category: selectedCategory 
+        });
+        setPricePlans(plans);
+      } catch (error) {
+        logError("요금제 목록 조회 실패:", error);
+      }
+    };
+
+    loadPricePlans();
+  }, [quote, selectedCategory]);
 
   const handleBack = () => {
     navigate("/seller-center");
@@ -282,50 +309,65 @@ const SellerBidCreatePage: React.FC = () => {
 
                 <div className="space-y-4 pt-4 border-t">
                   <div>
-                    <label className="text-sm font-medium text-foreground">
+                    <label className="text-sm font-medium text-foreground mb-2 block">
                       요금제 선택
                     </label>
-                    <input
-                      type="text"
-                      value={bidForm.formData.pricePlanName}
-                      onChange={(e) =>
-                        bidForm.updateField("pricePlanName", e.target.value)
-                      }
-                      placeholder="예: 5G 프리미어 에센셜"
-                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                    {bidForm.errors.pricePlanName && (
+                    <div className="flex gap-2 mb-3">
+                      <button
+                        type="button"
+                        onClick={() => setSelectedCategory("FIVE_G")}
+                        className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                          selectedCategory === "FIVE_G"
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-muted text-muted-foreground hover:bg-muted/80"
+                        }`}
+                      >
+                        5G
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedCategory("LTE")}
+                        className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                          selectedCategory === "LTE"
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-muted text-muted-foreground hover:bg-muted/80"
+                        }`}
+                      >
+                        LTE
+                      </button>
+                    </div>
+                    <select
+                      value={bidForm.formData.pricePlanId}
+                      onChange={(e) => {
+                        const plan = pricePlans.find(p => p.id === e.target.value);
+                        if (plan) bidForm.selectPricePlan(plan);
+                      }}
+                      className="w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value="">요금제를 선택해주세요</option>
+                      {pricePlans.map((plan) => (
+                        <option key={plan.id} value={plan.id}>
+                          {plan.planName} - {formatNumber(plan.monthlyFee)}원 ({plan.dataAllowanceText || "데이터 정보 없음"})
+                        </option>
+                      ))}
+                    </select>
+                    {bidForm.errors.pricePlanId && (
                       <p className="mt-1 text-sm text-red-500">
-                        {bidForm.errors.pricePlanName}
+                        {bidForm.errors.pricePlanId}
                       </p>
                     )}
-                  </div>
-
-                  <div>
-                    <label className="text-sm font-medium text-foreground">
-                      요금제 가격
-                    </label>
-                    <input
-                      type="text"
-                      value={
-                        bidForm.formData.pricePlanPrice > 0
-                          ? formatNumber(bidForm.formData.pricePlanPrice)
-                          : ""
-                      }
-                      onChange={(e) => {
-                        const numericValue = e.target.value.replace(/[^0-9]/g, "");
-                        bidForm.updateField(
-                          "pricePlanPrice",
-                          parseInt(numericValue) || 0
-                        );
-                      }}
-                      placeholder="0"
-                      className="mt-1 w-full border border-input rounded-md h-10 px-3 bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                    {bidForm.errors.pricePlanPrice && (
-                      <p className="mt-1 text-sm text-red-500">
-                        {bidForm.errors.pricePlanPrice}
-                      </p>
+                    {bidForm.formData.selectedPricePlan && (
+                      <div className="mt-2 p-3 bg-muted rounded-md text-sm">
+                        <div className="font-medium">{bidForm.formData.selectedPricePlan.planName}</div>
+                        <div className="text-muted-foreground text-xs mt-1 space-y-0.5">
+                          <div>월정액: {formatNumber(bidForm.formData.selectedPricePlan.monthlyFee)}원</div>
+                          <div>데이터: {bidForm.formData.selectedPricePlan.dataAllowanceText || "-"}</div>
+                          {bidForm.formData.selectedPricePlan.throttleSpeedText && bidForm.formData.selectedPricePlan.throttleSpeedText !== "-" && (
+                            <div>소진 시: {bidForm.formData.selectedPricePlan.throttleSpeedText}</div>
+                          )}
+                          <div>음성/문자: {bidForm.formData.selectedPricePlan.voiceSmsText || "-"}</div>
+                        </div>
+                      </div>
                     )}
                   </div>
 

--- a/frontend/src/services/pricePlanService.ts
+++ b/frontend/src/services/pricePlanService.ts
@@ -1,0 +1,24 @@
+import { apiClient } from "./apiClient";
+import type { PricePlan, PricePlanCategory } from "types/SellerTypes";
+
+const BASE_URL = "/auction/price-plans";
+
+export interface PricePlanFilters {
+  carrier?: "SKT" | "KT" | "LGU";
+  category?: PricePlanCategory;
+}
+
+export async function getActivePricePlans(filters?: PricePlanFilters): Promise<PricePlan[]> {
+  const params = new URLSearchParams();
+  if (filters?.carrier) params.append("carrier", filters.carrier);
+  if (filters?.category) params.append("category", filters.category);
+
+  const queryString = params.toString();
+  const url = queryString ? `${BASE_URL}?${queryString}` : BASE_URL;
+
+  return await apiClient.get<PricePlan[]>(url);
+}
+
+export async function getPricePlanById(id: string): Promise<PricePlan> {
+  return await apiClient.get<PricePlan>(`${BASE_URL}/${id}`);
+}

--- a/frontend/src/services/quoteService.ts
+++ b/frontend/src/services/quoteService.ts
@@ -34,8 +34,10 @@ interface BidListResponseDto {
   sellerRating: number | null;
   installmentPrincipal: number;
   totalMaintenanceCost: number;
+  pricePlanId: string | null;
   pricePlanName: string | null;
   pricePlanPrice: number | null;
+  pricePlanCategory: "FIVE_G" | "LTE" | null;
   status: "ACTIVE" | "SELECTED" | "REJECTED" | "WITHDRAWN";
   createdAt: string;
 }
@@ -151,8 +153,10 @@ export const getBidsByQuoteId = async (
     sellerRating: item.sellerRating,
     installmentPrincipal: item.installmentPrincipal,
     totalMaintenanceCost: item.totalMaintenanceCost,
+    pricePlanId: item.pricePlanId,
     pricePlanName: item.pricePlanName,
     pricePlanPrice: item.pricePlanPrice,
+    pricePlanCategory: item.pricePlanCategory,
     status: item.status,
     createdAt: item.createdAt,
   }));
@@ -172,8 +176,13 @@ interface BidResponseDto {
   installmentPrincipal: number;
   additionalSubsidy: number | null;
   totalMaintenanceCost: number;
+  pricePlanId: string | null;
   pricePlanName: string | null;
   pricePlanPrice: number | null;
+  pricePlanCategory: "FIVE_G" | "LTE" | null;
+  pricePlanDataAllowance: string | null;
+  pricePlanThrottleSpeed: string | null;
+  pricePlanVoiceSms: string | null;
   additionalServices: Array<{
     id: string;
     serviceName: string;
@@ -208,8 +217,13 @@ export const getBidDetail = async (bidId: string): Promise<BidDetail> => {
     installmentPrincipal: response.installmentPrincipal,
     additionalSubsidy: response.additionalSubsidy,
     totalMaintenanceCost: response.totalMaintenanceCost,
+    pricePlanId: response.pricePlanId,
     pricePlanName: response.pricePlanName,
     pricePlanPrice: response.pricePlanPrice,
+    pricePlanCategory: response.pricePlanCategory,
+    pricePlanDataAllowance: response.pricePlanDataAllowance,
+    pricePlanThrottleSpeed: response.pricePlanThrottleSpeed,
+    pricePlanVoiceSms: response.pricePlanVoiceSms,
     additionalServices: response.additionalServices.map((service) => ({
       id: service.id,
       serviceName: service.serviceName,

--- a/frontend/src/types/QuoteTypes.ts
+++ b/frontend/src/types/QuoteTypes.ts
@@ -72,6 +72,8 @@ export interface QuoteListItem {
   lowestPrice: number | null;
 }
 
+export type PricePlanCategory = "FIVE_G" | "LTE";
+
 export interface BidListItem {
   id: string;
   sellerId: string;
@@ -79,8 +81,10 @@ export interface BidListItem {
   sellerRating: number | null;
   installmentPrincipal: number;
   totalMaintenanceCost: number;
+  pricePlanId: string | null;
   pricePlanName: string | null;
   pricePlanPrice: number | null;
+  pricePlanCategory: PricePlanCategory | null;
   status: "ACTIVE" | "SELECTED" | "REJECTED" | "WITHDRAWN";
   createdAt: string;
 }
@@ -105,8 +109,13 @@ export interface BidDetail {
   installmentPrincipal: number;
   additionalSubsidy: number | null;
   totalMaintenanceCost: number;
+  pricePlanId: string | null;
   pricePlanName: string | null;
   pricePlanPrice: number | null;
+  pricePlanCategory: PricePlanCategory | null;
+  pricePlanDataAllowance: string | null;
+  pricePlanThrottleSpeed: string | null;
+  pricePlanVoiceSms: string | null;
   additionalServices: AdditionalService[];
   additionalServicesCount: number;
   additionalServicesTotalPrice: number;

--- a/frontend/src/types/SellerTypes.ts
+++ b/frontend/src/types/SellerTypes.ts
@@ -86,9 +86,23 @@ export interface BidCreateRequest {
   additionalSubsidy?: number;
   installmentPrincipal: number;
   contractMonths?: number;
-  pricePlanName: string;
-  pricePlanPrice: number;
+  pricePlanId: string;
   additionalServices?: AdditionalServiceRequest[];
+}
+
+export type PricePlanCategory = "FIVE_G" | "LTE";
+
+export interface PricePlan {
+  id: string;
+  carrier: "SKT" | "KT" | "LGU";
+  category: PricePlanCategory;
+  planName: string;
+  monthlyFee: number;
+  dataAllowanceText: string | null;
+  throttleSpeedText: string | null;
+  voiceSmsText: string | null;
+  isActive: boolean;
+  displayOrder: number | null;
 }
 
 export interface SellerProfileResponseDto {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #103

## ✨ 어떤 기능인가요?
- 요금제의 활성화/비활성화 기능을 추가하고, 사용자가 요금제를 선택하는 방식을 개선합니다.

## 📝 작업 내용
- [x] 요금제 엔티티/모델에 활성화 여부 필드 `isActive` 추가
- [x] 요금제 활성/비활성 상태를 수정할 수 있는 관리자용 API 구현
- [x] 관리자 화면에서 요금제를 활성/비활성할 수 있는 UI 추가
- [x] 비활성화된 요금제가 일반 사용자 화면에 노출되지 않도록 조회 로직/쿼리 필터링